### PR TITLE
Skip the job processing if current input is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ CHANGELOG
 
 - Refine `:Clap debug` and require it in the bug report. ([#241](https://github.com/liuchengxu/vim-clap/pull/241))
 
+### Fixed
+
+- Wrong async threshold in impl.vim.(https://github.com/liuchengxu/vim-clap/pull/248#issuecomment-576108100)
+
 ## [0.5] 2019-01-15
 
 ### Added

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -142,4 +142,4 @@ let g:clap_provider_quick_open = {
 
 #### How to add the preview support for my provider?
 
-Use `on_moved()`, ensure it always runs fast.
+Use `on_move()` and `g:clap.preview.show([lines])`, ensure it always runs fast.

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -140,6 +140,14 @@ function! s:unlet_vars(vars) abort
   endfor
 endfunction
 
+function! s:remove_provider_tmp_vars(vars) abort
+  for var in a:vars
+    if has_key(g:clap.provider, var)
+      call remove(g:clap.provider, var)
+    endif
+  endfor
+endfunction
+
 function! clap#_exit() abort
   call g:clap.provider.jobstop()
   call clap#forerunner#stop()
@@ -157,13 +165,11 @@ function! clap#_exit() abort
   call g:clap.input.clear()
   call g:clap.display.clear()
 
-  if has_key(g:clap.provider, 'args')
-    call remove(g:clap.provider, 'args')
-  endif
-
-  if has_key(g:clap.provider, 'source_tempfile')
-    call remove(g:clap.provider, 'source_tempfile')
-  endif
+  call s:remove_provider_tmp_vars([
+        \ 'args',
+        \ 'source_tempfile',
+        \ 'should_switch_to_async',
+        \ ])
 
   call s:unlet_vars([
         \ 'g:__clap_fuzzy_matched_indices',

--- a/autoload/clap/debugging.vim
+++ b/autoload/clap/debugging.vim
@@ -46,8 +46,8 @@ function! clap#debugging#info() abort
   echohl Type   | echo '         has +python3: ' | echohl NONE
   echohl Normal | echon has('python3')           | echohl NONE
 
-  echohl Type   | echo '         has py dylib: '   | echohl NONE
-  echohl Normal | echon clap#filter#has_rust_ext() | echohl NONE
+  echohl Type   | echo '         has py dylib: '            | echohl NONE
+  echohl Normal | echon clap#filter#has_py_dynamic_module() | echohl NONE
 
   echohl Type   | echo '     Current FileType: ' | echohl NONE
   echohl Normal | echon &filetype                | echohl NONE

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -248,7 +248,7 @@ function! s:on_exit_common() abort
   call clap#spinner#set_idle()
   if exists('g:__clap_maple_fuzzy_matched')
     let hl_lines = g:__clap_maple_fuzzy_matched[:g:clap.display.line_count()-1]
-    call clap#impl#add_highlight_for_fuzzy_indices(hl_lines)
+    call clap#highlight#add_fuzzy_async(hl_lines)
   endif
 endfunction
 

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -124,6 +124,7 @@ function! s:fallback_filter(query, candidates) abort
 endfunction
 
 let s:can_use_python = v:false
+let s:has_py_dynamic_module = v:false
 
 if s:py_exe !=# v:null
 
@@ -143,13 +144,13 @@ if s:py_exe !=# v:null
       execute s:pyfile s:plugin_root_dir.s:SETUP_PY
     endif
 
-    let s:has_rust_ext = filereadable(s:plugin_root_dir.s:LIB)
+    let s:has_py_dynamic_module = filereadable(s:plugin_root_dir.s:LIB)
 
     " For test only
     if get(g:, 'clap_use_pure_python', 0)
       let s:py_fn = 'clap_fzy_py'
     else
-      let s:py_fn = s:has_rust_ext ? 'clap_fzy_rs' : 'clap_fzy_py'
+      let s:py_fn = s:has_py_dynamic_module ? 'clap_fzy_rs' : 'clap_fzy_py'
     endif
 
     execute s:py_exe 'from clap.fzy import' s:py_fn
@@ -169,13 +170,13 @@ if s:py_exe !=# v:null
   endtry
 endif
 
-function! clap#filter#has_rust_ext() abort
-  return get(s:, 'has_rust_ext', v:false)
+function! clap#filter#has_py_dynamic_module() abort
+  return get(s:, 'has_py_dynamic_module', v:false)
 endfunction
 
 if exists('g:clap_builtin_fuzzy_filter_threshold')
   let s:builtin_filter_capacity = g:clap_builtin_fuzzy_filter_threshold
-elseif clap#filter#has_rust_ext()
+elseif s:has_py_dynamic_module
   let s:builtin_filter_capacity = 100000
 else
   let s:builtin_filter_capacity = 10000

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -47,7 +47,7 @@ else
 endif
 
 function! clap#filter#using_maple() abort
-  return s:cur_filter ==# 'maple'
+  return s:cur_ext_filter ==# 'maple'
 endfunction
 
 function! s:pattern_builder._force_case() abort
@@ -97,20 +97,20 @@ endfunction
 
 function! clap#filter#get_external_cmd_or_default() abort
   if has_key(g:clap.context, 'externalfilter')
-    let s:cur_filter = g:clap.context.externalfilter
+    let s:cur_ext_filter = g:clap.context.externalfilter
   elseif has_key(g:clap.context, 'ef')
-    let s:cur_filter = g:clap.context.ef
+    let s:cur_ext_filter = g:clap.context.ef
   elseif s:default_ext_filter is v:null
     call g:clap.abort('No external filter available')
     return
   else
-    let s:cur_filter = s:default_ext_filter
+    let s:cur_ext_filter = s:default_ext_filter
   endif
-  if s:cur_filter ==# 'maple'
+  if s:cur_ext_filter ==# 'maple'
     let g:__clap_maple_fuzzy_matched = []
     let Provider = g:clap.provider._()
   endif
-  return printf(s:ext_cmd[s:cur_filter], g:clap.input.get())
+  return printf(s:ext_cmd[s:cur_ext_filter], g:clap.input.get())
 endfunction
 
 function! s:filter(line, pattern) abort

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -47,7 +47,7 @@ else
 endif
 
 function! clap#filter#using_maple() abort
-  return s:ext_filter ==# 'maple'
+  return s:cur_filter ==# 'maple'
 endfunction
 
 function! s:pattern_builder._force_case() abort
@@ -97,20 +97,20 @@ endfunction
 
 function! clap#filter#get_external_cmd_or_default() abort
   if has_key(g:clap.context, 'externalfilter')
-    let s:ext_filter = g:clap.context.externalfilter
+    let s:cur_filter = g:clap.context.externalfilter
   elseif has_key(g:clap.context, 'ef')
-    let s:ext_filter = g:clap.context.ef
+    let s:cur_filter = g:clap.context.ef
   elseif s:default_ext_filter is v:null
     call g:clap.abort('No external filter available')
     return
   else
-    let s:ext_filter = s:default_ext_filter
+    let s:cur_filter = s:default_ext_filter
   endif
-  if s:ext_filter ==# 'maple'
+  if s:cur_filter ==# 'maple'
     let g:__clap_maple_fuzzy_matched = []
     let Provider = g:clap.provider._()
   endif
-  return printf(s:ext_cmd[s:ext_filter], g:clap.input.get())
+  return printf(s:ext_cmd[s:cur_filter], g:clap.input.get())
 endfunction
 
 function! s:filter(line, pattern) abort

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -1,5 +1,5 @@
 " Author: liuchengxu <xuliuchengxlc@gmail.com>
-" Description: Filter out the candidate lines given input.
+" Description: Filter out the candidate lines synchorously given the input.
 
 let s:save_cpo = &cpoptions
 set cpoptions&vim
@@ -171,6 +171,22 @@ endif
 
 function! clap#filter#has_rust_ext() abort
   return get(s:, 'has_rust_ext', v:false)
+endfunction
+
+if exists('g:clap_builtin_fuzzy_filter_threshold')
+  let s:builtin_filter_capacity = g:clap_builtin_fuzzy_filter_threshold
+elseif clap#filter#has_rust_ext()
+  let s:builtin_filter_capacity = 100000
+else
+  let s:builtin_filter_capacity = 10000
+endif
+
+function! clap#filter#beyond_capacity(size) abort
+  return a:size > s:builtin_filter_capacity
+endfunction
+
+function! clap#filter#capacity() abort
+  return s:builtin_filter_capacity
 endfunction
 
 if s:can_use_python

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -171,7 +171,7 @@ if s:py_exe !=# v:null
 endif
 
 function! clap#filter#has_py_dynamic_module() abort
-  return get(s:, 'has_py_dynamic_module', v:false)
+  return s:has_py_dynamic_module
 endfunction
 
 if exists('g:clap_builtin_fuzzy_filter_threshold')

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -6,14 +6,6 @@ set cpoptions&vim
 
 let s:job_id = -1
 
-if exists('g:clap_builtin_fuzzy_filter_threshold')
-  let s:builtin_fuzzy_filter_threshold = g:clap_builtin_fuzzy_filter_threshold
-elseif clap#filter#has_rust_ext()
-  let s:builtin_fuzzy_filter_threshold = 100000
-else
-  let s:builtin_fuzzy_filter_threshold = 10000
-endif
-
 function! s:on_complete_common(lines, initial_size) abort
   if empty(g:clap.input.get())
     call g:clap.display.set_lines_lazy(a:lines)
@@ -34,7 +26,7 @@ function! s:on_complete() abort
 
   " If the total results is not huge we could keep them in the memory
   " and use the built-in fzy impl later.
-  if chunks_size < s:builtin_fuzzy_filter_threshold
+  if !clap#filter#beyond_capacity(chunks_size)
     " g:__clap_forerunner_result is sort of a cache here.
     " If we already have g:__clap_forerunner_result and you
     " just created a new file outside the vim, this new file maybe not recongnized.
@@ -141,7 +133,7 @@ if clap#maple#is_available()
           \ s:empty_filter_cmd,
           \ a:cmd,
           \ cmd_dir,
-          \ s:builtin_fuzzy_filter_threshold,
+          \ clap#filter#capacity(),
           \ )
 
     return clap#maple#try_enable_icon(cmd)

--- a/autoload/clap/highlight.vim
+++ b/autoload/clap/highlight.vim
@@ -4,8 +4,8 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history']
 let s:related_maple_providers = ['files', 'git_files']
+let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history']
 
 " The icon can interfer the matched indices of fuzzy filter, but not the
 " substring filter.
@@ -63,6 +63,7 @@ if has('nvim')
     call g:clap.input.goto_win()
   endfunction
 
+  " This is same with g:clap.display.clear_highlight()
   function! clap#highlight#clear() abort
     call g:clap.display.goto_win()
     call g:clap.display.matchdelete()

--- a/autoload/clap/highlight.vim
+++ b/autoload/clap/highlight.vim
@@ -1,0 +1,105 @@
+" Author: liuchengxu <xuliuchengxlc@gmail.com>
+" Description: Functions for highlighting the fuzzy matched items.
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history']
+let s:related_maple_providers = ['files', 'git_files']
+
+" The icon can interfer the matched indices of fuzzy filter, but not the
+" substring filter.
+function! s:should_check_offset() abort
+  return g:clap_enable_icon && stridx(g:clap.input.get(), ' ') == -1
+endfunction
+
+function! s:builtin_fuzzy_idx_offset() abort
+  if s:should_check_offset()
+        \ && index(s:related_builtin_providers, g:clap.provider.id) > -1
+      return 2
+  else
+    return 0
+  endif
+endfunction
+
+function! s:maple_fuzzy_idx_offset() abort
+  if s:should_check_offset()
+        \ && index(s:related_maple_providers, g:clap.provider.id) > -1
+      return 4
+  else
+    return 0
+  endif
+endfunction
+
+if has('nvim')
+  function! s:apply_add_highlight(hl_lines, offset) abort
+    " Currently neovim does not have win_execute()
+    " and the highlight added by nvim_buf_add_highlight()
+    " can be overrided by the sign's highlight.
+    "
+    " Once the default highlight priority of nvim_buf_add_highlight() is
+    " higher, we could use the same impl with vim's s:apply_highlight().
+
+    call g:clap.display.goto_win()
+    " We should not use clearmatches() here.
+    call g:clap.display.matchdelete()
+
+    let w:clap_match_ids = []
+
+    let lnum = 0
+    for indices in a:hl_lines
+      let group_idx = 1
+      for idx in indices
+        if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
+          call add(w:clap_match_ids, clap#util#add_match_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx))
+          let group_idx += 1
+        else
+          call add(w:clap_match_ids, clap#util#add_match_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group))
+        endif
+      endfor
+      let lnum += 1
+    endfor
+
+    call g:clap.input.goto_win()
+  endfunction
+else
+  function! s:apply_add_highlight(hl_lines, offset) abort
+    " We do not have to clear the previous matches like neovim
+    " as the previous lines have been deleted, and the associated text_props have also been removed.
+    let lnum = 0
+    for indices in a:hl_lines
+      let group_idx = 1
+      for idx in indices
+        if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
+          call clap#util#add_highlight_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx)
+          let group_idx += 1
+        else
+          call clap#util#add_highlight_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group)
+        endif
+      endfor
+      let lnum += 1
+    endfor
+  endfunction
+endif
+
+" Used by the built-in sync filter.
+function! clap#highlight#add_fuzzy_sync() abort
+  " Due the cache strategy, g:__clap_fuzzy_matched_indices may be oversize
+  " than the actual display buffer, the rest highlight indices of g:__clap_fuzzy_matched_indices
+  " belong to the cached lines.
+  "
+  " TODO: also add highlights for the cached lines?
+  let hl_lines = g:__clap_fuzzy_matched_indices[:g:clap.display.line_count()-1]
+  let offset = s:builtin_fuzzy_idx_offset()
+
+  call s:apply_add_highlight(hl_lines, offset)
+endfunction
+
+" Used by the async job.
+function! clap#highlight#add_fuzzy_async(hl_lines) abort
+  let offset = s:maple_fuzzy_idx_offset()
+  call s:apply_add_highlight(a:hl_lines, offset)
+endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/highlight.vim
+++ b/autoload/clap/highlight.vim
@@ -62,6 +62,13 @@ if has('nvim')
 
     call g:clap.input.goto_win()
   endfunction
+
+  function! clap#highlight#clear() abort
+    call g:clap.display.goto_win()
+    call g:clap.display.matchdelete()
+    call g:clap.input.goto_win()
+  endfunction
+
 else
   function! s:apply_add_highlight(hl_lines, offset) abort
     " We do not have to clear the previous matches like neovim
@@ -79,6 +86,9 @@ else
       endfor
       let lnum += 1
     endfor
+  endfunction
+
+  function! clap#highlight#clear() abort
   endfunction
 endif
 

--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -172,12 +172,10 @@ function! s:detect_should_switch_to_async() abort
     let s:cur_source = Source()
   endif
 
-  if !exists('g:__clap_raw_source')
-    let g:__clap_raw_source = s:cur_source
-    let g:__clap_initial_source_size = len(g:__clap_raw_source)
-  endif
+  let g:__clap_raw_source = s:cur_source
+  let g:__clap_initial_source_size = len(g:__clap_raw_source)
 
-  if clap#filter#beyond_capacity(len(s:cur_source))
+  if clap#filter#beyond_capacity(g:__clap_initial_source_size)
     return v:true
   endif
 

--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -5,7 +5,7 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 let s:is_nvim = has('nvim')
-let s:async_threshold = 1
+let s:async_threshold = 10000
 
 " =======================================
 " sync implementation
@@ -107,108 +107,11 @@ function! s:on_typed_sync_impl() abort
 
   if !g:__clap_has_no_matches
     if exists('g:__clap_fuzzy_matched_indices')
-      call s:add_highlight_for_fuzzy_matched()
+      call clap#highlight#add_fuzzy_sync()
     else
       call g:clap.display.add_highlight()
     endif
   endif
-endfunction
-
-if s:is_nvim
-  function! s:apply_add_highlight(hl_lines, offset) abort
-    " Currently neovim does not have win_execute()
-    " and the highlight added by nvim_buf_add_highlight()
-    " can be overrided by the sign's highlight.
-    "
-    " Once the default highlight priority of nvim_buf_add_highlight() is
-    " higher, we could use the same impl with vim's s:apply_highlight().
-
-    call g:clap.display.goto_win()
-    " We should not use clearmatches() here.
-    call g:clap.display.matchdelete()
-
-    let w:clap_match_ids = []
-
-    let lnum = 0
-    for indices in a:hl_lines
-      let group_idx = 1
-      for idx in indices
-        if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
-          call add(w:clap_match_ids, clap#util#add_match_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx))
-          let group_idx += 1
-        else
-          call add(w:clap_match_ids, clap#util#add_match_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group))
-        endif
-      endfor
-      let lnum += 1
-    endfor
-
-    call g:clap.input.goto_win()
-  endfunction
-else
-  function! s:apply_add_highlight(hl_lines, offset) abort
-    " We do not have to clear the previous matches like neovim
-    " as the previous lines have been deleted, and the associated text_props have also been removed.
-    let lnum = 0
-    for indices in a:hl_lines
-      let group_idx = 1
-      for idx in indices
-        if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
-          call clap#util#add_highlight_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx)
-          let group_idx += 1
-        else
-          call clap#util#add_highlight_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group)
-        endif
-      endfor
-      let lnum += 1
-    endfor
-  endfunction
-endif
-
-" The icon can interfer the matched indices of fuzzy filter, but not the
-" substring filter.
-function! s:should_check_offset() abort
-  return g:clap_enable_icon && stridx(g:clap.input.get(), ' ') == -1
-endfunction
-
-let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history']
-let s:related_maple_providers = ['files', 'git_files']
-
-function! s:builtin_fuzzy_idx_offset() abort
-  if s:should_check_offset()
-        \ && index(s:related_builtin_providers, g:clap.provider.id) > -1
-      return 2
-  else
-    return 0
-  endif
-endfunction
-
-" Used by the built-in sync filter.
-function! s:add_highlight_for_fuzzy_matched() abort
-  " Due the cache strategy, g:__clap_fuzzy_matched_indices may be oversize
-  " than the actual display buffer, the rest highlight indices of g:__clap_fuzzy_matched_indices
-  " belong to the cached lines.
-  "
-  " TODO: also add highlights for the cached lines?
-  let hl_lines = g:__clap_fuzzy_matched_indices[:g:clap.display.line_count()-1]
-  let offset = s:builtin_fuzzy_idx_offset()
-
-  call s:apply_add_highlight(hl_lines, offset)
-endfunction
-
-function! s:maple_fuzzy_idx_offset() abort
-  if s:should_check_offset()
-        \ && index(s:related_maple_providers, g:clap.provider.id) > -1
-      return 4
-  else
-    return 0
-  endif
-endfunction
-
-" Used by the async job.
-function! clap#impl#add_highlight_for_fuzzy_indices(hl_lines) abort
-  let offset = s:maple_fuzzy_idx_offset()
-  call s:apply_add_highlight(a:hl_lines, offset)
 endfunction
 
 function! clap#impl#on_empty_input() abort

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -93,7 +93,7 @@ function! s:on_complete() abort
   endif
 
   if has_key(decoded, 'indices')
-    call clap#impl#add_highlight_for_fuzzy_indices(decoded.indices)
+    call clap#highlight#add_fuzzy_async(decoded.indices)
   endif
 
   call clap#sign#reset_to_first_line()

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -53,6 +53,7 @@ function! s:on_complete() abort
 
   call clap#spinner#set_idle()
 
+  " Skip the job processing if use already clears the input at the moment.
   if empty(g:clap.input.get())
     return
   endif

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -53,6 +53,10 @@ function! s:on_complete() abort
 
   call clap#spinner#set_idle()
 
+  if empty(g:clap.input.get())
+    return
+  endif
+
   if empty(s:chunks)
     return
   endif


### PR DESCRIPTION
- When people clear the input, the previous job could be still unfinished. https://github.com/liuchengxu/vim-clap/pull/248#issuecomment-575909963
- Use the capacity of filter globally.
- Split out highlight.vim.