### PR TITLE
Fix files provider to search tools in order they are listed

### DIFF
--- a/autoload/clap/provider/files.vim
+++ b/autoload/clap/provider/files.vim
@@ -6,18 +6,18 @@ set cpo&vim
 
 let s:files = {}
 
-let s:tools = {
-      \ 'fd': '',
-      \ 'rg': '--files',
-      \ 'git': 'ls-tree -r --name-only HEAD',
-      \ 'find': '.',
-      \ }
+let s:tools = [
+      \ ['fd', ''],
+      \ ['rg', '--files'],
+      \ ['git', 'ls-tree -r --name-only HEAD'],
+      \ ['find', '.'],
+      \ ]
 
 let s:find_cmd = v:null
 
-for exe in keys(s:tools)
+for [exe, cmd] in s:tools
   if executable(exe)
-    let s:find_cmd = join([exe, s:tools[exe]], ' ')
+    let s:find_cmd = join([exe, cmd], ' ')
     break
   endif
 endfor


### PR DESCRIPTION
The files provider used a dict to organize the tools it was searching. Iterating over the dict did not give items in the same order as they appeared in the file. This caused `git` to be used before `fd`.

This PR fixes the issue by switching from a dict to a list.