### PR TITLE
fix empty initial list for external filters

### DIFF
--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -516,8 +516,7 @@ function! s:init_provider() abort
   endfunction
 
   function! provider.init_display_win() abort
-    if self.is_pure_async()
-          \ || clap#api#has_externalfilter()
+    if !has_key(g:clap.provider._(), 'source')
       return
     elseif self.type == g:__t_string
       call clap#forerunner#start(g:clap.provider._().source)


### PR DESCRIPTION
When initializing the window for external filters some providers can show results before filtering I find this way to be more clear and makes more sense to show results to be filtered if possible.

I am not sure if this is the best way to do it but it I tested and it seem to work for all commands