### PR TITLE
Use todo-list syntax instead of mix and match lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,14 @@ Vim-clap is a modern generic interactive finder and dispatcher, based on the new
 
 ## Features
 
-- Pure vimscript.
-- Work out of the box, without any extra dependency.
-- Extensible, easy to add new source providers.
-- Find or dispatch anything on the fly, with smart cache strategy.
-- Untouch your current window layout, less eye movement.
-- Support multi-selection, use vim's regexp as filter by default.
-- Support the preview functionality when navigating the result list.
-- Support builtin match and external fuzzy filter tools.
-
-TODOs:
-
+- [x] Pure vimscript.
+- [x] Work out of the box, without any extra dependency.
+- [x] Extensible, easy to add new source providers.
+- [x] Find or dispatch anything on the fly, with smart cache strategy.
+- [x] Avoid touching the current window layout, less eye movement.
+- [x] Support multi-selection, use vim's regexp as filter by default.
+- [x] Support the preview functionality when navigating the result list.
+- [x] Support builtin match and external fuzzy filter tools.
 - [ ] Add the preview support for more providers.
 - [ ] Add the multi-selection support for more providers.
 - [ ] More UI layout.
@@ -133,17 +130,17 @@ The option naming convention for provider is `g:clap_provider_{provider_id}_{opt
 
 ### Movement
 
-- Use <kbd>Ctrl-j</kbd>/<kbd>Down</kbd> or <kbd>Ctrl-k</kbd>/<kbd>Up</kbd> to navigate the result list up and down.
-- Use <kbd>Ctrl-a</kbd> to go to the start of the input.
-- Use <kbd>Ctrl-e</kbd> to go to the end of the input.
-- Use <kbd>Ctrl-c</kbd>, <kbd>Ctrl-[</kbd> or <kbd>Esc</kbd> to exit.
+- [x] Use <kbd>Ctrl-j</kbd>/<kbd>Down</kbd> or <kbd>Ctrl-k</kbd>/<kbd>Up</kbd> to navigate the result list up and down.
+- [x] Use <kbd>Ctrl-a</kbd> to go to the start of the input.
+- [x] Use <kbd>Ctrl-e</kbd> to go to the end of the input.
+- [x] Use <kbd>Ctrl-c</kbd>, <kbd>Ctrl-[</kbd> or <kbd>Esc</kbd> to exit.
 - [ ] Use <kbd>Ctrl-h</kbd> to delete previous character.
 - [ ] Use <kbd>Ctrl-d</kbd> to delete next character.
-- Use <kbd>Ctrl-b</kbd> to move cursor left one character.
-- Use <kbd>Ctrl-f</kbd> to move cursor right one character.
-- Use <kbd>Enter</kbd> to select the entry and exit.
-- Use <kbd>Tab</kbd> to select multiple entries and open them using the quickfix window.(Need the provider has `sink*` support)
-- [ ] Use <kbd>Ctrl-t</kbd> or <kbd>Ctrl-x</kbd>, <kbd>Ctrl-v</kbd> to open the selected entry in a new tab or a new split.
+- [x] Use <kbd>Ctrl-b</kbd> to move cursor left one character.
+- [x] Use <kbd>Ctrl-f</kbd> to move cursor right one character.
+- [x] Use <kbd>Enter</kbd> to select the entry and exit.
+- [x] Use <kbd>Tab</kbd> to select multiple entries and open them using the quickfix window.(Need the provider has `sink*` support)
+- [ ] Use <kbd>Ctrl-t</kbd> or <kbd>Ctrl-x</kbd>, <kbd>Ctrl-v</kbd> to open the selected entry in a new tab or a new split. (See #34)
 
 ### Execute some code during the process
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The option naming convention for provider is `g:clap_provider_{provider_id}_{opt
 - [x] Use <kbd>Ctrl-a</kbd> to go to the start of the input.
 - [x] Use <kbd>Ctrl-e</kbd> to go to the end of the input.
 - [x] Use <kbd>Ctrl-c</kbd>, <kbd>Ctrl-[</kbd> or <kbd>Esc</kbd> to exit.
-- [ ] Use <kbd>Ctrl-h</kbd> to delete previous character.
+- [x] Use <kbd>Ctrl-h</kbd> to delete previous character.
 - [ ] Use <kbd>Ctrl-d</kbd> to delete next character.
 - [x] Use <kbd>Ctrl-b</kbd> to move cursor left one character.
 - [x] Use <kbd>Ctrl-f</kbd> to move cursor right one character.

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -327,7 +327,7 @@ let s:move_manager["\<C-F>"] = s:move_manager.ctrl_f
 let s:move_manager["\<Right>"] = s:move_manager.ctrl_f
 let s:move_manager["\<C-E>"] = s:move_manager.ctrl_e
 let s:move_manager["\<BS>"] = s:move_manager.bs
-let s:move_manager["\<C-D>"] = s:move_manager.bs
+let s:move_manager["\<C-H>"] = s:move_manager.bs
 let s:move_manager["\<C-G>"] = s:move_manager.ctrl_g
 
 function! s:move_manager.printable(key) abort


### PR DESCRIPTION
This addresses the documentation ambiguity mentioned in #34.

I was unsure whether to mark off the <kbd>Ctrl</kbd><kbd>h</kbd> bit as done. It works for me in NeoVim but perhaps it isn't working everywhere? I added that as a separate commit so it would be easy to drop if it's not appropriate.