### PR TITLE
Add search box border symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ CHANGELOG
 
 - New provider `:Clap lines`.
 - New provider `:Clap history`.
+- New provider `:Clap yanks` thanks to @ratheesh.
 - New external filter `fzy` and `fzf`.
 - Every provider could run async if you have one of the external filters installed.
 - Add the substring filter mode.
@@ -17,7 +18,9 @@ CHANGELOG
 - Support `:Clap` listing all the builtin providers, thanks to @wookayin implementing the sink of it.
 - Support opening files from the git base directory. See `:h g:clap_disable_run_rooter` if you don't like this behavior.
 - Support searching the hidden files via `:Clap files --hidden`.
+- Add `g:clap_provider_grep_opts` for globally configuring the used command line options of rg, thanks to @Olical.
 - Support using any other finder tools via `:Clap files ++finder=[YOUR FINDER] [FINDER ARGS]`.
+- Add search box border symbols support.([#85](https://github.com/liuchengxu/vim-clap/pull/85))
 
 ### Improved
 

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -46,11 +46,12 @@ let s:default_symbols = {
       \ 'nil' : ['', ''],
       \ }
 
-let g:clap_search_box_border_symbols = get(g:, 'clap_search_box_border_symbols', s:default_symbols)
-let g:clap_search_box_border_style = get(g:, 'clap_search_box_border_style', 'curve')
+let g:clap_search_box_border_symbols = extend(s:default_symbols, get(g:, 'clap_search_box_border_symbols', {}))
+let g:clap_search_box_border_style = get(g:, 'clap_search_box_border_style',
+      \ exists('g:spacevim_nerd_fonts') || exists('g:airline_powerline_fonts') ? 'curve' : 'nil')
 let g:__clap_search_box_border_symbol = {
-      \ 'left': get(g:clap_search_box_border_symbols, g:clap_search_box_border_style)[0],
-      \ 'right': get(g:clap_search_box_border_symbols, g:clap_search_box_border_style)[1],
+      \ 'left': get(g:clap_search_box_border_symbols, g:clap_search_box_border_style, '')[0],
+      \ 'right': get(g:clap_search_box_border_symbols, g:clap_search_box_border_style, '')[1],
       \ }
 
 let s:default_action = {

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -43,7 +43,7 @@ let g:__clap_no_matches_pattern = '^'.g:clap_no_matches_msg.'$'
 let s:default_symbols = {
       \ 'arrow' : ["\ue0b2", "\ue0b0"],
       \ 'curve' : ["\ue0b6", "\ue0b4"],
-      \ 'nil' : ['', ''],
+      \ 'nil'   : ['', ''],
       \ }
 
 let g:clap_search_box_border_symbols = extend(s:default_symbols, get(g:, 'clap_search_box_border_symbols', {}))

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -40,6 +40,19 @@ let s:provider_alias = extend(s:provider_alias, get(g:, 'clap_provider_alias', {
 let g:clap_no_matches_msg = get(g:, 'clap_no_matches_msg', 'NO MATCHES FOUND')
 let g:__clap_no_matches_pattern = '^'.g:clap_no_matches_msg.'$'
 
+let s:default_symbols = {
+      \ 'arrow' : ["\ue0b2", "\ue0b0"],
+      \ 'curve' : ["\ue0b6", "\ue0b4"],
+      \ 'nil' : ['', ''],
+      \ }
+
+let g:clap_search_box_border_symbols = get(g:, 'clap_search_box_border_symbols', s:default_symbols)
+let g:clap_search_box_border_style = get(g:, 'clap_search_box_border_style', 'curve')
+let g:__clap_search_box_border_symbol = {
+      \ 'left': get(g:clap_search_box_border_symbols, g:clap_search_box_border_style)[0],
+      \ 'right': get(g:clap_search_box_border_symbols, g:clap_search_box_border_style)[1],
+      \ }
+
 let s:default_action = {
   \ 'ctrl-t': 'tab split',
   \ 'ctrl-x': 'split',

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -27,6 +27,10 @@ function! s:_setbufvar_batch(dict) dict abort
   call map(a:dict, { key, val -> setbufvar(self.bufnr, key, val) })
 endfunction
 
+function! clap#api#setbufvar_batch(bufnr, dict) abort
+  call map(a:dict, { key, val -> setbufvar(a:bufnr, key, val) })
+endfunction
+
 function! s:_system(cmd) abort
   let lines = system(a:cmd)
   if v:shell_error

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -1,8 +1,8 @@
 " Author: liuchengxu <xuliuchengxlc@gmail.com>
 " Description: Filter out the candidate lines given input.
 
-let s:save_cpo = &cpo
-set cpo&vim
+let s:save_cpo = &cpoptions
+set cpoptions&vim
 
 let s:pattern_builder = {}
 
@@ -89,5 +89,5 @@ function! clap#filter#(lines, input) abort
   return filter(a:lines, 's:filter(v:val, l:filter_pattern)')
 endfunction
 
-let &cpo = s:save_cpo
+let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -229,9 +229,9 @@ function! clap#floating_win#preview.show(lines) abort
 endfunction
 
 function! clap#floating_win#preview.close() abort
-  if s:preview_winid > -1
+  if exists('s:preview_winid')
     call clap#util#nvim_win_close_safe(s:preview_winid)
-    let s:preview_winid = -1
+    unlet s:preview_winid
   endif
 endfunction
 

--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -27,18 +27,8 @@ let s:preview_bufnr = nvim_create_buf(v:false, v:true)
 
 let s:exists_deoplete = exists('*deoplete#custom#buffer_option')
 
-let s:symbols = {
-      \ 'arrow' : ["\ue0b2", "\ue0b0"],
-      \ 'curve' : ["\ue0b6", "\ue0b4"],
-      \ 'nil' : ['', ''],
-      \ }
-
-let s:symbol_left = s:symbols.curve[0]
-let s:symbol_right = s:symbols.curve[1]
-
-" let s:symbol_left = s:symbols.arrow[0]
-" let s:symbol_right = s:symbols.arrow[1]
-
+let s:symbol_left = g:__clap_search_box_border_symbol.left
+let s:symbol_right = g:__clap_search_box_border_symbol.right
 let s:symbol_width = strdisplaywidth(s:symbol_right)
 
 function! s:prepare_opts(row, col, width, height, ...) abort

--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -112,20 +112,22 @@ function! g:clap#floating_win#display.compact() abort
   endif
 endfunction
 
-function! s:open_win_decorator_left() abort
-  let opts = nvim_win_get_config(s:display_winid)
-  let opts.row -= 1
-  let opts.width = s:symbol_width
-  let opts.height = 1
-  let opts.focusable = v:false
+function! s:open_win_border_left() abort
+  if s:symbol_width > 0
+    let opts = nvim_win_get_config(s:display_winid)
+    let opts.row -= 1
+    let opts.width = s:symbol_width
+    let opts.height = 1
+    let opts.focusable = v:false
 
-  silent let s:symbol_left_winid = nvim_open_win(s:symbol_left_bufnr, v:false, opts)
+    silent let s:symbol_left_winid = nvim_open_win(s:symbol_left_bufnr, v:false, opts)
 
-  call setwinvar(s:symbol_left_winid, '&winhl', 'Normal:ClapSymbol')
-  call setbufvar(s:symbol_left_bufnr, '&filetype', 'clap_spinner')
-  call setbufvar(s:symbol_left_bufnr, '&signcolumn', 'no')
+    call setwinvar(s:symbol_left_winid, '&winhl', 'Normal:ClapSymbol')
+    call setbufvar(s:symbol_left_bufnr, '&filetype', 'clap_spinner')
+    call setbufvar(s:symbol_left_bufnr, '&signcolumn', 'no')
 
-  call setbufline(s:symbol_left_bufnr, 1, s:symbol_left)
+    call setbufline(s:symbol_left_bufnr, 1, s:symbol_left)
+  endif
 endfunction
 
 function! g:clap#floating_win#spinner.open() abort
@@ -170,19 +172,21 @@ function! g:clap#floating_win#input.open() abort
   let g:clap.input.winid = s:input_winid
 endfunction
 
-function! s:open_win_decorator_right() abort
-  let opts = nvim_win_get_config(s:input_winid)
-  let opts.col += opts.width
-  let opts.width = s:symbol_width
-  let opts.focusable = v:false
+function! s:open_win_border_right() abort
+  if s:symbol_width > 0
+    let opts = nvim_win_get_config(s:input_winid)
+    let opts.col += opts.width
+    let opts.width = s:symbol_width
+    let opts.focusable = v:false
 
-  silent let s:symbol_right_winid = nvim_open_win(s:symbol_right_bufnr, v:false, opts)
+    silent let s:symbol_right_winid = nvim_open_win(s:symbol_right_bufnr, v:false, opts)
 
-  call setwinvar(s:symbol_right_winid, '&winhl', 'Normal:ClapSymbol')
-  call setbufvar(s:symbol_right_bufnr, '&filetype', 'clap_spinner')
-  call setbufvar(s:symbol_right_bufnr, '&signcolumn', 'no')
+    call setwinvar(s:symbol_right_winid, '&winhl', 'Normal:ClapSymbol')
+    call setbufvar(s:symbol_right_bufnr, '&filetype', 'clap_spinner')
+    call setbufvar(s:symbol_right_bufnr, '&signcolumn', 'no')
 
-  call setbufline(s:symbol_right_bufnr, 1, s:symbol_right)
+    call setbufline(s:symbol_right_bufnr, 1, s:symbol_right)
+  endif
 endfunction
 
 function! s:try_adjust_preview() abort
@@ -194,7 +198,7 @@ function! s:try_adjust_preview() abort
   endif
 endfunction
 
-function! s:adjust_display_for_symbol() abort
+function! s:adjust_display_for_border_symbol() abort
   let opts = nvim_win_get_config(s:display_winid)
   let opts.col += s:symbol_width
   let opts.width -= s:symbol_width * 2
@@ -239,11 +243,13 @@ function! clap#floating_win#open() abort
 
   " The order matters.
   call g:clap#floating_win#display.open()
-  call s:open_win_decorator_left()
+  call s:open_win_border_left()
   call g:clap#floating_win#spinner.open()
   call g:clap#floating_win#input.open()
-  call s:open_win_decorator_right()
-  " call s:adjust_display_for_symbol()
+  call s:open_win_border_right()
+
+  " This seemingly does not look good.
+  " call s:adjust_display_for_border_symbol()
 
   call clap#_init()
 
@@ -266,8 +272,10 @@ endfunction
 function! clap#floating_win#close() abort
   silent! autocmd! ClapEnsureAllClosed
 
-  noautocmd call clap#util#nvim_win_close_safe(s:symbol_left_winid)
-  noautocmd call clap#util#nvim_win_close_safe(s:symbol_right_winid)
+  if s:symbol_width > 0
+    noautocmd call clap#util#nvim_win_close_safe(s:symbol_left_winid)
+    noautocmd call clap#util#nvim_win_close_safe(s:symbol_right_winid)
+  endif
 
   noautocmd call g:clap#floating_win#preview.close()
   noautocmd call clap#util#nvim_win_close_safe(g:clap.input.winid)

--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -18,9 +18,26 @@ let g:clap.input.bufnr = s:input_bufnr
 let s:display_bufnr = nvim_create_buf(v:false, v:true)
 let g:clap.display.bufnr = s:display_bufnr
 
+let s:symbol_left_bufnr = nvim_create_buf(v:false, v:true)
+let s:symbol_right_bufnr = nvim_create_buf(v:false, v:true)
+
 let s:preview_bufnr = nvim_create_buf(v:false, v:true)
 
 let s:exists_deoplete = exists('*deoplete#custom#buffer_option')
+
+let s:symbols = {
+      \ 'arrow' : ["\ue0b2", "\ue0b0"],
+      \ 'curve' : ["\ue0b6", "\ue0b4"],
+      \ 'nil' : ['', ''],
+      \ }
+
+let s:symbol_left = s:symbols.curve[0]
+let s:symbol_right = s:symbols.curve[1]
+
+" let s:symbol_left = s:symbols.arrow[0]
+" let s:symbol_right = s:symbols.arrow[1]
+
+let s:symbol_width = strdisplaywidth(s:symbol_right)
 
 function! s:prepare_opts(row, col, width, height, ...) abort
   let base_opts = {
@@ -103,8 +120,25 @@ function! g:clap#floating_win#display.compact() abort
   endif
 endfunction
 
+function! s:open_win_decorator_left() abort
+  let opts = nvim_win_get_config(s:display_winid)
+  let opts.row -= 1
+  let opts.width = s:symbol_width
+  let opts.height = 1
+  let opts.focusable = v:false
+
+  silent let s:symbol_left_winid = nvim_open_win(s:symbol_left_bufnr, v:false, opts)
+
+  call setwinvar(s:symbol_left_winid, '&winhl', 'Normal:ClapSymbol')
+  call setbufvar(s:symbol_left_bufnr, '&filetype', 'clap_spinner')
+  call setbufvar(s:symbol_left_bufnr, '&signcolumn', 'no')
+
+  call setbufline(s:symbol_left_bufnr, 1, s:symbol_left)
+endfunction
+
 function! g:clap#floating_win#spinner.open() abort
   let opts = nvim_win_get_config(s:display_winid)
+  let opts.col += s:symbol_width
   let opts.row -= 1
   let opts.width = clap#spinner#width()
   let opts.height = 1
@@ -123,7 +157,7 @@ endfunction
 function! g:clap#floating_win#input.open() abort
   let opts = nvim_win_get_config(s:spinner_winid)
   let opts.col += opts.width
-  let opts.width = s:display_opts.width - opts.width
+  let opts.width = s:display_opts.width - opts.width - s:symbol_width * 2
   let opts.focusable = v:true
 
   let g:clap#floating_win#input.width = opts.width
@@ -144,6 +178,21 @@ function! g:clap#floating_win#input.open() abort
   let g:clap.input.winid = s:input_winid
 endfunction
 
+function! s:open_win_decorator_right() abort
+  let opts = nvim_win_get_config(s:input_winid)
+  let opts.col += opts.width
+  let opts.width = s:symbol_width
+  let opts.focusable = v:false
+
+  silent let s:symbol_right_winid = nvim_open_win(s:symbol_right_bufnr, v:false, opts)
+
+  call setwinvar(s:symbol_right_winid, '&winhl', 'Normal:ClapSymbol')
+  call setbufvar(s:symbol_right_bufnr, '&filetype', 'clap_spinner')
+  call setbufvar(s:symbol_right_bufnr, '&signcolumn', 'no')
+
+  call setbufline(s:symbol_right_bufnr, 1, s:symbol_right)
+endfunction
+
 function! s:try_adjust_preview() abort
   if exists('s:preview_winid')
     let preview_opts = nvim_win_get_config(s:preview_winid)
@@ -151,6 +200,13 @@ function! s:try_adjust_preview() abort
     let preview_opts.row = opts.row + opts.height
     call nvim_win_set_config(s:preview_winid, preview_opts)
   endif
+endfunction
+
+function! s:adjust_display_for_symbol() abort
+  let opts = nvim_win_get_config(s:display_winid)
+  let opts.col += s:symbol_width
+  let opts.width -= s:symbol_width * 2
+  call nvim_win_set_config(s:display_winid, opts)
 endfunction
 
 function! clap#floating_win#preview.show(lines) abort
@@ -191,8 +247,11 @@ function! clap#floating_win#open() abort
 
   " The order matters.
   call g:clap#floating_win#display.open()
+  call s:open_win_decorator_left()
   call g:clap#floating_win#spinner.open()
   call g:clap#floating_win#input.open()
+  call s:open_win_decorator_right()
+  " call s:adjust_display_for_symbol()
 
   call clap#_init()
 
@@ -214,6 +273,9 @@ endfunction
 
 function! clap#floating_win#close() abort
   silent! autocmd! ClapEnsureAllClosed
+
+  noautocmd call clap#util#nvim_win_close_safe(s:symbol_left_winid)
+  noautocmd call clap#util#nvim_win_close_safe(s:symbol_right_winid)
 
   noautocmd call g:clap#floating_win#preview.close()
   noautocmd call clap#util#nvim_win_close_safe(g:clap.input.winid)

--- a/autoload/clap/init.vim
+++ b/autoload/clap/init.vim
@@ -113,6 +113,17 @@ function! s:init_hi_groups() abort
           \ )
   endif
 
+    let input_ctermbg = s:extract_or('ClapInput', 'bg', 'cterm', '60')
+    let input_guibg = s:extract_or('ClapInput', 'bg', 'gui', '#544a65')
+    let normal_ctermfg = s:extract_or('Normal', 'bg', 'cterm', '249')
+    let normal_guifg = s:extract_or('Normal', 'bg', 'gui', '#b2b2b2')
+    execute printf(
+          \ "hi ClapSymbol guifg=%s ctermfg=%s ctermbg=%s guibg=%s",
+          \ input_guibg,
+          \ input_ctermbg,
+          \ normal_ctermfg,
+          \ normal_guifg,
+          \ )
   if !hlexists('ClapDisplay')
     execute 'hi default link ClapDisplay' s:display_default_hi_group
     let s:display_group = s:display_default_hi_group

--- a/autoload/clap/init.vim
+++ b/autoload/clap/init.vim
@@ -121,7 +121,7 @@ function! s:init_hi_groups() abort
     let normal_ctermfg = s:extract_or('Normal', 'bg', 'cterm', '249')
     let normal_guifg = s:extract_or('Normal', 'bg', 'gui', '#b2b2b2')
     execute printf(
-          \ "hi ClapSymbol guifg=%s ctermfg=%s ctermbg=%s guibg=%s",
+          \ 'hi ClapSymbol guifg=%s ctermfg=%s ctermbg=%s guibg=%s',
           \ input_guibg,
           \ input_ctermbg,
           \ normal_ctermfg,

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -139,7 +139,7 @@ function! s:create_indicator() abort
   if !exists('s:indicator_winid') || empty(popup_getpos(s:indicator_winid))
     let pos = popup_getpos(s:display_winid)
     let pos.line = pos.line - 1
-    let pos.col = pos.col + pos.width - s:indicator_width
+    let pos.col = pos.col + pos.width - s:indicator_width - s:symbol_width
     let pos.minwidth = s:indicator_width
     let pos.maxwidth = s:indicator_width
     let pos.highlight = 'ClapInput'
@@ -151,9 +151,55 @@ function! s:create_indicator() abort
   endif
 endfunction
 
+function! s:create_symbol_right() abort
+  if !exists('s:symbol_right_winid') || empty(popup_getpos(s:symbol_right_winid))
+    let pos = popup_getpos(s:display_winid)
+    let pos.line = pos.line - 1
+    let pos.col = pos.col + pos.width - s:symbol_width
+    let pos.minwidth = s:symbol_width
+    let pos.maxwidth = pos.minwidth
+    let pos.highlight = 'ClapSymbol'
+    let pos.wrap = v:false
+    let pos.zindex = 100
+    let s:symbol_right_winid = popup_create(s:symbol_right, pos)
+    call popup_hide(s:symbol_right_winid)
+    call win_execute(s:symbol_right_winid, 'setlocal nonumber')
+  endif
+endfunction
+
+let s:symbols = {
+      \ 'arrow' : ["\ue0b2", "\ue0b0"],
+      \ 'curve' : ["\ue0b6", "\ue0b4"],
+      \ 'nil' : ['', ''],
+      \ }
+
+let s:symbol_left = s:symbols.curve[0]
+let s:symbol_right = s:symbols.curve[1]
+
+" let s:symbol_left = s:symbols.arrow[0]
+" let s:symbol_right = s:symbols.arrow[1]
+
+let s:symbol_width = strdisplaywidth(s:symbol_right)
+
+function! s:create_symbol_left() abort
+  if !exists('s:symbol_left_winid') || empty(popup_getpos(s:symbol_left_winid))
+    let pos = popup_getpos(s:display_winid)
+    let pos.line = pos.line - 1
+    let pos.minwidth = s:symbol_width
+    let pos.maxwidth = pos.minwidth
+    let pos.highlight = 'ClapSymbol'
+    let pos.wrap = v:false
+    let pos.zindex = 100
+    let s:symbol_left_winid = popup_create(s:symbol_left, pos)
+    call popup_hide(s:symbol_left_winid)
+    call win_execute(s:symbol_left_winid, 'setlocal nonumber')
+  endif
+endfunction
+
 function! s:create_spinner() abort
   if !exists('s:spinner_winid') || empty(popup_getpos(s:spinner_winid))
     let pos = popup_getpos(s:display_winid)
+    let pos.col += s:symbol_width
     let pos.line = pos.line - 1
     let pos.minwidth = clap#spinner#width() + 2
     let pos.maxwidth = pos.minwidth
@@ -195,8 +241,8 @@ function! s:create_input() abort
     let pos = popup_getpos(s:display_winid)
     let pos.line = pos.line - 1
     let spinner_width = clap#spinner#width()
-    let pos.col += spinner_width
-    let pos.minwidth = s:display_opts.width - s:indicator_width - spinner_width
+    let pos.col += spinner_width + s:symbol_width
+    let pos.minwidth = s:display_opts.width - s:indicator_width - spinner_width - s:symbol_width
     let pos.maxwidth = pos.minwidth
     let pos.highlight = 'ClapInput'
     let pos.wrap = v:false
@@ -227,6 +273,8 @@ function! s:close_others() abort
   noautocmd call popup_close(s:indicator_winid)
   noautocmd call popup_close(s:input_winid)
   noautocmd call popup_close(s:spinner_winid)
+  noautocmd call popup_close(s:symbol_left_winid)
+  noautocmd call popup_close(s:symbol_right_winid)
 endfunction
 
 " This somehow doesn't get called if you don't map <C-C> to <C-[>.
@@ -431,10 +479,12 @@ endfunction
 function! s:open_popup() abort
   call s:create_display()
 
+  call s:create_symbol_left()
   call s:create_preview()
   call s:create_indicator()
   call s:create_input()
   call s:create_spinner()
+  call s:create_symbol_right()
 
   call s:mock_input()
 
@@ -446,6 +496,8 @@ function! s:show_all() abort
   call popup_show(s:indicator_winid)
   call popup_show(s:input_winid)
   call popup_show(s:spinner_winid)
+  call popup_show(s:symbol_left_winid)
+  call popup_show(s:symbol_right_winid)
   call popup_settext(s:spinner_winid, clap#spinner#get())
 endfunction
 

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -156,33 +156,37 @@ function! s:create_indicator() abort
 endfunction
 
 function! s:create_symbol_right() abort
-  if !exists('s:symbol_right_winid') || empty(popup_getpos(s:symbol_right_winid))
-    let pos = popup_getpos(s:display_winid)
-    let pos.line = pos.line - 1
-    let pos.col = pos.col + pos.width - s:symbol_width
-    let pos.minwidth = s:symbol_width
-    let pos.maxwidth = pos.minwidth
-    let pos.highlight = 'ClapSymbol'
-    let pos.wrap = v:false
-    let pos.zindex = 100
-    let s:symbol_right_winid = popup_create(s:symbol_right, pos)
-    call popup_hide(s:symbol_right_winid)
-    call win_execute(s:symbol_right_winid, 'setlocal nonumber')
+  if s:symbol_width > 0
+    if !exists('s:symbol_right_winid') || empty(popup_getpos(s:symbol_right_winid))
+      let pos = popup_getpos(s:display_winid)
+      let pos.line = pos.line - 1
+      let pos.col = pos.col + pos.width - s:symbol_width
+      let pos.minwidth = s:symbol_width
+      let pos.maxwidth = pos.minwidth
+      let pos.highlight = 'ClapSymbol'
+      let pos.wrap = v:false
+      let pos.zindex = 100
+      let s:symbol_right_winid = popup_create(s:symbol_right, pos)
+      call popup_hide(s:symbol_right_winid)
+      call win_execute(s:symbol_right_winid, 'setlocal nonumber')
+    endif
   endif
 endfunction
 
 function! s:create_symbol_left() abort
-  if !exists('s:symbol_left_winid') || empty(popup_getpos(s:symbol_left_winid))
-    let pos = popup_getpos(s:display_winid)
-    let pos.line = pos.line - 1
-    let pos.minwidth = s:symbol_width
-    let pos.maxwidth = pos.minwidth
-    let pos.highlight = 'ClapSymbol'
-    let pos.wrap = v:false
-    let pos.zindex = 100
-    let s:symbol_left_winid = popup_create(s:symbol_left, pos)
-    call popup_hide(s:symbol_left_winid)
-    call win_execute(s:symbol_left_winid, 'setlocal nonumber')
+  if s:symbol_width > 0
+    if !exists('s:symbol_left_winid') || empty(popup_getpos(s:symbol_left_winid))
+      let pos = popup_getpos(s:display_winid)
+      let pos.line = pos.line - 1
+      let pos.minwidth = s:symbol_width
+      let pos.maxwidth = pos.minwidth
+      let pos.highlight = 'ClapSymbol'
+      let pos.wrap = v:false
+      let pos.zindex = 100
+      let s:symbol_left_winid = popup_create(s:symbol_left, pos)
+      call popup_hide(s:symbol_left_winid)
+      call win_execute(s:symbol_left_winid, 'setlocal nonumber')
+    endif
   endif
 endfunction
 
@@ -248,7 +252,7 @@ function! s:create_input() abort
   endif
 endfunction
 
-" Now we don't choose the hide way for the benefit of reusing the popup buffer,
+" Depreacted: Now we don't choose the hide way for the benefit of reusing the popup buffer,
 " for it could be very problematic.
 function! s:hide_all() abort
   call popup_hide(s:display_winid)
@@ -263,8 +267,12 @@ function! s:close_others() abort
   noautocmd call popup_close(s:indicator_winid)
   noautocmd call popup_close(s:input_winid)
   noautocmd call popup_close(s:spinner_winid)
-  noautocmd call popup_close(s:symbol_left_winid)
-  noautocmd call popup_close(s:symbol_right_winid)
+  if exists('s:symbol_left_winid')
+    noautocmd call popup_close(s:symbol_left_winid)
+  endif
+  if exists('s:symbol_right_winid')
+    noautocmd call popup_close(s:symbol_right_winid)
+  endif
 endfunction
 
 " This somehow doesn't get called if you don't map <C-C> to <C-[>.
@@ -469,12 +477,14 @@ endfunction
 function! s:open_popup() abort
   call s:create_display()
 
-  call s:create_symbol_left()
+  if s:symbol_width > 0
+    call s:create_symbol_left()
+    call s:create_symbol_right()
+  endif
   call s:create_preview()
   call s:create_indicator()
   call s:create_input()
   call s:create_spinner()
-  call s:create_symbol_right()
 
   call s:mock_input()
 
@@ -486,8 +496,12 @@ function! s:show_all() abort
   call popup_show(s:indicator_winid)
   call popup_show(s:input_winid)
   call popup_show(s:spinner_winid)
-  call popup_show(s:symbol_left_winid)
-  call popup_show(s:symbol_right_winid)
+  if exists('s:symbol_left_winid')
+    call popup_show(s:symbol_left_winid)
+  endif
+  if exists('s:symbol_right_winid')
+    call popup_show(s:symbol_right_winid)
+  endif
   call popup_settext(s:spinner_winid, clap#spinner#get())
 endfunction
 

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -16,6 +16,10 @@ let s:indicator_width = 10
 
 let s:exists_deoplete = exists('*deoplete#custom#buffer_option')
 
+let s:symbol_left = g:__clap_search_box_border_symbol.left
+let s:symbol_right = g:__clap_search_box_border_symbol.right
+let s:symbol_width = strdisplaywidth(s:symbol_right)
+
 "  ----------------------------------------
 " | spinner |     input        | indicator |
 " |----------------------------------------|
@@ -166,20 +170,6 @@ function! s:create_symbol_right() abort
     call win_execute(s:symbol_right_winid, 'setlocal nonumber')
   endif
 endfunction
-
-let s:symbols = {
-      \ 'arrow' : ["\ue0b2", "\ue0b0"],
-      \ 'curve' : ["\ue0b6", "\ue0b4"],
-      \ 'nil' : ['', ''],
-      \ }
-
-let s:symbol_left = s:symbols.curve[0]
-let s:symbol_right = s:symbols.curve[1]
-
-" let s:symbol_left = s:symbols.arrow[0]
-" let s:symbol_right = s:symbols.arrow[1]
-
-let s:symbol_width = strdisplaywidth(s:symbol_right)
 
 function! s:create_symbol_left() abort
   if !exists('s:symbol_left_winid') || empty(popup_getpos(s:symbol_left_winid))

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -200,7 +200,7 @@ function! s:create_spinner() abort
     let pos.highlight = 'ClapSpinner'
     let pos.wrap = v:false
     let pos.zindex = 100
-    let s:spinner_winid = popup_create([], pos)
+    let s:spinner_winid = popup_create(clap#spinner#get(), pos)
     call popup_hide(s:spinner_winid)
     call win_execute(s:spinner_winid, 'setlocal nonumber')
     let g:clap_spinner_winid = s:spinner_winid
@@ -502,7 +502,6 @@ function! s:show_all() abort
   if exists('s:symbol_right_winid')
     call popup_show(s:symbol_right_winid)
   endif
-  call popup_settext(s:spinner_winid, clap#spinner#get())
 endfunction
 
 function! clap#popup#get_input() abort

--- a/autoload/clap/provider/marks.vim
+++ b/autoload/clap/provider/marks.vim
@@ -6,6 +6,8 @@ set cpoptions&vim
 
 let s:marks = {}
 
+let s:ext_to_ft = {'rs': 'rust', 'js': 'javascript'}
+
 let s:preview_size = 5
 
 function! s:format_mark(line) abort
@@ -88,7 +90,12 @@ function! clap#provider#marks#preview_impl(line, col, file_text) abort
         let ft = fnamemodify(expand(bufname(origin_bufnr)), ':e')
       endif
     else
-      let ft = fnamemodify(file_text, ':e')
+      let ext = fnamemodify(file_text, ':e')
+      if !empty(ft) && has_key(s:ext_to_ft, ext)
+        let ft = s:ext_to_ft[ext]
+      else
+        let ft = ''
+      endif
     endif
     if !empty(ft)
       call s:render_syntax(ft)

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -282,6 +282,29 @@ g:clap_open_action                                         *g:clap_open_action*
   default bindings of vim-clap, and only `ctrl-*` is supported for now.
 
 
+g:clap_search_box_border_symbols              *g:clap_search_box_border_symbols*
+
+  Type: |Dict|
+  Default: ` { 'arrow': ["\ue0b2", "\ue0b0"], 'curve': ["\ue0b6", "\ue0b4"], 'nil': ['', ''] }`
+
+  This variable defines the symbols that could be used for customizing the
+  search box border. See |g:clap_search_box_border_style| .
+
+  These two symbols must be symmetrically equal. Not every font and terminal
+  emulator can render these symbols perfectly. Use it at your own risk.
+
+
+g:clap_search_box_border_style                  *g:clap_search_box_border_style*
+
+  Type: |Dict|
+  Default: `exists('g:spacevim_nerd_fonts') || exists('g:airline_powerline_fonts') ? 'curve' : 'nil')`
+
+  This variable controls the style of border symbol used for the search box
+  window.
+
+  Set it to `nil` to disable it.
+
+
 -------------------------------------------------------------------------------
 5.1. Highlights                                                *clap-highlights*
 

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -303,7 +303,7 @@ g:clap_search_box_border_style                  *g:clap_search_box_border_style*
   This variable controls the style of border symbol used for the search box
   window.
 
-  Set it to `nil` to disable it.
+  Set this variable to `nil` to disable the search box border symbol.
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Close #73

The default is `nil` style if no expected font is found as not every font and terminal emulator can render these symbols perfectly. You can use it when you are satisfied with the rendered result.

`let g:clap_search_box_border_style = 'curve'`:

<img width="1170" alt="屏幕快照 2019-10-25 上午8 01 46" src="https://user-images.githubusercontent.com/8850248/67533764-c859d500-f6fd-11e9-9517-4e4264f897e8.png">

`let g:clap_search_box_border_style = 'nil'`:

<img width="1147" alt="屏幕快照 2019-10-25 上午8 03 19" src="https://user-images.githubusercontent.com/8850248/67533826-f8a17380-f6fd-11e9-8a1e-554703432dff.png">

I'm using kitty with FuraCode Nerd Font.

