### PR TITLE
Impl maple helptags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ CHANGELOG
 
 ### Added
 
+- Add new provider `:Clap help_tags` by @markwu. ([#248](https://github.com/liuchengxu/vim-clap/pull/248))
 - Add `maple version` to get the detailed maple info and include it in `:Clap debug`.([#262](https://github.com/liuchengxu/vim-clap/pull/262))
 - Add `g:clap_forerunner_status_sign` and deprecate `g:clap_forerunner_status_sign_done` and `g:clap_forerunner_status_sign_running`.
 - Support skim as the external filter, ref https://github.com/lotabout/skim/issues/225 . ([#269](https://github.com/liuchengxu/vim-clap/pull/269))

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Command                                | List                                   
 `Clap git_diff_files`                  | Files managed by git and having uncommitted changes | **[git][git]**
 `Clap grep`**<sup>+</sup>**            | Grep on the fly                                     | **[rg][rg]**
 `Clap history`                         | Open buffers and `v:oldfiles`                       | _none_
+`Clap help_tags`                       | Help tags                                           | _none_
 `Clap jumps`                           | Jumps                                               | _none_
 `Clap lines`                           | Lines in the loaded buffers                         | _none_
 `Clap marks`                           | Marks                                               | _none_

--- a/autoload/clap/cache.vim
+++ b/autoload/clap/cache.vim
@@ -34,6 +34,7 @@ endf
 function! clap#cache#location_for(provider_id, fname) abort
   if empty(a:provider_id)
     call clap#helper#echo_error('provider_id can not be empty.')
+    return v:null
   endif
 
   let provider_cache_directory = clap#cache#directory() . s:path_separator . a:provider_id

--- a/autoload/clap/cache.vim
+++ b/autoload/clap/cache.vim
@@ -5,20 +5,25 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 let s:path_separator = has('win32') ? '\' : '/'
-let s:clap_cache_directory = get(g:, 'clap_cache_directory', '')
+
+function! s:default_cache_dir() abort
+  if has('nvim')
+    let user_cache = stdpath('cache')
+  elseif exists('$XDG_CACHE_HOME')
+    let user_cache = $XDG_CACHE_HOME
+  else
+    let user_cache = $HOME . s:path_separator . '.cache'
+  endif
+  return user_cache . s:path_separator . 'clap'
+endfunction
+
+if exists('g:clap_cache_directory')
+  let s:clap_cache_directory = expand(g:clap_cache_directory)
+else
+  let s:clap_cache_directory = s:default_cache_dir()
+endif
 
 function! clap#cache#directory() abort
-  if empty(s:clap_cache_directory)
-    if has('nvim')
-      let user_cache = stdpath('cache')
-    elseif exists('$XDG_CACHE_HOME')
-      let user_cache = $XDG_CACHE_HOME
-    else
-      let user_cache = $HOME . s:path_separator . '.cache'
-    endif
-    let s:clap_cache_directory = user_cache . s:path_separator . 'clap'
-  endif
-
   if !isdirectory(s:clap_cache_directory)
     call mkdir(s:clap_cache_directory, 'p')
   endif
@@ -28,7 +33,7 @@ endf
 
 function! clap#cache#location_for(provider_id, fname) abort
   if empty(a:provider_id)
-    call clap#helper#echo_error('provider_id cannnot be empty.')
+    call clap#helper#echo_error('provider_id can not be empty.')
   endif
 
   let provider_cache_directory = clap#cache#directory() . s:path_separator . a:provider_id

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -8,8 +8,7 @@ function! s:get_doc_tags() abort
   return ['/doc/tags'] + map(filter(split(&helplang, ','), 'v:val !=? "en"'), '"/doc/tags-".v:val')
 endfunction
 
-if clap#maple#is_available()
-" if 0
+if clap#maple#is_available() && clap#filter#has_py_dynamic_module()
 
   function! s:help_tags_source() abort
     let tmp = tempname()

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -16,6 +16,15 @@ if clap#maple#is_available() && clap#filter#has_py_dynamic_module()
     return clap#maple#inject_bin('helptags '.tmp)
   endfunction
 
+  function! s:help_tags_sink(line) abort
+    let [tag, doc_fname] = split(a:line, "\t")
+    if doc_fname =~# '.txt$'
+      execute 'help' trim(tag).'@en'
+    else
+      execute 'help' tag
+    endif
+  endfunction
+
 else
 
   let s:help_tags_memory_cache = []
@@ -60,16 +69,12 @@ else
     endfor
     return tags_files
   endfunction
-endif
 
-function! s:help_tags_sink(line) abort
-  let [tag, doc_fname] = split(a:line, "\t")
-  if doc_fname =~# '.txt$'
-    execute 'help' trim(tag).'@en'
-  else
+  function! s:help_tags_sink(line) abort
+    let tag = get(split(a:line, "\t"), 0)
     execute 'help' tag
-  endif
-endfunction
+  endfunction
+endif
 
 let s:help_tags = {}
 let s:help_tags.sink = function('s:help_tags_sink')

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -63,8 +63,12 @@ else
 endif
 
 function! s:help_tags_sink(line) abort
-  let tag = get(split(a:line, "\t"), 0)
-  execute 'help' tag
+  let [tag, doc_fname] = split(a:line, "\t")
+  if doc_fname =~# '.txt$'
+    execute 'help' trim(tag).'@en'
+  else
+    execute 'help' tag
+  endif
 endfunction
 
 let s:help_tags = {}

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -4,53 +4,64 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:help_tags_memory_cache = []
+function! s:get_doc_tags() abort
+  return ['/doc/tags'] + map(filter(split(&helplang, ','), 'v:val !=? "en"'), '"/doc/tags-".v:val')
+endfunction
 
-function! s:help_tags_source() abort
-  let help_tags_cache_file = clap#cache#location_for('help_tags', 'help_tags.txt')
-  if empty(s:help_tags_memory_cache)
-    if getftime(help_tags_cache_file) > max(map(s:get_tags_files(), 'getftime(v:val)'))
-      if filereadable(help_tags_cache_file)
-        let s:help_tags_memory_cache = readfile(help_tags_cache_file)
+if clap#maple#is_available()
+" if 0
+
+  function! s:help_tags_source() abort
+    let tmp = tempname()
+    call writefile([join(s:get_doc_tags(), ','), &runtimepath], tmp)
+    return clap#maple#inject_bin('helptags '.tmp)
+  endfunction
+
+else
+
+  let s:help_tags_memory_cache = []
+
+  function! s:help_tags_source() abort
+    if empty(s:help_tags_memory_cache)
+      let help_tags_cache_file = clap#cache#location_for('help_tags', 'help_tags.txt')
+      if getftime(help_tags_cache_file) > max(map(s:get_tags_files(), 'getftime(v:val)'))
+        if filereadable(help_tags_cache_file)
+          let s:help_tags_memory_cache = readfile(help_tags_cache_file)
+        endif
+      else
+        let s:help_tags_memory_cache = s:get_tags_list()
+        silent! call writefile(s:help_tags_memory_cache, help_tags_cache_file)
       endif
-    else
-      let s:help_tags_memory_cache = s:get_tags_list()
-      silent! call writefile(s:help_tags_memory_cache, help_tags_cache_file)
     endif
-  endif
 
-  return s:help_tags_memory_cache
-endfunction
+    return s:help_tags_memory_cache
+  endfunction
 
-function! s:get_tags_list() abort
-  let tagsfiles = s:get_tags_files()
+  function! s:get_tags_list() abort
+    let tags_files = s:get_tags_files()
 
-  let input_dict = {}
-  for tagsfile in tagsfiles
-    for line in readfile(tagsfile)
-      let items = split(line, "\t")
-      let tag_subject = items[0]
-      if !has_key(input_dict, tag_subject)
-        let input_dict[tag_subject] = printf("%-60s\t%s", tag_subject, items[1])
-      endif
+    let tags_dict = {}
+    for tagsfile in tags_files
+      for line in readfile(tagsfile)
+        let items = split(line, "\t")
+        let tag_subject = items[0]
+        if !has_key(tags_dict, tag_subject)
+          let tags_dict[tag_subject] = printf("%-60s\t%s", tag_subject, items[1])
+        endif
+      endfor
     endfor
-  endfor
-  let input = sort(values(input_dict))
 
-  return input
-endfunction
+    return sort(values(tags_dict))
+  endfunction
 
-function! s:get_tags_files() abort
-  let tagspaths = map(filter(split(&helplang, ','), 'v:val !=? "en"'), '"/doc/tags-".v:val')
-  call add(tagspaths, '/doc/tags')
-
-  let tagsfiles = []
-  for tagspath in tagspaths
-    call extend(tagsfiles, filter(map(split(&runtimepath, ','), 'v:val . tagspath'), 'filereadable(v:val)'))
-  endfor
-
-  return tagsfiles
-endfunction
+  function! s:get_tags_files() abort
+    let tags_files = []
+    for tags_path in s:get_doc_tags()
+      call extend(tags_files, filter(map(split(&runtimepath, ','), 'v:val . tags_path'), 'filereadable(v:val)'))
+    endfor
+    return tags_files
+  endfunction
+endif
 
 function! s:help_tags_sink(line) abort
   let tag = get(split(a:line, "\t"), 0)

--- a/autoload/clap/provider/providers.vim
+++ b/autoload/clap/provider/providers.vim
@@ -7,7 +7,7 @@ set cpoptions&vim
 let s:providers = {}
 
 function! s:providers.sink(selected) abort
-  let provider = matchstr(a:selected, '^\(.*\)\ze:')
+  let provider = a:selected[: stridx(a:selected, ':') - 1]
   " a sink for "Clap providers" (dispatch to other builtin clap providers).
   call timer_start(0, {-> clap#_for(provider)})
 endfunction

--- a/doc/clap-support.txt
+++ b/doc/clap-support.txt
@@ -1,0 +1,148 @@
+===============================================================================
+Supported Providers & Tools                                    *clap-support*
+
+
+                                                    *:Clap-bcommits*
+:Clap bcommits           List git commits for the current buffer.
+                         Require `git`
+
+
+                                                    *:Clap-blines*
+:Clap blines             List Lines in the current buffer.
+
+
+                                                    *:Clap-buffers*
+:Clap buffers            List open buffers.
+
+
+                                                    *:Clap-colors*
+:Clap colors             List Colorschemes.
+                         Support preview.
+
+
+                                                    *:Clap-command*
+:Clap command            List Command.
+
+
+                                                    *:Clap-hist:*
+                                                    *:Clap-command_history*
+:Clap hist:              List Command history.
+:Clap command_history
+
+
+                                                    *:Clap-commits*
+:Clap commits            List Git commits.
+                         Require `git`
+
+                                                    *:Clap-files*
+:Clap files              List Files.
+                         Require `fd`/`rg`/`git`/`find`
+
+                         The order of default finder executable used
+                         for files is [ `fd`, `rg`, `git`, `find` ] .
+
+                         Use `++finder` to specify another finder
+                         executable for the files and pass the options
+                         after, e.g., `:Clap files ++finder=rg --files` means
+                         the actual command line used is `rg --files` .
+
+                         If you have `fd` installed, `:Clap files` is equivalent to
+                         `:Clap files ++finder=fd --type f` .
+
+                         For the `fd` and `rg` finder, you can pass
+                         `--hidden` to search the hidden files as well, i.e,
+                         `:Clap files --hidden` .
+
+                         The last argument can be a directory, i.e.,
+                         `Clap files [DIR]` to search files under a
+                         specific directory. By default clap will try to use
+                         the git base directory or `getcwd()` . For example,
+                         use `Clap files ..` to search files under the parent directory.
+
+
+                                                     *:Clap-filetypes*
+:Clap filetypes          List File types.
+
+
+                                                     *:Clap-gfiles*
+                                                     *:Clap-git_files*
+:Clap gfiles             List Files managed by git.
+:Clap git_files          Require `git`
+
+
+                                                     *:Clap-git_diff_files*
+:Clap git_diff_files     List Files managed by git and having uncommitted changes.
+                         Require `git`
+
+                                                     *:Clap-grep*
+:Clap grep               Grep on the fly.
+                         Require `rg`
+
+                         Use `Clap grep ++query=<cword>` to grep
+                         the word under cursor.
+
+                         Use `Clap grep ++opt=[OPTION]` to pass extra options
+                         from the command line which will be put after
+                         `g:clap_provider_grep_opts`, e.g.,
+                         `Clap grep ++opt=--no-ignore ++opt=--hidden` .
+
+                         The last argument can be a directory, i.e.,
+                         `Clap grep [DIR]` to start the grep job under a
+                         specific directory. By default clap will try to use
+                         the git base directory or `getcwd()` . For example,
+                         use `Clap grep ..` to grep from the parent directory.
+
+
+                                                     *:Clap-help_tags*
+:Clap help_tags          List the help tags.
+
+
+                                                      *:Clap-history*
+:Clap history            List the open buffers and |v:oldfiles|.
+
+
+                                                     *:Clap-jumps*
+:Clap jumps              List Jumps
+                         Support preview
+
+
+                                                     *:Clap-lines*
+:Clap lines              List the lines of the loaded buffers.
+
+
+                                                    *:Clap-quickfix*
+:Clap quickfix           List the entries of the quickfix list.
+
+
+                                                     *:Clap-loclist*
+:Clap loclist            List the entries of the location list.
+
+
+                                                     *:Clap-providers*
+:Clap providers          List the clap providers.
+
+                                                     *:Clap-marks*
+:Clap marks              List Marks
+                         Support preview
+
+
+                                                     *:Clap-registers*
+:Clap registers          List Registers
+
+
+                                                     *:Clap-tags*
+:Clap tags               List Tags in the current buffer
+                         Require `vista.vim`
+
+
+                                                     *:Clap-windows*
+:Clap windows            List Windows
+
+
+[fd]: https://github.com/sharkdp/fd
+[rg]: https://github.com/BurntSushi/ripgrep
+[git]: https://github.com/git/git
+[vista.vim]: https://github.com/liuchengxu/vista.vim
+
+===============================================================================
+vim:tw=78:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -15,6 +15,7 @@ CONTENTS                                                         *clap-contents*
   1. Introduction.........................|clap-introduction|
   2. Features.............................|clap-features|
   3. Supported Providers & Tools..........|clap-support|
+  4. Provider introduction ...............|clap-provider-intro|
   5. Global Options.......................|clap-options|
     5.1 Highlights........................|clap-highlights|
   6. Provider Options.....................|clap-provider-options|
@@ -51,150 +52,14 @@ to work everywhere out of the box, with fast response.
 
 
 ===============================================================================
-3. Supported Providers & Tools                                    *clap-support*
+3. Supported Providers & Tools                           *clap-builtin-providers*
 
+Checkout the builtin clap providers |clap-support| .
 
-                                                    *:Clap-bcommits*
-:Clap bcommits           List git commits for the current buffer.
-                         Require `git`
+===============================================================================
+4. Provider introduction                                    *clap-provider-intro*
 
-
-                                                    *:Clap-blines*
-:Clap blines             List Lines in the current buffer.
-
-
-                                                    *:Clap-buffers*
-:Clap buffers            List open buffers.
-
-
-                                                    *:Clap-colors*
-:Clap colors             List Colorschemes.
-                         Support preview.
-
-
-                                                    *:Clap-command*
-:Clap command            List Command.
-
-
-                                                    *:Clap-hist:*
-                                                    *:Clap-command_history*
-:Clap hist:              List Command history.
-:Clap command_history
-
-
-                                                    *:Clap-commits*
-:Clap commits            List Git commits.
-                         Require `git`
-
-                                                    *:Clap-files*
-:Clap files              List Files.
-                         Require `fd`/`rg`/`git`/`find`
-
-                         The order of default finder executable used
-                         for files is [ `fd`, `rg`, `git`, `find` ] .
-
-                         Use `++finder` to specify another finder
-                         executable for the files and pass the options
-                         after, e.g., `:Clap files ++finder=rg --files` means
-                         the actual command line used is `rg --files` .
-
-                         If you have `fd` installed, `:Clap files` is equivalent to
-                         `:Clap files ++finder=fd --type f` .
-
-                         For the `fd` and `rg` finder, you can pass
-                         `--hidden` to search the hidden files as well, i.e,
-                         `:Clap files --hidden` .
-
-                         The last argument can be a directory, i.e.,
-                         `Clap files [DIR]` to search files under a
-                         specific directory. By default clap will try to use
-                         the git base directory or `getcwd()` . For example,
-                         use `Clap files ..` to search files under the parent directory.
-
-
-                                                     *:Clap-filetypes*
-:Clap filetypes          List File types.
-
-
-                                                     *:Clap-gfiles*
-                                                     *:Clap-git_files*
-:Clap gfiles             List Files managed by git.
-:Clap git_files          Require `git`
-
-
-                                                     *:Clap-git_diff_files*
-:Clap git_diff_files     List Files managed by git and having uncommitted changes.
-                         Require `git`
-
-                                                     *:Clap-grep*
-:Clap grep               Grep on the fly.
-                         Require `rg`
-
-                         Use `Clap grep ++query=<cword>` to grep
-                         the word under cursor.
-
-                         Use `Clap grep ++opt=[OPTION]` to pass extra options
-                         from the command line which will be put after
-                         `g:clap_provider_grep_opts`, e.g.,
-                         `Clap grep ++opt=--no-ignore ++opt=--hidden` .
-
-                         The last argument can be a directory, i.e.,
-                         `Clap grep [DIR]` to start the grep job under a
-                         specific directory. By default clap will try to use
-                         the git base directory or `getcwd()` . For example,
-                         use `Clap grep ..` to grep from the parent directory.
-
-
-                                                     *:Clap-help_tags*
-:Clap help_tags          List the help tags.
-
-
-                                                      *:Clap-history*
-:Clap history            List the open buffers and |v:oldfiles|.
-
-
-                                                     *:Clap-jumps*
-:Clap jumps              List Jumps
-                         Support preview
-
-
-                                                     *:Clap-lines*
-:Clap lines              List the lines of the loaded buffers.
-
-
-                                                    *:Clap-quickfix*
-:Clap quickfix           List the entries of the quickfix list.
-
-
-                                                     *:Clap-loclist*
-:Clap loclist            List the entries of the location list.
-
-
-                                                     *:Clap-providers*
-:Clap providers          List the clap providers.
-
-                                                     *:Clap-marks*
-:Clap marks              List Marks
-                         Support preview
-
-
-                                                     *:Clap-registers*
-:Clap registers          List Registers
-
-
-                                                     *:Clap-tags*
-:Clap tags               List Tags in the current buffer
-                         Require `vista.vim`
-
-
-                                                     *:Clap-windows*
-:Clap windows            List Windows
-
-
-[fd]: https://github.com/sharkdp/fd
-[rg]: https://github.com/BurntSushi/ripgrep
-[git]: https://github.com/git/git
-[vista.vim]: https://github.com/liuchengxu/vista.vim
+Checkout |write-clap-provider| for the details.
 
 ===============================================================================
 5. Global Options                                                 *clap-options*
@@ -438,7 +303,7 @@ g:clap_search_box_border_style                  *g:clap_search_box_border_style*
 g:clap_default_external_filter                  *g:clap_default_external_filter*
 
   Type: |String| or |v:null|
-  Default: `'maple' | 'fzy' | 'fzf' | v:null`
+  Default: `'maple' | 'fzy' | 'fzf' | 'sk' | v:null`
 
   The default provider's async implementation is based on these external
   filter programs in the following order:
@@ -446,6 +311,7 @@ g:clap_default_external_filter                  *g:clap_default_external_filter*
   `maple` - actually using the algorithm of skim, with the highlight of matched indices.
   `fzy` - no highlight of matched indices.
   `fzf` - no highlight of matched indices.
+  `sk` - no highlight of matched indices.
 
 
 g:clap_prompt_format                             *g:clap_prompt_format*

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -218,18 +218,16 @@ g:clap_cache_directory                                  *g:clap_cache_directory*
   Type: |String|
   Default: `Undefined`
 
-  This variable controls the cache directory of clap. In default, clap will set
-  cache directory according to the following order:
+  This variable controls the cache directory of clap. By default, clap will set
+  the cache directory according to the following order:
 
-  1. If has('nvim'), the default cache directory is `stdpath('cache')/clap`
-  2. If has `$XDG_CACHE_HOME`, the default cache directory is `$XDG_CACHE_HOME/clap`
-  3. If not all above, the default cache directory is `$HOME/.cache/clap`
+  1. If has('nvim'), use `stdpath('cache')/clap`
+  2. If has `$XDG_CACHE_HOME`, use `$XDG_CACHE_HOME/clap`
+  3. Otherwise use `$HOME/.cache/clap`
 
-  If you want to change it to your cache directory, just set this variable. For
-  example:
+  Set another directory as the cache directory of clap:
 >
   let g:clap_cache_directory = $HOME . '/.vim/cache/clap'
-<
 
 
 g:clap_layout                                                    *g:clap_layout*

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -73,7 +73,7 @@ pub enum Cmd {
     #[structopt(name = "helptags")]
     Helptags {
         #[structopt(index = 1, short, long, parse(from_os_str))]
-        tags_info: PathBuf,
+        meta_info: PathBuf,
     },
 }
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -70,6 +70,11 @@ pub enum Cmd {
         #[structopt(long = "cmd-dir", parse(from_os_str))]
         cmd_dir: Option<PathBuf>,
     },
+    #[structopt(name = "helptags")]
+    Helptags {
+        #[structopt(index = 1, short, long, parse(from_os_str))]
+        tags_info: PathBuf,
+    },
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/cmd_impl.rs
+++ b/src/cmd_impl.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufRead};
 use std::path::{Path, PathBuf};
@@ -34,14 +35,13 @@ pub fn print_helptags(meta_path: &PathBuf) -> Result<()> {
                         dt
                     )
                 });
-                let mut seen = std::collections::HashMap::new();
+                let mut seen = HashMap::new();
                 let mut v: Vec<String> = Vec::new();
                 for tags_file in tags_files {
                     if let Ok(lines) = read_lines(tags_file) {
                         lines.for_each(|line| {
                             if let Ok(helptag) = line {
                                 v = helptag.split('\t').map(Into::into).collect();
-                                // println!("{}", format!("{:<60}\t{}", v[0], v[1]));
                                 if !seen.contains_key(&v[0]) {
                                     seen.insert(v[0].clone(), format!("{:<60}\t{}", v[0], v[1]));
                                 }
@@ -49,9 +49,9 @@ pub fn print_helptags(meta_path: &PathBuf) -> Result<()> {
                         });
                     }
                 }
-                // println!("see: {:?}", seen.values());
-                // println!("see: {:?}", seen.len());
-                for line in seen.values() {
+                let mut tag_lines = seen.values().collect::<Vec<_>>();
+                tag_lines.sort();
+                for line in tag_lines {
                     println!("{}", line);
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod cmd;
+mod cmd_impl;
 mod error;
 mod icon;
 
@@ -16,6 +17,7 @@ use serde_json::json;
 use structopt::StructOpt;
 
 use crate::cmd::{Algo, Cmd, Maple};
+use crate::cmd_impl::*;
 use crate::error::DummyError;
 use crate::icon::{prepend_grep_icon, prepend_icon, DEFAULT_ICONIZED};
 
@@ -335,6 +337,7 @@ impl Maple {
 
                 light_cmd.execute(&args)?;
             }
+            Cmd::Helptags { tags_info } => print_helptags(tags_info)?,
         }
         Ok(())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,7 +337,7 @@ impl Maple {
 
                 light_cmd.execute(&args)?;
             }
-            Cmd::Helptags { tags_info } => print_helptags(tags_info)?,
+            Cmd::Helptags { meta_info } => print_helptags(meta_info)?,
         }
         Ok(())
     }


### PR DESCRIPTION
Follow up of #248

Implement the helptags in maple and other various nits. The result of maple is more complete compared with the vimscript impl which differentiates the `hello.txt` and `hello.cnx`.