### PR TITLE
Fix sign group name in vim's popup

### DIFF
--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -90,12 +90,15 @@ function! s:on_typed_sync_impl() abort
   if empty(l:lines)
     let l:lines = [g:clap_no_matches_msg]
     let g:__clap_has_no_matches = v:true
+    call g:clap.display.set_lines_lazy(lines)
+    " In clap#impl#refresh_matches_count() we reset the sign to the first line,
+    " But the signs are seemingly removed when setting the lines, so we should
+    " postpone the sign update.
     call clap#impl#refresh_matches_count('0')
   else
+    call g:clap.display.set_lines_lazy(lines)
     call clap#impl#refresh_matches_count(string(len(l:lines)))
   endif
-
-  call g:clap.display.set_lines_lazy(lines)
 
   call g:clap#display_win.compact_if_undersize()
   call clap#spinner#set_idle()

--- a/autoload/clap/sign.vim
+++ b/autoload/clap/sign.vim
@@ -6,8 +6,8 @@ set cpoptions&vim
 
 let s:is_nvim = has('nvim')
 let s:signed = []
-let s:sign_group = 'clapSelected'
-let s:sign_cur_group = 'clapCurrentSelected'
+let s:sign_group = 'PopUpClapSelected'
+let s:sign_cur_group = 'PopUpClapCurrentSelected'
 let s:last_signed_id = -1
 
 if !exists('s:sign_inited')
@@ -26,7 +26,7 @@ endif
 
 " lnum is the sign id
 function! s:place_sign_at(lnum) abort
-  call sign_place(a:lnum, s:sign_group, 'clapSelected', g:clap.display.bufnr, {'lnum': a:lnum})
+  call sign_place(a:lnum, s:sign_group, 'PopUpClapSelected', g:clap.display.bufnr, {'lnum': a:lnum})
 endfunction
 
 function! s:unplace_sign_at(sign_id) abort
@@ -34,7 +34,7 @@ function! s:unplace_sign_at(sign_id) abort
 endfunction
 
 function! s:place_cur_sign_at(lnum) abort
-  call sign_place(a:lnum, s:sign_cur_group, 'clapCurrentSelected', g:clap.display.bufnr, {'lnum': a:lnum})
+  call sign_place(a:lnum, s:sign_cur_group, 'PopUpClapCurrentSelected', g:clap.display.bufnr, {'lnum': a:lnum})
 endfunction
 
 function! s:unplace_cur_sign_at(sign_id) abort


### PR DESCRIPTION
based on https://github.com/vim/vim/commit/7257073043252c2e01c8e168e6842a1121797243

fixed #130 