### PR TITLE
Use s:loaded_size instead of line_count of neovim as we don't clear the old content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ CHANGELOG
 
 - Do not apply the offset for matched items when using substring filter.
 - Git submodule detection.([#175](https://github.com/liuchengxu/vim-clap/pull/175))
+- Regression of using neovim job without maple.([#234](https://github.com/liuchengxu/vim-clap/pull/234))
 
 ## [0.4] 2019-01-06
 

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -26,16 +26,25 @@ function! s:set_or_append_lines(lines) abort
   endif
 endfunction
 
+function! s:put_raw_lines(lines) abort
+  if s:has_converter
+    let lines = map(a:lines, 's:Converter(v:val)')
+  else
+    let lines = a:lines
+  endif
+  call s:set_or_append_lines(lines)
+endfunction
+
 if has('nvim')
 
   if s:drop_cache
     " to_cache is a List.
     function! s:handle_cache(to_cache) abort
-      let s:droped_size += len(a:to_cache)
+      let s:dropped_size += len(a:to_cache)
     endfunction
 
     function! s:set_matches_count() abort
-      let matches_count = s:loaded_size + s:droped_size
+      let matches_count = s:loaded_size + s:dropped_size
       call clap#impl#refresh_matches_count(string(matches_count))
     endfunction
   else
@@ -66,18 +75,13 @@ if has('nvim')
       let s:preload_is_complete = v:true
       let s:loaded_size += len(to_append)
 
-      let to_handle = to_append
+      let to_put = to_append
     else
       let s:loaded_size += len(raw_output)
-      let to_handle = raw_output
+      let to_put = raw_output
     endif
 
-    " Converter
-    if s:has_converter
-      let to_handle = map(to_handle, 's:Converter(v:val)')
-    endif
-
-    call s:set_or_append_lines(to_handle)
+    call s:put_raw_lines(to_put)
   endfunction
 
   function! s:append_output(data) abort
@@ -132,11 +136,11 @@ else
 
   if s:drop_cache
     function! s:handle_cache(_line_to_cache) abort
-      let s:droped_size += 1
+      let s:dropped_size += 1
     endfunction
 
     function! s:matched_count_when_preload_is_complete() abort
-      return s:loaded_size + s:droped_size
+      return s:loaded_size + s:dropped_size
     endfunction
   else
     function! s:handle_cache(line_to_cache) abort
@@ -153,17 +157,10 @@ else
       return
     endif
 
-    let to_append = a:preload
+    call s:put_raw_lines(a:preload)
 
-    if s:has_converter
-      let to_append = map(to_append, 's:Converter(v:val)')
-    endif
-
-    call s:set_or_append_lines(to_append)
-
-    let s:loaded_size = len(to_append)
+    let s:loaded_size = len(a:preload)
     let s:preload_is_complete = v:true
-    let s:did_preload = v:true
   endfunction
 
   function! s:update_indicator() abort
@@ -274,22 +271,19 @@ function! s:prepare_job_start(cmd) abort
 
   let s:cache_size = 0
   let s:loaded_size = 0
+  let s:dropped_size = 0
   let g:clap.display.cache = []
   let s:preload_is_complete = v:false
-  let s:droped_size = 0
   let s:did_set_lines = v:false
 
   let s:cmd = a:cmd
 
   let s:vim_output = []
 
-  if has_key(g:clap.provider._(), 'converter')
-    let s:has_converter = v:true
+  let s:has_converter = has_key(g:clap.provider._(), 'converter')
+  if s:has_converter
     let s:Converter = g:clap.provider._().converter
-  else
-    let s:has_converter = v:false
   endif
-
 endfunction
 
 function! s:job_strart_with_delay() abort

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -17,22 +17,20 @@ function! s:jobstop() abort
   endif
 endfunction
 
-function! s:set_or_append_lines(lines) abort
-  if s:did_set_lines
-    call g:clap.display.append_lines(a:lines)
-  else
-    call g:clap.display.set_lines(a:lines)
-    let s:did_set_lines = v:true
-  endif
-endfunction
-
 function! s:put_raw_lines(lines) abort
   if s:has_converter
     let lines = map(a:lines, 's:Converter(v:val)')
   else
     let lines = a:lines
   endif
-  call s:set_or_append_lines(lines)
+
+  " Set or append lines
+  if s:did_set_lines
+    call g:clap.display.append_lines(lines)
+  else
+    call g:clap.display.set_lines(lines)
+    let s:did_set_lines = v:true
+  endif
 endfunction
 
 if has('nvim')

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -56,8 +56,7 @@ if has('nvim')
     " Append the minimum raw_output, the rest goes to the cache.
     if len(raw_output) + s:loaded_size >= g:clap.display.preload_capacity
       " Here are dragons!
-      let line_count = g:clap.display.line_count()
-      let start = g:clap.display.preload_capacity - line_count
+      let start = g:clap.display.preload_capacity - s:loaded_size
       let to_append = raw_output[:start-1]
       let to_cache = raw_output[start :]
 


### PR DESCRIPTION

Close #234