### PR TITLE
yanks: set minimum length to store in yanks stack

### DIFF
--- a/autoload/clap/provider/yanks.vim
+++ b/autoload/clap/provider/yanks.vim
@@ -6,11 +6,16 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 let s:yank_history = []
-let s:yanks = {}
-let s:max_yanks = get(g:, 'clap_provider_yanks_max_entries', 20)
+let s:yanks        = {}
+let s:max_yanks    = get(g:, 'clap_provider_yanks_max_entries', 20)
+let s:min_len      = get(g:, 'clap_provider_yanks_min_len', 1)
 
 function! clap#provider#yanks#collect() abort
   let last_yanked = getreg('"')
+
+  if len(last_yanked) < s:min_len
+    return
+  endif
 
   if !empty(s:yank_history) && last_yanked == s:yank_history[0]
     return

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -648,6 +648,13 @@ g:clap_provider_yanks_max_entries             *g:clap_provider_yanks_max_entries
 
   Set this variable to limit maximum yanks entries.
 
+g:clap_provider_yanks_min_len             *g:clap_provider_yanks_min_len*
+
+  Type: |Number|
+  Default: `1`
+
+  Set minimum length of yanked text to be stored in yanks stack. Setting this
+  variable to less than 2 has no effect.
 
 -------------------------------------------------------------------------------
 6.3 Other Provider Options                          *clap-other-provider-options*


### PR DESCRIPTION
Set the minimum length of yanked text to be stored in yanks stack. This
can be configured through a variable 'g:clap_provider_yanks_min_len'.

This feature is disabled by default(set to 1).