### PR TITLE
Add highlight for displaying buffer by setting syntax option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ CHANGELOG
 ### Improved
 
 - Cache the result of forerunner job into a temp file if it's larger than the threshold of built-in sync filter can handle.([#177](https://github.com/liuchengxu/vim-clap/pull/177))
+- Set `syntax` instead of `filetype` for the highlight as setting `filetype` can start some unexpected filetype related services.
 
 ### Fixed
 

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -318,7 +318,7 @@ if !exists('g:clap')
   call clap#register('_', {
         \ 'source': function('s:_source'),
         \ 'sink': function('s:_sink'),
-        \ 'on_enter': { -> g:clap.display.setbufvar('&ft', 'clap_global') },
+        \ 'on_enter': { -> g:clap.display.setbufvar('&syntax', 'clap_global') },
         \ })
 endif
 

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -610,10 +610,6 @@ function! clap#api#bake() abort
   if s:is_nvim
     let g:clap.preview = g:clap#floating_win#preview
 
-    function! g:clap.preview.load_syntax(filetype) abort
-      call g:clap.preview.setbufvar('&ft', a:filetype)
-    endfunction
-
     function! g:clap.preview.add_highlight(lnum) abort
       noautocmd call win_gotoid(g:clap.preview.winid)
       call s:matchaddpos(a:lnum)
@@ -626,11 +622,6 @@ function! clap#api#bake() abort
   else
     let g:clap.preview = g:clap#popup#preview
 
-    function! g:clap.preview.load_syntax(filetype) abort
-      " vim using noautocmd in win_execute, hence we have to load the syntax file manually.
-      call win_execute(g:clap.preview.winid, 'runtime syntax/'.a:filetype.'.vim')
-    endfunction
-
     function! g:clap.preview.add_highlight(lnum) abort
       call win_execute(g:clap.preview.winid, 'noautocmd call s:matchaddpos(a:lnum)')
     endfunction
@@ -639,6 +630,10 @@ function! clap#api#bake() abort
     let g:clap.open_win = function('clap#popup#open')
     let g:clap.close_win = function('clap#popup#close')
   endif
+
+  function! g:clap.preview.set_syntax(syntax) abort
+    call g:clap.preview.setbufvar('&syntax', a:syntax)
+  endfunction
 
   call s:inject_base_api(g:clap.preview)
 endfunction

--- a/autoload/clap/provider/blines.vim
+++ b/autoload/clap/provider/blines.vim
@@ -26,13 +26,13 @@ function! s:blines.on_move() abort
   let [start, end, hi_lnum] = clap#util#get_preview_line_range(lnum, 5)
   let lines = getbufline(g:clap.start.bufnr, start, end)
   call g:clap.preview.show(lines)
-  call g:clap.preview.load_syntax(s:origin_ft)
+  call g:clap.preview.set_syntax(s:origin_syntax)
   call g:clap.preview.add_highlight(hi_lnum+1)
 endfunction
 
 function! s:blines.on_enter() abort
-  let s:origin_ft = getbufvar(g:clap.start.bufnr, '&ft')
-  call g:clap.display.setbufvar('&ft', 'clap_blines')
+  let s:origin_syntax = getbufvar(g:clap.start.bufnr, '&syntax')
+  call g:clap.display.setbufvar('&syntax', 'clap_blines')
 endfunction
 
 let g:clap#provider#blines# = s:blines

--- a/autoload/clap/provider/buffers.vim
+++ b/autoload/clap/provider/buffers.vim
@@ -50,7 +50,7 @@ function! s:buffers_sink(selected) abort
 endfunction
 
 function! s:buffers_on_enter() abort
-  call g:clap.display.setbufvar('&ft', 'clap_buffers')
+  call g:clap.display.setbufvar('&syntax', 'clap_buffers')
 endfunction
 
 let s:buffers = {}

--- a/autoload/clap/provider/command.vim
+++ b/autoload/clap/provider/command.vim
@@ -18,7 +18,7 @@ function! s:command.source() abort
   return split(l:command, "\n")
 endfunction
 
-let s:command.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_command') }
+let s:command.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_command') }
 
 let g:clap#provider#command# = s:command
 

--- a/autoload/clap/provider/command_history.vim
+++ b/autoload/clap/provider/command_history.vim
@@ -28,7 +28,7 @@ endfunction
 let s:command_history = {}
 let s:command_history.sink = function('s:command_history_sink')
 let s:command_history.source = function('s:command_history_source')
-let s:command_history.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_command_history') }
+let s:command_history.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_command_history') }
 
 let g:clap#provider#command_history# = s:command_history
 

--- a/autoload/clap/provider/commits.vim
+++ b/autoload/clap/provider/commits.vim
@@ -38,7 +38,7 @@ function! s:commits.sink(line) abort
   call g:clap.abort('Not implemented yet')
 endfunction
 
-let s:commits.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_commits') }
+let s:commits.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_commits') }
 
 let g:clap#provider#commits# = s:commits
 

--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -161,7 +161,7 @@ function! s:grep_on_move() abort
   let [start, end, hi_lnum] = clap#util#get_preview_line_range(lnum, 5)
   let preview_lines = s:preview_cache[fpath]['lines'][start : end]
   call g:clap.preview.show(preview_lines)
-  call g:clap.preview.load_syntax(s:preview_cache[fpath].filetype)
+  call g:clap.preview.set_syntax(s:preview_cache[fpath].filetype)
   call g:clap.preview.add_highlight(hi_lnum)
 endfunction
 
@@ -239,7 +239,7 @@ let s:grep.on_typed = function('s:grep_with_delay')
 
 let s:grep.on_move = function('s:grep_on_move')
 
-let s:grep.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_grep') }
+let s:grep.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_grep') }
 
 if get(g:, 'clap_provider_grep_enable_icon',
       \ exists('g:loaded_webdevicons')

--- a/autoload/clap/provider/jumps.vim
+++ b/autoload/clap/provider/jumps.vim
@@ -42,7 +42,7 @@ function! s:jumps.on_move() abort
   call clap#provider#marks#preview_impl(matched[2], matched[3], matched[4])
 endfunction
 
-let s:jumps.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_jumps') }
+let s:jumps.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_jumps') }
 let g:clap#provider#jumps# = s:jumps
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/provider/lines.vim
+++ b/autoload/clap/provider/lines.vim
@@ -74,7 +74,7 @@ function! s:lines.source() abort
 endfunction
 
 function! s:lines.on_enter() abort
-  call g:clap.display.setbufvar('&ft', 'clap_lines')
+  call g:clap.display.setbufvar('&syntax', 'clap_lines')
 endfunction
 
 let g:clap#provider#lines# = s:lines

--- a/autoload/clap/provider/marks.vim
+++ b/autoload/clap/provider/marks.vim
@@ -63,7 +63,7 @@ function! clap#provider#marks#preview_impl(line, col, file_text) abort
       let ft = clap#ext#into_filetype(file_text)
     endif
     if !empty(ft)
-      call g:clap.preview.load_syntax(ft)
+      call g:clap.preview.set_syntax(ft)
     endif
     call g:clap.preview.add_highlight(hi_lnum)
   endif
@@ -89,7 +89,7 @@ function! s:marks.on_move() abort
   call clap#provider#marks#preview_impl(line, col, file_text)
 endfunction
 
-let s:marks.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_marks') }
+let s:marks.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_marks') }
 
 let g:clap#provider#marks# = s:marks
 

--- a/autoload/clap/provider/quickfix.vim
+++ b/autoload/clap/provider/quickfix.vim
@@ -32,13 +32,7 @@ function! s:quickfix.sink(selected) abort
 endfunction
 
 function! s:quickfix.on_enter() abort
-  if has('nvim')
-    call g:clap.display.goto_win()
-    runtime! syntax/qf.vim
-    call g:clap.input.goto_win()
-  else
-    call win_execute(g:clap.display.winid, 'runtime! syntax/qf.vim')
-  endif
+  call g:clap.display.setbufvar('&syntax', 'qf')
 endfunction
 
 let g:clap#provider#quickfix# = s:quickfix

--- a/autoload/clap/provider/registers.vim
+++ b/autoload/clap/provider/registers.vim
@@ -53,7 +53,7 @@ function! s:registers.sink(selected) abort
   execute 'normal!' '"'.reg.'p'
 endfunction
 
-let s:registers.on_enter = { -> g:clap.display.setbufvar('&ft', 'clap_registers') }
+let s:registers.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_registers') }
 
 let g:clap#provider#registers# = s:registers
 

--- a/autoload/clap/provider/tags.vim
+++ b/autoload/clap/provider/tags.vim
@@ -35,13 +35,13 @@ function! s:tags.on_move() abort
   let [start, end, hi_lnum] = clap#util#get_preview_line_range(lnum, 5)
   let lines = getbufline(g:clap.start.bufnr, start, end)
   call g:clap.preview.show(lines)
-  call g:clap.preview.load_syntax(s:origin_ft)
+  call g:clap.preview.set_syntax(s:origin_syntax)
   call g:clap.preview.add_highlight(hi_lnum+1)
 endfunction
 
 function! s:tags.on_enter() abort
-  let s:origin_ft = getbufvar(g:clap.start.bufnr, '&ft')
-  call g:clap.display.setbufvar('&ft', 'clap_tags')
+  let s:origin_syntax = getbufvar(g:clap.start.bufnr, '&syntax')
+  call g:clap.display.setbufvar('&syntax', 'clap_tags')
 endfunction
 
 let s:tags.sink = function('vista#finder#fzf#sink')


### PR DESCRIPTION
Setting `filetype` would also trigger some other filetype related hooks, which is normaly unexpected.