### PR TITLE
Uppercase the NONE term attribute

### DIFF
--- a/syntax/clap_files.vim
+++ b/syntax/clap_files.vim
@@ -1,4 +1,4 @@
-hi TNormal ctermfg=249 ctermbg=None guifg=#b2b2b2 guibg=None
+hi TNormal ctermfg=249 ctermbg=NONE guifg=#b2b2b2 guibg=NONE
 execute 'syntax match ClapFile' '/^.*/' 'contains='.join(clap#icon#add_head_hl_groups(), ',')
 
 hi default link ClapFile TNormal


### PR DESCRIPTION
A capitalised term attribute (None) results in a `E254: Cannot allocate color None` error message when running `:Clap files`. This pull request fixes that issue by uppercasing the attribute.