### PR TITLE
Don't let the highlight of sign override the fuzzy matched highlights

### DIFF
--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -89,6 +89,52 @@ function! s:on_typed_sync_impl() abort
   endif
 endfunction
 
+if s:is_nvim
+  function! s:apply_add_highlight(hl_lines, offset) abort
+    " Currently neovim does not have win_execute()
+    " and the highlight added by nvim_buf_add_highlight()
+    " can be overrided by the sign's highlight.
+    "
+    " Once the default highlight priority of nvim_buf_add_highlight() is
+    " higher, we could use the same impl with vim's s:apply_highlight().
+
+    call g:clap.display.goto_win()
+    call clearmatches()
+
+    let lnum = 0
+    for indices in a:hl_lines
+      let group_idx = 1
+      for idx in indices
+        if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
+          call clap#util#add_match_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx)
+          let group_idx += 1
+        else
+          call clap#util#add_match_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group)
+        endif
+      endfor
+      let lnum += 1
+    endfor
+
+    call g:clap.input.goto_win()
+  endfunction
+else
+  function! s:apply_add_highlight(hl_lines, offset) abort
+    let lnum = 0
+    for indices in a:hl_lines
+      let group_idx = 1
+      for idx in indices
+        if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
+          call clap#util#add_match_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx)
+          let group_idx += 1
+        else
+          call clap#util#add_highlight_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group)
+        endif
+      endfor
+      let lnum += 1
+    endfor
+  endfunction
+endif
+
 function! s:add_highlight_for_fuzzy_matched() abort
   " Due the cache strategy, g:__clap_fuzzy_matched_indices may be oversize
   " than the actual display buffer, the rest highlight indices of g:__clap_fuzzy_matched_indices
@@ -103,20 +149,7 @@ function! s:add_highlight_for_fuzzy_matched() abort
     let offset = 0
   endif
 
-  let lnum = 0
-
-  for indices in hl_lines
-    let group_idx = 1
-    for idx in indices
-      if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
-        call clap#util#add_highlight_at(lnum, idx+offset, 'ClapFuzzyMatches'.group_idx)
-        let group_idx += 1
-      else
-        call clap#util#add_highlight_at(lnum, idx+offset, g:__clap_fuzzy_last_hl_group)
-      endif
-    endfor
-    let lnum += 1
-  endfor
+  call s:apply_add_highlight(hl_lines, offset)
 endfunction
 
 " =======================================

--- a/autoload/clap/util.vim
+++ b/autoload/clap/util.vim
@@ -252,6 +252,10 @@ function! clap#util#getfsize(fname) abort
   return size
 endfunction
 
+function! clap#util#add_match_at(lnum, col, hl_group) abort
+  call matchaddpos(a:hl_group, [[a:lnum+1, a:col+1, 1]])
+endfunction
+
 if has('nvim')
   " 0-based
   function! clap#util#add_highlight_at(lnum, col, hl_group) abort


### PR DESCRIPTION
Use matchaddpos() instead of nvim_buf_add_highlight()