### PR TITLE
Add working git_files based on git_diff_files and files providers

### DIFF
--- a/autoload/clap/provider/git_files.vim
+++ b/autoload/clap/provider/git_files.vim
@@ -6,14 +6,32 @@ set cpoptions&vim
 
 let s:git_files = {}
 
-if executable('git')
-  let s:git_files.source = 'git ls-files '.(has('win32') ? '' : ' | uniq')
-else
-  let s:git_files.source = ['git executable not found']
-endif
+function! s:git_files.source() abort
+  if !executable('git')
+    call clap#helper#echo_error('git executable not found')
+    return []
+  endif
 
-let s:git_files.sink = 'e'
+  let changed = systemlist('git ls-files '.(has('win32') ? '' : ' | uniq'))
+  if v:shell_error
+    call clap#helper#echo_error('Error occurs on calling `git ls-files`. Maybe you are not in a git repo?')
+    return []
+  else
+    return map(changed, 'split(v:val)[-1]')
+  endif
+endfunction
+
+function! s:git_files.sink(selected) abort
+  if has_key(g:clap, 'open_action')
+    execute g:clap.open_action a:selected
+  else
+    execute 'edit' a:selected
+  endif
+endfunction
+
 let s:git_files.enable_rooter = v:true
+let s:git_files.support_open_action = v:true
+let s:git_files.on_enter = { -> g:clap.display.setbufvar('&syntax', 'clap_files')}
 
 let g:clap#provider#git_files# = s:git_files
 


### PR DESCRIPTION
The `git_files` provider does not work for me; I always get an empty window with no results. As well, the existing provider does not support open actions, etc.

This PR replaces the existing `git_files` provider with one constructed from code from the existing `git_diff_files` and `files` providers (both of which do work for me). It adds better error reporting, syntax highlighting like the `files` provider,  and handling of open actions.

I looked into getting this provider to support icons, like the files provider, but wasn't sure how to get that working.