### PR TITLE
Implement basic registers provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Command                                | List                                  |
 `Clap jumps`                           | Jumps                                 | _none_
 `Clap lines`                           | Lines in the loaded buffers           | _none_
 `Clap marks`                           | Marks                                 | _none_
+`Clap registers`                       | Registers                             | _none_
 `Clap tags`                            | Tags in the current buffer            | **[vista.vim][vista.vim]**
 `Clap yanks`                           | Yank stack of the current vim session | _none_
 `Clap windows` **<sup>!</sup>**        | Windows                               | _none_

--- a/autoload/clap/provider/registers.vim
+++ b/autoload/clap/provider/registers.vim
@@ -1,17 +1,26 @@
+" Author: Ratheesh S<ratheeshreddy@gmail.com>
 " Author: liuchengxu <xuliuchengxlc@gmail.com>
-" Description: List the register list with the preview.
+" Description: List the registers
 
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 let s:registers = {}
 
+function! s:fetch_registers()
+  let s = ''
+  redir => s
+  silent registers
+  redir END
+  return map(split(s, "\n")[1:], 'v:val[1:]')
+endfunc
+
 function! s:registers.source() abort
-  call g:clap.abort('Not implemented yet')
+  return s:fetch_registers()
 endfunction
 
 function! s:registers.sink(line) abort
-  call g:clap.abort('Not implemented yet')
+  execute 'normal! "'.split(a:line, ' ')[0].'p'
 endfunction
 
 let g:clap#provider#registers# = s:registers


### PR DESCRIPTION
This commit adds support for basic registers provider. Preview feature
is currently not supported.

This implementation is loosely based on
https://github.com/mattn/ctrlp-register.git