### PR TITLE
Using +nightly chanel for building rust

### DIFF
--- a/autoload/clap/helper.vim
+++ b/autoload/clap/helper.vim
@@ -93,7 +93,7 @@ endfunction
 if has('win32')
   let s:from = '.\fuzzymatch-rs\target\release\libfuzzymatch_rs.dll'
   let s:to = 'libfuzzymatch_rs.pyd'
-  let s:rust_ext_cmd = printf('cargo build --release && copy %s %s', s:from, s:to)
+  let s:rust_ext_cmd = printf('cargo +nightly build --release && copy %s %s', s:from, s:to)
   let s:rust_ext_cwd = fnamemodify(g:clap#autoload_dir, ':h').'\pythonx\clap'
 else
   let s:rust_ext_cmd = 'make build'

--- a/pythonx/clap/Makefile
+++ b/pythonx/clap/Makefile
@@ -17,7 +17,7 @@ test:
 run-cargo:
 	@echo "\033[1;34m==>\033[0m Trying to build rust extension"; \
 	cd fuzzymatch-rs; \
-	cargo build --release
+	cargo +nightly build --release
 
 ifeq ($(OS),darwin)
 move-so: run-cargo


### PR DESCRIPTION
When trying build rust module for vim-clap I got error:
```bash
pythonx/clap/fuzzymatch-rs on > master is 📦 v0.1.0 via 🦀 v1.39.0
[ 14:13:13 ]  ❯ cargo build --release
   Compiling pyo3 v0.8.3
error: failed to run custom build command for `pyo3 v0.8.3`

Caused by:
  process didn't exit successfully: `/Users/d.evsyukov/.vim/plugged/vim-clap/pythonx/clap/fuzzymatch-rs/target/release/build/pyo3-eb13f65051f8e97f/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'Error: pyo3 requires a nightly or dev version of Rust.', /Users/d.evsyukov/.cargo/registry/src/github.com-1ecc6299db9ec823/pyo3-0.8.3/build.rs:542:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

for building this code we need to use nightly rust chanel.