### PR TITLE
Fixed grep provider on windows nvim

### DIFF
--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -32,7 +32,7 @@ function! s:cmd(query) abort
     call g:clap.abort('rg not found')
     return
   endif
-  let cmd = 'rg -H --no-heading --vimgrep --smart-case "'.a:query.'" .'
+  let cmd = 'rg -H --no-heading --vimgrep --smart-case "'.a:query.'"'.(has('win32') ? ' .' : '')
   let g:clap.provider.cmd = cmd
   return cmd
 endfunction

--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -32,7 +32,7 @@ function! s:cmd(query) abort
     call g:clap.abort('rg not found')
     return
   endif
-  let cmd = 'rg -H --no-heading --vimgrep --smart-case "'.a:query.'"'
+  let cmd = 'rg -H --no-heading --vimgrep --smart-case "'.a:query.'" .'
   let g:clap.provider.cmd = cmd
   return cmd
 endfunction


### PR DESCRIPTION
Fixed an issue where on windows (in nvim) where ripgrep will wait for input from stdin instead of implicitly using current directory.

When I tried to use the grep functionality it didn't work for me. After some time I noticed that while the popup is going, the ripgrep process was still running.

Turns out, on windows and nvim the ripgrep process will wait for stdin to provide data instead of implicitly using the current directory. (source: https://github.com/mhinz/vim-grepper/issues/205#issuecomment-497941276)

This change should not be breaking for other environments.