### PR TITLE
Fix async external filter on typing falling back to sync

### DIFF
--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -240,7 +240,8 @@ endfunction
 "             on_move
 "
 function! clap#impl#on_typed() abort
-  if exists('g:__clap_forerunner_result')
+  if exists('g:__clap_forerunner_result') &&
+        \ !(has_key(g:clap.context, 'ef') || has_key(g:clap.context, 'externalfilter'))
     call s:on_typed_sync_impl()
     return
   endif


### PR DESCRIPTION
When using external async filters vim-clap will revert back to the sync internal filter unless the provider returns more than 10000 entries. 

From what I could tell internally what is happening is that vim-clap is storing some cache in memory and if there is cache it will always run synchronously. This results in losing fuzzy matching when using external filters(unless you have the internal one written in phyton).

With this PR if there is a external filter set then even if there is cache the filtering will be done async.