### PR TITLE
Fix printf too many args error if maple exec not found

### DIFF
--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -122,7 +122,11 @@ function! clap#maple#job_start(cmd) abort
   return
 endfunction
 
-let s:empty_filter_cmd = printf(clap#maple#filter_cmd_fmt(), '')
+if clap#maple#is_available()
+  let s:empty_filter_cmd = printf(clap#maple#filter_cmd_fmt(), '')
+else
+  let s:empty_filter_cmd = ''
+endif
 
 " Run the command via maple to minimalize the payload of this job.
 "


### PR DESCRIPTION
I was getting the error: "too many arguments to printf"
when the maple command was not available. This change works
for me.