### PR TITLE
doc: Update the "Download the pre-built binaries"

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,7 +76,7 @@ Then use `:call clap#helper#build_python_dynamic_module()` to install the Python
 
 ## Download the prebuilt binary
 
-You can call `:call clap#helper#download_binary()` in Vim/NeoVim, or do it manually as follows.
+You can call `:call clap#installer#download_binary()` in Vim/NeoVim, or do it manually as follows.
 
 ### `maple`
 


### PR DESCRIPTION
Since `clap#helper#download_binary()` has been changed to `clap#installer#download_binary()`, "Install.md" also needs to be updated.