### PR TITLE
Support multibyte input for popup filter

### DIFF
--- a/autoload/clap/popup/move_manager.vim
+++ b/autoload/clap/popup/move_manager.vim
@@ -150,7 +150,7 @@ call s:define_open_action_filter()
 
 function! s:move_manager.printable(key) abort
   let s:input = s:strpart_input(0, s:cursor_idx).a:key.s:strpart_input(s:cursor_idx)
-  let s:cursor_idx += strchars(a:key, 1)
+  let s:cursor_idx = strchars(s:strpart_input(0, s:cursor_idx) . a:key, 1)
 
   " Always hold a delay before reacting actually.
   "

--- a/autoload/clap/popup/move_manager.vim
+++ b/autoload/clap/popup/move_manager.vim
@@ -8,7 +8,7 @@ let s:input = ''
 let s:input_timer = -1
 let s:input_delay = get(g:, 'clap_popup_input_delay', 100)
 let s:cursor_shape = get(g:, 'clap_popup_cursor_shape', '|')
-let s:cursor_width = strdisplaywidth(s:cursor_shape)
+let s:cursor_length = strlen(s:cursor_shape)
 
 let s:move_manager = {}
 
@@ -163,7 +163,7 @@ function! s:hl_cursor() abort
   if exists('w:clap_cursor_id')
     call matchdelete(w:clap_cursor_id)
   endif
-  let w:clap_cursor_id = matchaddpos('ClapPopupCursor', [[1, byteidx(s:input, s:cursor_idx) + 1, s:cursor_width]])
+  let w:clap_cursor_id = matchaddpos('ClapPopupCursor', [[1, byteidx(s:input, s:cursor_idx) + 1, s:cursor_length]])
 endfunction
 
 function! s:mock_input() abort


### PR DESCRIPTION
Currently clap does not accept non-ascii characters for filtering on Vim (#129). I enabled that by using `strchar*()` functions instead of byte index. `s:cursor_idx` has been changed to indicate character index instead of byte index.
Since `strcharpart()` does not throw error for out-of-bound indexes, the source have gotten simpler.

Also, I fixed that the cursor in popup was not highlighted properly if the cursor contains multi-byte characters.