### PR TITLE
Add preview for tags provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ CHANGELOG
 
 ### Added
 
+- Add Python version subscorer fuzzy filter.([#159](https://github.com/liuchengxu/vim-clap/pull/159))
 - New provider `:Clap git_diff_files` by @kit494way.
 - Add the preview support for `:Clap registers`. If the content of some register is too much to fit on one line, then it will be shown in the preview window, otherwise do nothing.
-- Make the built-in fuzzy filter 10x faster using Rust.([147](https://github.com/liuchengxu/vim-clap/pull/147))
+- Add the preview support for `:Clap tags`.
+- Make the built-in fuzzy filter 10x faster using Rust.([#147](https://github.com/liuchengxu/vim-clap/pull/147))
 
 ## [0.2] 2019-12-10
 

--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -15,6 +15,7 @@ function! s:reset_on_empty_input() abort
   call clap#indicator#set_matches('['.g:__clap_initial_source_size.']')
   call clap#sign#toggle_cursorline()
   call g:clap#display_win.compact_if_undersize()
+  call g:clap.preview.hide()
 endfunction
 
 " g:__clap_forerunner_result is fetched in async.
@@ -95,6 +96,7 @@ function! s:on_typed_sync_impl() abort
     " But the signs are seemingly removed when setting the lines, so we should
     " postpone the sign update.
     call clap#impl#refresh_matches_count('0')
+    call g:clap.preview.hide()
   else
     call g:clap.display.set_lines_lazy(lines)
     call clap#impl#refresh_matches_count(string(len(l:lines)))

--- a/autoload/clap/provider/tags.vim
+++ b/autoload/clap/provider/tags.vim
@@ -17,7 +17,11 @@ function! s:tags.source(...) abort
 endfunction
 
 function! s:tags.on_move() abort
-  let [lnum, tag] = vista#finder#fzf#extract(g:clap.display.getcurline())
+  try
+    let [lnum, tag] = vista#finder#fzf#extract(g:clap.display.getcurline())
+  catch
+    return
+  endtry
   let [start, end, hi_lnum] = clap#util#get_preview_line_range(lnum, 5)
   let lines = getbufline(g:clap.start.bufnr, start, end)
   call g:clap.preview.show(lines)

--- a/autoload/clap/provider/tags.vim
+++ b/autoload/clap/provider/tags.vim
@@ -16,8 +16,21 @@ function! s:tags.source(...) abort
   return vista#finder#PrepareSource(data)
 endfunction
 
+function! s:tags.on_move() abort
+  let [lnum, tag] = vista#finder#fzf#extract(g:clap.display.getcurline())
+  let [start, end, hi_lnum] = clap#util#get_preview_line_range(lnum, 5)
+  let lines = getbufline(g:clap.start.bufnr, start, end)
+  call g:clap.preview.show(lines)
+  call g:clap.preview.load_syntax(s:origin_ft)
+  call g:clap.preview.add_highlight(hi_lnum+1)
+endfunction
+
+function! s:tags.on_enter() abort
+  let s:origin_ft = getbufvar(g:clap.start.bufnr, '&ft')
+  call g:clap.display.setbufvar('&ft', 'clap_tags')
+endfunction
+
 let s:tags.sink = function('vista#finder#fzf#sink')
-let s:tags.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_tags') }
 
 let g:clap#provider#tags# = s:tags
 


### PR DESCRIPTION
- Need the API exposed by vista.vim https://github.com/liuchengxu/vista.vim/commit/5538f9bc62beecb68f4ab1be63f92e77bd2c93f0

-  Hide the preview window when the input is empty and has no matches.