### PR TITLE
Add Ctrl-p and Ctrl-n to navigate up and down

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ See `:help clap-options` for more information.
 
 ### Keybindings
 
-- [x] Use <kbd>Ctrl-j</kbd>/<kbd>Down</kbd> or <kbd>Ctrl-k</kbd>/<kbd>Up</kbd> to navigate the result list up and down.
+- [x] Use <kbd>Ctrl-j</kbd>/<kbd>Ctrl-n</kbd>/<kbd>Down</kbd> to navigate the result down.
+- [x] Use <kbd>Ctrl-k</kbd>/<kbd>Ctrl-p</kbd>/<kbd>Up</kbd> to navigate the result list up.
 - [x] Use <kbd>Ctrl-a</kbd>/<kbd>Home</kbd> to go to the start of the input.
 - [x] Use <kbd>Ctrl-e</kbd>/<kbd>End</kbd> to go to the end of the input.
 - [x] Use <kbd>Ctrl-c</kbd>, <kbd>Ctrl-[</kbd> or <kbd>Esc</kbd> to exit.

--- a/ftplugin/clap_input.vim
+++ b/ftplugin/clap_input.vim
@@ -59,6 +59,9 @@ inoremap <silent> <buffer> <C-k> <C-R>=clap#handler#navigate_result('up')<CR>
 inoremap <silent> <buffer> <Down> <C-R>=clap#handler#navigate_result('down')<CR>
 inoremap <silent> <buffer> <Up> <C-R>=clap#handler#navigate_result('up')<CR>
 
+inoremap <silent> <buffer> <C-n> <C-R>=clap#handler#navigate_result('down')<CR>
+inoremap <silent> <buffer> <C-p> <C-R>=clap#handler#navigate_result('up')<CR>
+
 inoremap <silent> <buffer> <Tab> <C-R>=clap#handler#select_toggle()<CR>
 
 call clap#util#define_open_action_mappings()


### PR DESCRIPTION
## Summary

Added new keybindings:
  `<C-n>` to navigate the result list down
  `<C-p>` to navigate the result list up

## Motivation

Default _eMacs-y_ movement keybindings had been implemented, such as
- `<C-b>` to move backward
- `<C-e>` to move to the end of line

Problem is, navigating up and down doesn't support `<C-p>` and `<C-n>`. That binding is the most standard for navigating (used in VSCode, most dropdown in OS, even most browsers on Mac support that)