### PR TITLE
Spawn a forerunner job when initializing the display window

### DIFF
--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -127,6 +127,14 @@ function! clap#_init() abort
   call g:clap.provider.init_display_win()
 endfunction
 
+function! s:unlet_vars(vars) abort
+  for var in a:vars
+    if exists(var)
+      execute 'unlet' var
+    endif
+  endfor
+endfunction
+
 function! clap#_exit() abort
   call g:clap.provider.jobstop()
   call clap#forerunner#stop()
@@ -143,17 +151,11 @@ function! clap#_exit() abort
     call remove(g:clap.provider, 'args')
   endif
 
-  if exists('g:__clap_fuzzy_matched_indices')
-    unlet g:__clap_fuzzy_matched_indices
-  endif
-
-  if exists('g:__clap_maple_fuzzy_matched')
-    unlet g:__clap_maple_fuzzy_matched
-  endif
-
-  if exists('g:__clap_forerunner_cached')
-    unlet g:__clap_forerunner_cached
-  endif
+  call s:unlet_vars([
+        \ 'g:__clap_fuzzy_matched_indices',
+        \ 'g:__clap_maple_fuzzy_matched',
+        \ 'g:__clap_forerunner_cached',
+        \ ])
 
   call clap#sign#reset()
 

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -150,6 +150,10 @@ function! clap#_exit() abort
     unlet g:__clap_maple_fuzzy_matched
   endif
 
+  if exists('g:__clap_forerunner_cached')
+    unlet g:__clap_forerunner_cached
+  endif
+
   call clap#sign#reset()
 
   call map(g:clap.tmps, 'delete(v:val)')

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -143,6 +143,7 @@ function! clap#_exit() abort
 
   let g:clap.is_busy = 0
   let g:clap.display.cache = []
+  let g:clap.display.initial_size = -1
 
   call g:clap.input.clear()
   call g:clap.display.clear()
@@ -154,7 +155,7 @@ function! clap#_exit() abort
   call s:unlet_vars([
         \ 'g:__clap_fuzzy_matched_indices',
         \ 'g:__clap_maple_fuzzy_matched',
-        \ 'g:__clap_forerunner_cached',
+        \ 'g:__clap_forerunner_result',
         \ ])
 
   call clap#sign#reset()

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -129,6 +129,7 @@ endfunction
 
 function! clap#_exit() abort
   call g:clap.provider.jobstop()
+  call clap#forerunner#stop()
 
   call g:clap.close_win()
 

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -509,8 +509,14 @@ function! s:init_provider() abort
 
   function! provider.init_display_win() abort
     if self.is_pure_async()
-          \ || self.type == g:__t_string
-          \ || self.type == g:__t_func_string
+      return
+    elseif self.type == g:__t_string
+      call clap#forerunner#start(g:clap.provider._().source)
+      return
+    elseif self.type == g:__t_func_string
+      let Source = g:clap.provider._().source
+      let cmd = Source()
+      call clap#forerunner#start(cmd)
       return
     endif
 

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -12,6 +12,13 @@ let s:is_win = has('win32')
 
 let s:drop_cache = get(g:, 'clap_dispatcher_drop_cache', v:true)
 
+function! s:jobstop() abort
+  if s:job_id > 0
+    call clap#job#stop(s:job_id)
+    let s:job_id = -1
+  endif
+endfunction
+
 if has('nvim')
 
   if s:drop_cache
@@ -124,13 +131,6 @@ if has('nvim')
           \ })
   endfunction
 
-  function! s:jobstop() abort
-    if s:job_id > 0
-      silent! call jobstop(s:job_id)
-      let s:job_id = -1
-    endif
-  endfunction
-
 else
 
   if s:drop_cache
@@ -235,14 +235,6 @@ else
           \ 'cwd': clap#job#cwd(),
           \ })
     let s:job_id = clap#util#parse_vim8_job_id(string(job))
-  endfunction
-
-  function! s:jobstop() abort
-    if s:job_id > 0
-      " Kill it!
-      silent! call jobstop(s:job_id, 'kill')
-      let s:job_id = -1
-    endif
   endfunction
 
 endif

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -29,7 +29,7 @@ if has('nvim')
 
     function! s:set_matches_count() abort
       let matches_count = s:loaded_size + s:droped_size
-      call clap#indicator#set_matches('['.matches_count.']')
+      call clap#impl#refresh_matches_count(string(matches_count))
     endfunction
   else
     function! s:handle_cache(to_cache) abort
@@ -38,7 +38,7 @@ if has('nvim')
 
     function! s:set_matches_count() abort
       let matches_count = s:loaded_size + len(g:clap.display.cache)
-      call clap#indicator#set_matches('['.matches_count.']')
+      call clap#impl#refresh_matches_count(string(matches_count))
     endfunction
   endif
 
@@ -171,7 +171,7 @@ else
       let matches_count = g:clap.display.line_count()
     endif
 
-    call clap#indicator#set_matches('['.matches_count.']')
+    call clap#impl#refresh_matches_count(string(matches_count))
   endfunction
 
   function! s:post_check() abort

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -18,7 +18,10 @@ let s:ext_cmd = {}
 let s:ext_cmd.fzy = 'fzy --show-matches="%s"'
 let s:ext_cmd.fzf = 'fzf --filter="%s"'
 let s:ext_cmd.sk = 'sk --filter="%s"'
-let s:ext_cmd.maple = 'maple %s'
+" Use "%s" instead of bare %s in case of the query containing ';',
+" e.g., rg --files | maple hello;world, world can be misinterpreted as a
+" command.
+let s:ext_cmd.maple = 'maple "%s"'
 
 if exists('g:clap_default_external_filter')
   let s:default_ext_filter = g:clap_default_external_filter

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -1,6 +1,9 @@
 " Author: liuchengxu <xuliuchengxlc@gmail.com>
 " Description: Spawn a job when initalizing the display window if possible.
 
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
 function! s:on_complete() abort
   if empty(g:clap.input.get())
     call g:clap.display.set_lines_lazy(s:chunks)
@@ -64,3 +67,6 @@ function! clap#forerunner#start(cmd) abort
   let s:chunks = []
   call s:start_forerunner(a:cmd)
 endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -10,12 +10,18 @@ function! s:on_complete() abort
   if empty(g:clap.input.get())
     call g:clap.display.set_lines_lazy(s:chunks)
   endif
+
   let chunks_size = len(s:chunks)
   let g:clap.display.initial_size = chunks_size
   call clap#impl#refresh_matches_count(string(chunks_size))
+
   " If the total results is not huge we could keep them in the memory
   " and use the built-in fzy impl later.
   if chunks_size < 10000
+    " g:__clap_forerunner_result is sort of a cache here.
+    " If we already have g:__clap_forerunner_result and you
+    " just created a new file outside the vim, this new file maybe not recongnized.
+    " TODO: add a flag to disable this cache.
     let g:__clap_forerunner_result = s:chunks
   endif
 endfunction

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -4,6 +4,8 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
+let s:job_id = -1
+
 function! s:on_complete() abort
   if empty(g:clap.input.get())
     call g:clap.display.set_lines_lazy(s:chunks)
@@ -66,6 +68,13 @@ endif
 function! clap#forerunner#start(cmd) abort
   let s:chunks = []
   call s:start_forerunner(a:cmd)
+endfunction
+
+function! clap#forerunner#stop() abort
+  if s:job_id > 0
+    call clap#job#stop(s:job_id)
+    let s:job_id = -1
+  endif
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -1,0 +1,77 @@
+" Author: liuchengxu <xuliuchengxlc@gmail.com>
+" Description: Spawn a job when initalizing the display window if possible.
+
+function! s:on_complete() abort
+  if empty(g:clap.input.get())
+    call g:clap.display.set_lines_lazy(s:chunks)
+  endif
+  let chunks_size = len(s:chunks)
+  if chunks_size < 10000
+    let g:__clap_forerunner_cached = s:chunks
+    let g:clap.display.initial_size = chunks_size
+    call clap#impl#refresh_matches_count(string(g:clap.display.initial_size))
+  endif
+endfunction
+
+function! s:on_event(job_id, data, event) abort
+  " We only process the job that was spawned last time.
+  if a:job_id != s:job_id
+    return
+  endif
+
+  if a:event ==# 'stdout'
+    if len(a:data) > 1
+      " Second last is the real last one for neovim.
+      call extend(s:chunks, a:data[:-2])
+    endif
+  elseif a:event ==# 'stderr'
+    " Ignore the error
+  else
+    call s:on_complete()
+  endif
+endfunction
+
+function! s:job_cwd() abort
+  if get(g:, 'clap_disable_run_rooter', v:false)
+    return getcwd()
+  else
+    let git_root = clap#util#find_git_root(g:clap.start.bufnr)
+    return empty(git_root) ? getcwd() : git_root
+  endif
+endfunction
+
+function! s:close_cb(channel) abort
+  if clap#util#job_id_of(a:channel) == s:job_id
+    " https://github.com/vim/vim/issues/5143
+    let s:chunks = split(ch_readraw(a:channel), "\n")
+    call s:on_complete()
+  endif
+endfunction
+
+if has('nvim')
+  function! s:start_forerunner(cmd) abort
+    let s:job_id = jobstart(a:cmd, {
+          \ 'on_exit': function('s:on_event'),
+          \ 'on_stdout': function('s:on_event'),
+          \ 'on_stderr': function('s:on_event'),
+          \ 'stdout_buffered': v:true,
+          \ 'cwd': s:job_cwd(),
+          \ })
+  endfunction
+else
+  function! s:start_forerunner(cmd) abort
+    let job = job_start(['bash', '-c', a:cmd], {
+          \ 'in_io': 'null',
+          \ 'close_cb': function('s:close_cb'),
+          \ 'noblock': 1,
+          \ 'mode': 'raw',
+          \ 'cwd': s:job_cwd(),
+          \ })
+    let s:job_id = clap#util#parse_vim8_job_id(string(job))
+  endfunction
+endif
+
+function! clap#forerunner#start(cmd) abort
+  let s:chunks = []
+  call s:start_forerunner(a:cmd)
+endfunction

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -11,10 +11,12 @@ function! s:on_complete() abort
     call g:clap.display.set_lines_lazy(s:chunks)
   endif
   let chunks_size = len(s:chunks)
+  let g:clap.display.initial_size = chunks_size
+  call clap#impl#refresh_matches_count(string(chunks_size))
+  " If the total results is not huge we could keep them in the memory
+  " and use the built-in fzy impl later.
   if chunks_size < 10000
-    let g:__clap_forerunner_cached = s:chunks
-    let g:clap.display.initial_size = chunks_size
-    call clap#impl#refresh_matches_count(string(chunks_size))
+    let g:__clap_forerunner_result = s:chunks
   endif
 endfunction
 

--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -64,7 +64,7 @@ function! s:on_typed_sync_impl() abort
 
   let l:has_no_matches = v:false
 
-  let l:raw_lines = s:get_source()
+  let l:raw_lines = get(g:, '__clap_forerunner_cached', s:get_source())
   let l:lines = call(g:clap.provider.filter(), [l:cur_input, l:raw_lines])
 
   if empty(l:lines)
@@ -215,6 +215,10 @@ endfunction
 "             on_move
 "
 function! clap#impl#on_typed() abort
+  if exists('g:__clap_forerunner_cached')
+    call s:on_typed_sync_impl()
+    return
+  endif
   if g:clap.provider.can_async()
     " Run async explicitly
     if get(g:clap.context, 'async') is v:true

--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -64,7 +64,7 @@ function! s:on_typed_sync_impl() abort
 
   let l:has_no_matches = v:false
 
-  let l:raw_lines = get(g:, '__clap_forerunner_cached', s:get_source())
+  let l:raw_lines = get(g:, '__clap_forerunner_result', s:get_source())
   let l:lines = call(g:clap.provider.filter(), [l:cur_input, l:raw_lines])
 
   if empty(l:lines)
@@ -215,7 +215,7 @@ endfunction
 "             on_move
 "
 function! clap#impl#on_typed() abort
-  if exists('g:__clap_forerunner_cached')
+  if exists('g:__clap_forerunner_result')
     call s:on_typed_sync_impl()
     return
   endif

--- a/autoload/clap/indicator.vim
+++ b/autoload/clap/indicator.vim
@@ -28,8 +28,12 @@ else
 endif
 
 " Caveat: This function can have a peformance bottle neck if update frequently.
+"
 " If you feel the responsive is slow, try to disable the indicator.
 " especially for the outside async jobs which could be cpu-intensive.
+"
+" If the initial_size is possible, use clap#impl#refresh_matches_count()
+" instead in that it will combine the initial_size info.
 function! clap#indicator#set_matches(indicator) abort
   if get(g:, 'clap_disable_matches_indicator', v:false)
     return

--- a/autoload/clap/job.vim
+++ b/autoload/clap/job.vim
@@ -1,0 +1,11 @@
+" Author: liuchengxu <xuliuchengxlc@gmail.com>
+" Description: APIs for working with Asynchronous jobs.
+
+function! clap#job#cwd() abort
+  if get(g:, 'clap_disable_run_rooter', v:false)
+    return getcwd()
+  else
+    let git_root = clap#util#find_git_root(g:clap.start.bufnr)
+    return empty(git_root) ? getcwd() : git_root
+  endif
+endfunction

--- a/autoload/clap/job.vim
+++ b/autoload/clap/job.vim
@@ -1,6 +1,9 @@
 " Author: liuchengxu <xuliuchengxlc@gmail.com>
 " Description: APIs for working with Asynchronous jobs.
 
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
 function! clap#job#cwd() abort
   if get(g:, 'clap_disable_run_rooter', v:false)
     return getcwd()
@@ -9,3 +12,6 @@ function! clap#job#cwd() abort
     return empty(git_root) ? getcwd() : git_root
   endif
 endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/job.vim
+++ b/autoload/clap/job.vim
@@ -4,6 +4,17 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
+if has('nvim')
+  function! clap#job#stop(job_id) abort
+    silent! call jobstop(a:job_id)
+  endfunction
+else
+  function! clap#job#stop(job_id) abort
+    " Kill it!
+    silent! call jobstop(a:job_id, 'kill')
+  endfunction
+endif
+
 function! clap#job#cwd() abort
   if get(g:, 'clap_disable_run_rooter', v:false)
     return getcwd()

--- a/autoload/clap/util.vim
+++ b/autoload/clap/util.vim
@@ -257,15 +257,27 @@ function! clap#util#add_match_at(lnum, col, hl_group) abort
 endfunction
 
 if has('nvim')
+
   " 0-based
   function! clap#util#add_highlight_at(lnum, col, hl_group) abort
     call nvim_buf_add_highlight(g:clap.display.bufnr, -1, a:hl_group, a:lnum, a:col, a:col+1)
   endfunction
+
 else
+
   function! clap#util#add_highlight_at(lnum, col, hl_group) abort
     " 1-based
     call prop_add(a:lnum+1, a:col+1, {'length': 1, 'type': a:hl_group, 'bufnr': g:clap.display.bufnr})
   endfunction
+
+  function! clap#util#parse_vim8_job_id(job_str) abort
+    return str2nr(matchstr(a:job_str, '\d\+'))
+  endfunction
+
+  function! clap#util#job_id_of(channel) abort
+    return clap#util#parse_vim8_job_id(ch_getjob(a:channel))
+  endfunction
+
 endif
 
 let &cpoptions = s:save_cpo


### PR DESCRIPTION
First step of the optimization, currently only the small scale searching is fully supported. The
benefits of the forerunner jobs are:

- avoid the redraw caused by job.
- don't have to spawn a new job on each of your type.


Related: #98
