### PR TITLE
Add forerunner job status sign and a delay timer for running maple

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ Vim-clap is a modern generic interactive finder and dispatcher, based on the new
 * [Requirement](#requirement)
   * [Optional](#optional)
     * [`python`](#python)
-    * [`maple`](#maple)
-    * [Rust extension](#rust-extension)
+    * [`Rust`](#rust)
+      * [`maple` binary](#maple-binary)
+      * [Python dynamic module](#python-dynamic-module)
 * [Installation](#installation)
 * [Usage](#usage)
   * [Commands](#commands)
@@ -85,30 +86,41 @@ Vim-clap is a modern generic interactive finder and dispatcher, based on the new
   $ python3 -m pip install pynvim
   ```
 
-#### `maple`
+#### `Rust`
 
-`maple` is essentially a tiny wrapper of [skim](https://github.com/lotabout/skim) and [fzy](https://github.com/jhawthorn/fzy), with the matched indices exposed to be highlighted in vim-clap's async providers.
+If you have installed Rust on your system, specifically, `cargo` executable exists, you can build the extra tools for a performant and nicer vim-clap using one single command `:call clap#helper#build_all()`.
 
-Use `:call clap#helper#build_maple()` or install maple manually:
+##### `maple` binary
 
-```bash
-# Compile the release build
-cargo build --release
+`maple` mainly serves two functions:
 
-# Or use cargo install
-cargo install --path . --force
-```
+1. Expose the fuzzy matched indices so that the matched elements can be highlighted in vim-clap, being a tiny wrapper of external fuzzy filter [fzf](https://github.com/junegunn/fzf) and [fzy](https://github.com/jhawthorn/fzy). Once you installed `maple`, fzy/skim binary are unneeded as `maple` does not rely the binary directly but reuses their filter algorithm internally.
 
-#### Rust extension
+2. Reduce the overhead of async job of Vim/NeoVim dramastically.
 
-Use `:call clap#helper#build_rust_ext()` to install the Rust extension for 10x faster fuzzy filter than the Python one.
+To install `maple` you can use the helper function and run `:call clap#helper#build_maple()`, or install it manually:
+
+  ```bash
+  # Compile the release build
+  cargo build --release
+
+  # Or use cargo install globally
+  cargo install --path . --force
+  ```
+
+##### Python dynamic module
+
+Use `:call clap#helper#build_rust_ext()` to install the Python dynamic module written in Rust for 10x faster fuzzy filter than the Python one. Refer to the post [Make Vim Python plugin 10x faster using Rust](http://liuchengxu.org/posts/speed-up-vim-python-plugin-using-rust/) for the whole story.
 
 ## Installation
+
+Using [vim-plug](https://github.com/junegunn/vim-plug):
 
 ```vim
 Plug 'liuchengxu/vim-clap'
 
-" Build the all optional dependency, cargo is needed.
+" The do hook is highly recommended.
+" It will try to build all the optional dependency if cargo exists on your system.
 Plug 'liuchengxu/vim-clap', { 'do': function('clap#helper#build_all') }
 ```
 

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -40,6 +40,9 @@ let s:provider_alias = {
 let s:provider_alias = extend(s:provider_alias, get(g:, 'clap_provider_alias', {}))
 let g:clap#provider_alias = s:provider_alias
 
+let g:clap_forerunner_status_sign_done = get(g:, 'clap_forerunner_status_sign_done', '*')
+let g:clap_forerunner_status_sign_running = get(g:, 'clap_forerunner_status_sign_running', '!')
+
 let g:clap_no_matches_msg = get(g:, 'clap_no_matches_msg', 'NO MATCHES FOUND')
 let g:__clap_no_matches_pattern = '^'.g:clap_no_matches_msg.'$'
 

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -39,7 +39,7 @@ function! s:on_complete() abort
     unlet s:chunks
   endif
 
-  let g:clap_forerunner_status_sign = ' '
+  let g:clap_forerunner_status_sign = g:clap_forerunner_status_sign_done
   call clap#spinner#refresh()
 endfunction
 
@@ -61,7 +61,7 @@ function! s:on_complete_maple() abort
     endif
   endif
 
-  let g:clap_forerunner_status_sign = ' '
+  let g:clap_forerunner_status_sign = g:clap_forerunner_status_sign_done
   call clap#spinner#refresh()
 endfunction
 
@@ -157,7 +157,7 @@ if clap#maple#is_available()
 else
   function! clap#forerunner#start(cmd) abort
     let s:chunks = []
-    let g:clap_forerunner_status_sign = '!'
+    let g:clap_forerunner_status_sign = g:clap_forerunner_status_sign_running
     call clap#forerunner#refresh()
     call clap#rooter#run(function('s:start_forerunner'), a:cmd)
   endfunction

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -38,6 +38,9 @@ function! s:on_complete() abort
     endif
     unlet s:chunks
   endif
+
+  let g:clap_forerunner_status_sign = ' '
+  call clap#spinner#refresh()
 endfunction
 
 function! s:on_complete_maple() abort
@@ -57,6 +60,9 @@ function! s:on_complete_maple() abort
       let g:__clap_forerunner_result = decoded.lines
     endif
   endif
+
+  let g:clap_forerunner_status_sign = ' '
+  call clap#spinner#refresh()
 endfunction
 
 function! s:on_event(job_id, data, event) abort
@@ -144,11 +150,15 @@ if clap#maple#is_available()
 
   function! clap#forerunner#start(cmd) abort
     let s:chunks = []
+    let g:clap_forerunner_status_sign = '!'
+    call clap#spinner#refresh()
     call s:start_maple(s:into_maple_cmd(a:cmd))
   endfunction
 else
   function! clap#forerunner#start(cmd) abort
     let s:chunks = []
+    let g:clap_forerunner_status_sign = '!'
+    call clap#forerunner#refresh()
     call clap#rooter#run(function('s:start_forerunner'), a:cmd)
   endfunction
 endif

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -6,6 +6,8 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 let s:job_id = -1
+let s:job_timer = -1
+let s:maple_delay = 100
 
 let s:maple_bin = fnamemodify(g:clap#autoload_dir, ':h').'/target/release/maple'
 
@@ -76,11 +78,20 @@ function! clap#maple#stop() abort
   endif
 endfunction
 
-function! clap#maple#job_start(cmd) abort
-  call clap#maple#stop()
+function! s:apply_start(_timer) abort
   let s:chunks = []
-  let s:cmd = a:cmd.' --number '.g:clap.display.preload_capacity
   call s:start_maple()
+endfunction
+
+function! clap#maple#job_start(cmd) abort
+  if s:job_timer != -1
+    call timer_stop(s:job_timer)
+  endif
+
+  call clap#maple#stop()
+
+  let s:cmd = a:cmd.' --number '.g:clap.display.preload_capacity
+  let s:job_timer = timer_start(s:maple_delay, function('s:apply_start'))
   return
 endfunction
 

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -7,7 +7,7 @@ set cpoptions&vim
 
 let s:job_id = -1
 let s:job_timer = -1
-let s:maple_delay = 100
+let s:maple_delay = get(g:, 'clap_maple_delay', 100)
 
 let s:maple_bin = fnamemodify(g:clap#autoload_dir, ':h').'/target/release/maple'
 

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -29,10 +29,18 @@ endfunction
 
 function! s:on_complete() abort
   call clap#spinner#set_idle()
+
   let decoded = json_decode(s:chunks[0])
+  if decoded.total == 0
+    call g:clap.display.set_lines([g:clap_no_matches_msg])
+    call clap#indicator#set_matches('[0]')
+    call clap#sign#disable_cursorline()
+    return
+  endif
   call clap#impl#refresh_matches_count(string(decoded.total))
   call g:clap.display.set_lines(decoded.lines)
   call clap#impl#add_highlight_for_fuzzy_indices(decoded.indices)
+  call clap#sign#reset_to_first_line()
 endfunction
 
 if has('nvim')

--- a/autoload/clap/spinner.vim
+++ b/autoload/clap/spinner.vim
@@ -17,7 +17,7 @@ function! s:compose_prompt() abort
   let l:prompt = s:prompt_format
 
   let l:spinner = s:spinner
-  let l:provider_id = g:clap.provider.id
+  let l:provider_id = get(g:, 'clap_forerunner_status_sign', '').g:clap.provider.id
 
   " Replace special markers with certain information.
   " \=l:variable is used to avoid escaping issues.
@@ -36,6 +36,10 @@ else
     call popup_settext(g:clap_spinner_winid, s:compose_prompt())
   endfunction
 endif
+
+function! clap#spinner#refresh() abort
+  call s:set_spinner()
+endfunction
 
 function! clap#spinner#get() abort
   return s:compose_prompt()

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -407,6 +407,15 @@ g:clap_popup_input_delay                              *g:clap_popup_input_delay*
   This option is only meaningful for Vim, NeoVim does not have this delay.
 
 
+g:clap_maple_delay                                          *g:clap_maple_delay*
+
+  Type: |Number|
+  Default: `100`
+
+  This variable controls the milliseconds delay after which `maple` will be
+  run in case of you have 1 million items.
+
+
 g:clap_popup_cursor_shape                            *g:clap_popup_cursor_shape*
 
   Type: |String|
@@ -422,6 +431,24 @@ g:clap_on_move_delay                                      *g:clap_on_move_delay*
 
   This variable controls the milliseconds delay after which the `on_move` of
   provider will be run when you navigate the result list.
+
+
+g:clap_forerunner_status_sign_done          *g:clap_forerunner_status_sign_done*
+
+  Type: |String|
+  Default: `'*'`
+
+  The async forerunner job is done in this vim-clap session. Everything should
+  be fast and deterministic even you have 1 million items as long as you
+  install the `maple` Rust extension.
+
+
+g:clap_forerunner_status_sign_running     *g:clap_forerunner_status_sign_running*
+
+  Type: `String`
+  Default: `'!'`
+
+  The async forerunner job is still running.
 
 
 g:clap_disable_optional_async                    *g:clap_disable_optional_async*


### PR DESCRIPTION
- Add the forerunner job status sign:
  - `!files`: the forerunner job is not finished yet. If you type something rightnow, the result is incomplete and uncertain.

  - `*files`: the forerunner job is done, now the responose of vim-clap should be fast and deterministic.
 
  The forerunner job is normally super fast and imperceptible unless you have 1 million items, in which case it may take seconds but Vim/NeoVim is still well responsive and you won't feel any typing lag.

- Add the delay for running maple.

![clap-fix-perf](https://user-images.githubusercontent.com/8850248/71542047-743ccc80-299c-11ea-84d1-340b668f98b0.gif)

I proposed serveral solutions for the perfornce improvement in #140. Although I have not tried all of them, the `maple` extension written in Rust already works very well. If you want to a performant vim-clap, please [install Rust](https://www.rust-lang.org/tools/install) and then run `:call clap#helper#build_all()` in Vim/NeoVim.


Close #140.



