### PR TITLE
Add extra (optional) arguments for grep

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The option naming convention for provider is `g:clap_provider_{provider_id}_{opt
 - `g:clap_provider_grep_delay`: 300ms by default, delay for actually spawning the grep job in the background.
 
 - `g:clap_provider_grep_blink`: [2, 100] by default, blink 2 times with 100ms timeout when jumping the result. Set it to [0, 0] to disable the blink.
+- `g:clap_provider_grep_opts`: An empty string by default, allows you to enable flags such as `--hidden`.
 
 See `:help clap-options` for more information.
 

--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -6,6 +6,7 @@ set cpoptions&vim
 
 let s:grep_delay = get(g:, 'clap_provider_grep_delay', 300)
 let s:grep_blink = get(g:, 'clap_provider_grep_blink', [2, 100])
+let s:grep_opts = get(g:, 'clap_provider_grep_opts', '')
 
 let s:old_query = ''
 let s:grep_timer = -1
@@ -32,7 +33,7 @@ function! s:cmd(query) abort
     call g:clap.abort('rg not found')
     return
   endif
-  let cmd = 'rg -H --no-heading --vimgrep --smart-case "'.a:query.'"'.(has('win32') ? ' .' : '')
+  let cmd = 'rg -H --no-heading --vimgrep --smart-case '.s:grep_opts.' "'.a:query.'"'.(has('win32') ? ' .' : '')
   let g:clap.provider.cmd = cmd
   return cmd
 endfunction

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -373,6 +373,14 @@ g:clap_provider_grep_blink                         *g:clap_provider_grep_blink*
 
   Set it to `[0, 0]` to disable this blink.
 
+g:clap_provider_grep_opts                          *g:clap_provider_grep_opts*
+
+  Type: |String|
+  Default: `''`
+
+  Set this to control the extra arguments that get passed to the grep tool.
+  Setting `--hidden` for example would enable grepping hidden files and
+  folders.
 
 g:clap_provider_grep_enable_icon              *g:clap_provider_grep_enable_icon*
 


### PR DESCRIPTION
This allows the user to enable things such as searching hidden files and folders with ripgrep.