### PR TITLE
Cache the result of forerunner to a tmp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ CHANGELOG
 - Add the helper function for building Rust extension easily. Now you can use `:call clap#helper#build_all()` to build the optional Rust dependency.
 - Make the built-in fuzzy filter 10x faster using Rust.([#147](https://github.com/liuchengxu/vim-clap/pull/147))
 
+### Improved
+
+- Cache the result of forerunner job into a temp file if it's larger than the threshold of built-in sync filter can handle.([#177](https://github.com/liuchengxu/vim-clap/pull/177))
+
 ### Fixed
 
 - Fix vim popup sign not showing.([#141](https://github.com/liuchengxu/vim-clap/pull/141))

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -256,6 +256,21 @@ function! s:try_register_is_ok(provider_id) abort
   return s:validate_provider(registration_info)
 endfunction
 
+function! s:clear_state() abort
+  call s:unlet_vars([
+        \ 'g:__clap_provider_cwd',
+        \ 'g:__clap_raw_source',
+        \ 'g:__clap_initial_source_size',
+        \ ])
+
+  if exists('g:__clap_forerunner_tmp_file')
+    if filereadable(g:__clap_forerunner_tmp_file)
+      call delete(g:__clap_forerunner_tmp_file)
+    endif
+    unlet g:__clap_forerunner_tmp_file
+  endif
+endfunction
+
 function! clap#for(provider_id_or_alias) abort
   if has_key(s:provider_alias, a:provider_id_or_alias)
     let provider_id = s:provider_alias[a:provider_id_or_alias]
@@ -267,21 +282,12 @@ function! clap#for(provider_id_or_alias) abort
   let g:clap.display.cache = []
 
   " If the registrar is not aware of this provider, try registering it.
-  if !has_key(g:clap.registrar, provider_id) && !s:try_register_is_ok(provider_id)
+  if !has_key(g:clap.registrar, provider_id)
+        \ && !s:try_register_is_ok(provider_id)
     return
   endif
 
-  call s:unlet_vars([
-        \ 'g:__clap_provider_cwd',
-        \ 'g:__clap_raw_source',
-        \ 'g:__clap_initial_source_size',
-        \ ])
-
-  if exists('g:__clap_forerunner_tmp_file')
-    if filereadable(g:__clap_forerunner_tmp_file)
-      call delete(g:__clap_forerunner_tmp_file)
-    endif
-  endif
+  call s:clear_state()
 
   call clap#handler#init()
 

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -277,6 +277,12 @@ function! clap#for(provider_id_or_alias) abort
         \ 'g:__clap_initial_source_size',
         \ ])
 
+  if exists('g:__clap_forerunner_tmp_file')
+    if filereadable(g:__clap_forerunner_tmp_file)
+      call delete(g:__clap_forerunner_tmp_file)
+    endif
+  endif
+
   call clap#handler#init()
 
   call g:clap.open_win()

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -401,8 +401,12 @@ function! s:init_provider() abort
   " Pipe the source into the external filter
   function! s:wrap_async_cmd(source_cmd) abort
     let ext_filter_cmd = clap#filter#get_external_cmd_or_default()
-    " FIXME Does it work well in Windows?
-    let cmd = a:source_cmd.' | '.ext_filter_cmd
+    if exists('g:__clap_forerunner_tmp_file')
+      let cmd = printf('%s %s | %s', s:cat_or_type, g:__clap_forerunner_tmp_file, ext_filter_cmd)
+    else
+      " FIXME Does it work well in Windows?
+      let cmd = a:source_cmd.' | '.ext_filter_cmd
+    endif
     return cmd
   endfunction
 

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -402,7 +402,9 @@ function! s:init_provider() abort
   function! s:wrap_async_cmd(source_cmd) abort
     let ext_filter_cmd = clap#filter#get_external_cmd_or_default()
     if exists('g:__clap_forerunner_tmp_file')
-      " Reading from a cached file should be faster than running the coommand again.
+      " Reading from a cached file should be faster than running the command again.
+      " Currently only maple extension supports --input option, for the other
+      " external filter, use cat instead.
       if clap#filter#using_maple()
         let cmd = printf('%s --input %s', ext_filter_cmd, g:__clap_forerunner_tmp_file)
       else

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -402,7 +402,12 @@ function! s:init_provider() abort
   function! s:wrap_async_cmd(source_cmd) abort
     let ext_filter_cmd = clap#filter#get_external_cmd_or_default()
     if exists('g:__clap_forerunner_tmp_file')
-      let cmd = printf('%s %s | %s', s:cat_or_type, g:__clap_forerunner_tmp_file, ext_filter_cmd)
+      " Reading from a cached file should be faster than running the coommand again.
+      if clap#filter#using_maple()
+        let cmd = printf('%s --input %s', ext_filter_cmd, g:__clap_forerunner_tmp_file)
+      else
+        let cmd = printf('%s %s | %s', s:cat_or_type, g:__clap_forerunner_tmp_file, ext_filter_cmd)
+      endif
     else
       " FIXME Does it work well in Windows?
       let cmd = a:source_cmd.' | '.ext_filter_cmd

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -46,7 +46,7 @@ else
 endif
 
 function! clap#filter#using_maple() abort
-  return s:default_ext_filter == 'maple'
+  return s:ext_filter == 'maple'
 endfunction
 
 function! s:pattern_builder._force_case() abort
@@ -104,23 +104,23 @@ endfunction
 
 function! clap#filter#get_external_cmd_or_default() abort
   if has_key(g:clap.context, 'externalfilter')
-    let ext_filter = g:clap.context.externalfilter
+    let s:ext_filter = g:clap.context.externalfilter
   elseif has_key(g:clap.context, 'ef')
-    let ext_filter = g:clap.context.ef
+    let s:ext_filter = g:clap.context.ef
   elseif s:default_ext_filter is v:null
     call g:clap.abort('No external filter available')
     return
   else
-    let ext_filter = s:default_ext_filter
+    let s:ext_filter = s:default_ext_filter
   endif
-  if ext_filter ==# 'maple'
+  if s:ext_filter ==# 'maple'
     let g:__clap_maple_fuzzy_matched = []
     let Provider = g:clap.provider._()
     if !has_key(Provider, 'converter')
       let Provider.converter = function('s:maple_converter')
     endif
   endif
-  return printf(s:ext_cmd[ext_filter], g:clap.input.get())
+  return printf(s:ext_cmd[s:ext_filter], g:clap.input.get())
 endfunction
 
 function! s:filter(line, pattern) abort

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -45,6 +45,10 @@ else
   endfor
 endif
 
+function! clap#filter#using_maple() abort
+  return s:default_ext_filter == 'maple'
+endfunction
+
 function! s:pattern_builder._force_case() abort
   " Smart case
   if self.input =~? '\u'

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -35,7 +35,6 @@ function! s:on_complete() abort
     let tmp = tempname()
     if writefile(s:chunks, tmp) == 0
       let g:__clap_forerunner_tmp_file = tmp
-      return tmp
     endif
     unlet s:chunks
   endif

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -32,6 +32,11 @@ function! s:on_complete() abort
     " TODO: add a flag to disable this cache.
     let g:__clap_forerunner_result = s:chunks
   else
+    let tmp = tempname()
+    if writefile(s:chunks, tmp) == 0
+      let g:__clap_forerunner_tmp_file = tmp
+      return tmp
+    endif
     unlet s:chunks
   endif
 endfunction

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,16 +28,18 @@ struct Opt {
     #[structopt(short, long, possible_values = &Algo::variants(), case_insensitive = true)]
     algo: Option<Algo>,
 
-    /// Print a JSON with two fields: total and payload. The payload size is decided by number.
-    ///
-    /// total: total number
-    /// payload: lines
-    #[structopt(short = "n", long = "number")]
-    number: Option<usize>,
-
     /// Read input from a file instead of stdin.
     #[structopt(long = "input", parse(from_os_str))]
     input: Option<PathBuf>,
+
+    /// Print the top number of filtered items.
+    ///
+    /// The returned JSON has three fields:
+    ///   - total: total number of initial filtered result set.
+    ///   - lines: text lines used for displaying directly.
+    ///   - indices: the indices of matched elements per line, used for the highlight purpose.
+    #[structopt(short = "n", long = "number")]
+    number: Option<usize>,
 }
 
 pub fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ struct Opt {
     /// total: total number
     /// payload: lines
     #[structopt(short = "n", long = "number")]
-    number: Option<u32>,
+    number: Option<usize>,
 
     /// Read input from a file instead of stdin.
     #[structopt(long = "input", parse(from_os_str))]
@@ -80,9 +80,9 @@ pub fn main() {
 
     if let Some(number) = opt.number {
         let total = ranked.len();
-        let payload = ranked.into_iter().take(number as usize).collect::<Vec<_>>();
-        let mut lines = Vec::with_capacity(number as usize);
-        let mut indices = Vec::with_capacity(number as usize);
+        let payload = ranked.into_iter().take(number).collect::<Vec<_>>();
+        let mut lines = Vec::with_capacity(number);
+        let mut indices = Vec::with_capacity(number);
         for (text, _, idxs) in payload.iter() {
             lines.push(text);
             indices.push(idxs);


### PR DESCRIPTION
Close #98

When the result set is too large for the built-in sync filter, and the furerunner job is completed, save the results to a tmp file instead of always running the heavy command again, which could be 2x faster.

```bash
$ cd ~ && fd --type f > home.txt

# Reading from a file
$ time /Users/xlc/.vim/plugged/vim-clap/target/release/maple "srli" --input /Users/xlc/home.txt --number 96
real	0m1.674s
user	0m1.640s
sys	0m0.093s

# Runing the command and pip into maple
$ time fd --type f | /Users/xlc/.vim/plugged/vim-clap/target/release/maple "srli" --number 96
real	0m3.173s
user	0m6.310s
sys	0m13.075s
```

This commit 3557163 using rayon's `par_lines` gains 3x faster again than reading file using std lib.

```bash
$ time /Users/xlc/.vim/plugged/vim-clap/target/release/maple "srli" --input /Users/xlc/home.txt --number 96
real	0m0.491s
user	0m2.838s
sys	0m0.158s
```