### PR TITLE
Add help tags provider

### DIFF
--- a/autoload/clap/cache.vim
+++ b/autoload/clap/cache.vim
@@ -1,0 +1,44 @@
+" Author: Mark Wu <markplace@gmail.com>
+" Description: Cache API for clap.
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+let s:path_separator = has('win32') ? '\' : '/'
+let s:clap_cache_directory = get(g:, 'clap_cache_directory', '')
+
+function! clap#cache#directory() abort
+  if empty(s:clap_cache_directory)
+    if has('nvim')
+      let user_cache = stdpath('cache')
+    elseif exists('$XDG_CACHE_HOME')
+      let user_cache = $XDG_CACHE_HOME
+    else
+      let user_cache = $HOME . s:path_separator . '.cache'
+    endif
+    let s:clap_cache_directory = user_cache . s:path_separator . 'clap'
+  endif
+
+  if !isdirectory(s:clap_cache_directory)
+    call mkdir(s:clap_cache_directory, 'p')
+  endif
+
+  return s:clap_cache_directory
+endf
+
+function! clap#cache#location_for(provider_id, fname) abort
+  if empty(a:provider_id)
+    call clap#helper#echo_error('provider_id cannnot be empty.')
+  endif
+
+  let provider_cache_directory = clap#cache#directory() . s:path_separator . a:provider_id
+
+  if !isdirectory(provider_cache_directory)
+    call mkdir(provider_cache_directory, 'p')
+  endif
+
+  return provider_cache_directory . s:path_separator . a:fname
+endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -1,24 +1,25 @@
 " Author: Mark Wu <markplace@gmail.com>
-" Description: List the help tags.
+" Description: List the help tags, ported from https://github.com/zeero/vim-ctrlp-help
 
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-" Help tags support, ported from https://github.com/zeero/vim-ctrlp-help
-let s:help_tags_filecache = get(g:, 'clap_provider_help_tags_cache', fnamemodify($MYVIMRC, ':p:h') . '/clap_provider_help_tags_cache')
-let s:help_tags_memcache = []
+let s:help_tags_memory_cache = []
 
 function! s:help_tags_source() abort
-  if empty(s:help_tags_memcache)
-    if getftime(s:help_tags_filecache) > max(map(s:get_tags_files(), 'getftime(v:val)'))
-      let s:help_tags_memcache = readfile(s:help_tags_filecache)
+  let help_tags_cache_file = clap#cache#location_for('help_tags', 'help_tags.txt')
+  if empty(s:help_tags_memory_cache)
+    if getftime(help_tags_cache_file) > max(map(s:get_tags_files(), 'getftime(v:val)'))
+      if filereadable(help_tags_cache_file)
+        let s:help_tags_memory_cache = readfile(help_tags_cache_file)
+      endif
     else
-      let s:help_tags_memcache = s:get_tags_list()
-      silent! call writefile(s:help_tags_memcache, s:help_tags_filecache)
+      let s:help_tags_memory_cache = s:get_tags_list()
+      silent! call writefile(s:help_tags_memory_cache, help_tags_cache_file)
     endif
   endif
 
-  return s:help_tags_memcache
+  return s:help_tags_memory_cache
 endfunction
 
 function! s:get_tags_list() abort

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -1,0 +1,66 @@
+" Author: Mark Wu <markplace@gmail.com>
+" Description: List the help tags.
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+" Help tags support, ported from https://github.com/zeero/vim-ctrlp-help
+let s:help_tags_filecache = get(g:, 'clap_provider_help_tags_cache', fnamemodify($MYVIMRC, ':p:h') . '/clap_provider_help_tags_cache')
+let s:help_tags_memcache = []
+
+function! s:help_tags_source() abort
+  if empty(s:help_tags_memcache)
+    if getftime(s:help_tags_filecache) > max(map(s:get_tags_files(), 'getftime(v:val)'))
+      let s:help_tags_memcache = readfile(s:help_tags_filecache)
+    else
+      let s:help_tags_memcache = s:get_tags_list()
+      silent! call writefile(s:help_tags_memcache, s:help_tags_filecache)
+    endif
+  endif
+
+  return s:help_tags_memcache
+endfunction
+
+function! s:get_tags_list() abort
+  let tagsfiles = s:get_tags_files()
+
+  let input_dict = {}
+  for tagsfile in tagsfiles
+    for line in readfile(tagsfile)
+      let items = split(line, "\t")
+      let tag_subject = items[0]
+      if !has_key(input_dict, tag_subject)
+        let input_dict[tag_subject] = printf("%-60s\t%s", tag_subject, items[1])
+      endif
+    endfor
+  endfor
+  let input = sort(values(input_dict))
+
+  return input
+endfunction
+
+function! s:get_tags_files() abort
+  let tagspaths = map(filter(split(&helplang, ','), 'v:val !=? "en"'), '"/doc/tags-".v:val')
+  call add(tagspaths, '/doc/tags')
+
+  let tagsfiles = []
+  for tagspath in tagspaths
+    call extend(tagsfiles, filter(map(split(&runtimepath, ','), 'v:val . tagspath'), 'filereadable(v:val)'))
+  endfor
+
+  return tagsfiles
+endfunction
+
+function! s:help_tags_sink(line) abort
+  let tag = get(split(a:line, "\t"), 0)
+  execute 'help' tag
+endfunction
+
+let s:help_tags = {}
+let s:help_tags.sink = function('s:help_tags_sink')
+let s:help_tags.source = function('s:help_tags_source')
+
+let g:clap#provider#help_tags# = s:help_tags
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -213,6 +213,25 @@ g:clap_provider_alias                                    *g:clap_provider_alias*
   provider name.
 
 
+g:clap_cache_directory                                  *g:clap_cache_directory*
+
+  Type: |String|
+  Default: `Undefined`
+
+  This variable controls the cache directory of clap. In default, clap will set
+  cache directory according to the following order:
+
+  1. If has('nvim'), the default cache directory is `stdpath('cache')/clap`
+  2. If has `$XDG_CACHE_HOME`, the default cache directory is `$XDG_CACHE_HOME/clap`
+  3. If not all above, the default cache directory is `$HOME/.cache/clap`
+
+  If you want to change it to your cache directory, just set this variable. For
+  example:
+>
+  let g:clap_cache_directory = $HOME . '/.vim/cache/clap'
+<
+
+
 g:clap_layout                                                    *g:clap_layout*
 
   Type: |Dict|

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -145,6 +145,10 @@ to work everywhere out of the box, with fast response.
                          use `Clap grep ..` to grep from the parent directory.
 
 
+                                                     *:Clap-help_tags*
+:Clap help_tags          List the help tags.
+
+
                                                       *:Clap-history*
 :Clap history            List the open buffers and |v:oldfiles|.
 


### PR DESCRIPTION
Hi @liuchengxu,

I add a provider to list help tags.

I implement cache for better performance, but it seems no file cache folder in Clap, therefore, I use `fnamemodify($MYVIMRC, ':p:h')` as my default cache folder.

If you have better place, just let me know.

And, I have no idea how to implement preview,  so, no preview at this moment.