### PR TITLE
Add <C-U> mapping to popup for clearing inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ See `:help clap-options` for more information.
 - [x] Use <kbd>Enter</kbd> to select the entry and exit.
 - [x] Use <kbd>Tab</kbd> to select multiple entries and open them using the quickfix window.(Need the provider has `sink*` support)
 - [x] Use <kbd>Ctrl-t</kbd> or <kbd>Ctrl-x</kbd>, <kbd>Ctrl-v</kbd> to open the selected entry in a new tab or a new split.
+- [x] Use <kbd>Ctrl-u</kbd> to clear inputs.
 
 See `:help clap-keybindings` for more information.
 

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -413,6 +413,15 @@ function! s:move_manager.ctrl_d(_winid) abort
   call s:apply_on_typed()
 endfunction
 
+function! s:move_manager.ctrl_u(_winid) abort
+  if empty(s:input)
+    return 1
+  endif
+  let s:input = ''
+  let s:cursor_idx = 0
+  call s:apply_on_typed()
+endfunction
+
 " noautocmd is neccessary in that too many plugins use redir, otherwise we'll
 " see E930: Cannot use :redir inside execute().
 let s:move_manager["\<C-J>"] = { winid -> win_execute(winid, 'noautocmd call clap#handler#navigate_result("down")') }
@@ -434,6 +443,7 @@ let s:move_manager["\<BS>"] = s:move_manager.bs
 let s:move_manager["\<C-H>"] = s:move_manager.bs
 let s:move_manager["\<C-D>"] = s:move_manager.ctrl_d
 let s:move_manager["\<C-G>"] = s:move_manager["\<Esc>"]
+let s:move_manager["\<C-U>"] = s:move_manager.ctrl_u
 
 function! s:define_open_action_filter() abort
   for k in keys(g:clap_open_action)

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -884,6 +884,8 @@ The form of `[++opt]` is `++{optname}={value}`, where {optname} is one of:
 
 - Use `Ctrl-t` or `Ctrl-x`, `Ctrl-v` to open the selected entry in a new tab
   or a new split.
+  
+- Use `Ctrl-u` to clear inputs.
 
 
 ===============================================================================


### PR DESCRIPTION
For neovim, `<C-u>` will clear inputs, but vim won't.
This PR adds `<C-u>` mapping to vim's popup for clearing inputs.