### PR TITLE
Support normal mode mappings for neovim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ CHANGELOG
 - Add `g:clap_project_root_markers` for specifing how vim-clap intentify a project root. Previously only the git-based project is supported, i.e., `g:clap_project_root_markers = ['.git', '.git/']`. The default value of `g:clap_project_root_markers` is `['.root', '.git', '.git/']` you can add `.root` file under the directory you want to the project root.([#290](https://github.com/liuchengxu/vim-clap/pull/290))
 - Add preview support for `files`, `git_files` and `history` provider.
 - Add new highlight group `ClapSelectedSign` and `ClapCurrentSelectionSign` for the sign `texthl`, they are linked to `WarningMsg` by default.
+- [neovim] normal mappings: j/k, gg/G, `<C-d>`/`<C-u>` and see `ftplugin/clap_input.vim`.
 
 ### Improved
 
@@ -29,6 +30,7 @@ CHANGELOG
 - Decrease the default `g:clap_popup_input_delay` from 200ms to 100ms, use the Rust binary.
 - Update `clap_tags` syntax due to https://github.com/liuchengxu/vista.vim/pull/231.
 - Use a standalone floating win instead of virtual text for the matches count.([#315](https://github.com/liuchengxu/vim-clap/pull/315))
+- [neovim] `<Esc>` won't exit clap but enter the normal mode.[#322](https://github.com/liuchengxu/vim-clap/issues/322)
 
 ## [0.7] 2020-01-31
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ See `:help clap-options` for more information.
 
 #### Normal mode
 
+Normal mode mappings are neovim only now.
+
 - [x] Use <kbd>j</kbd>/<kbd>Down</kbd> or <kbd>k</kbd>/<kbd>Up</kbd> to navigate the result list up and down linewise.
 - [x] Use <kbd>Ctrl-d</kbd>/<kbd>Ctrl-u</kbd>/<kbd>PageDown</kbd>/<kbd>PageUp</kbd> to scroll the result list down and up.
 - [x] Use <kbd>gg</kbd> and <kbd>G</kbd> to scroll to the first and last item.

--- a/README.md
+++ b/README.md
@@ -174,11 +174,13 @@ See `:help clap-options` for more information.
 
 ### Keybindings
 
+#### Insert mode
+
 - [x] Use <kbd>Ctrl-j</kbd>/<kbd>Down</kbd> or <kbd>Ctrl-k</kbd>/<kbd>Up</kbd> to navigate the result list up and down linewise.
 - [x] Use <kbd>PageDown</kbd>/<kbd>PageUp</kbd> to scroll the result list down and up.
 - [x] Use <kbd>Ctrl-a</kbd>/<kbd>Home</kbd> to go to the start of the input.
 - [x] Use <kbd>Ctrl-e</kbd>/<kbd>End</kbd> to go to the end of the input.
-- [x] Use <kbd>Ctrl-c</kbd>, <kbd>Ctrl-g</kbd>, <kbd>Ctrl-[</kbd> or <kbd>Esc</kbd> to exit.
+- [x] Use <kbd>Ctrl-c</kbd>, <kbd>Ctrl-g</kbd>, <kbd>Ctrl-[</kbd> or <kbd>Esc</kbd>(vim) to exit.
 - [x] Use <kbd>Ctrl-h</kbd>/<kbd>BS</kbd> to delete previous character.
 - [x] Use <kbd>Ctrl-d</kbd> to delete next character.
 - [x] Use <kbd>Ctrl-b</kbd> to move cursor left one character.
@@ -188,6 +190,13 @@ See `:help clap-options` for more information.
     - Use <kbd>Tab</kbd> to expand the directory for `:Clap filer`.
 - [x] Use <kbd>Ctrl-t</kbd> or <kbd>Ctrl-x</kbd>, <kbd>Ctrl-v</kbd> to open the selected entry in a new tab or a new split.
 - [x] Use <kbd>Ctrl-u</kbd> to clear inputs.
+
+#### Normal mode
+
+- [x] Use <kbd>j</kbd>/<kbd>Down</kbd> or <kbd>k</kbd>/<kbd>Up</kbd> to navigate the result list up and down linewise.
+- [x] Use <kbd>Ctrl-d</kbd>/<kbd>Ctrl-u</kbd>/<kbd>PageDown</kbd>/<kbd>PageUp</kbd> to scroll the result list down and up.
+- [x] Use <kbd>gg</kbd> and <kbd>G</kbd> to scroll to the first and last item.
+- [x] Use <kbd>Enter</kbd> to select the entry and exit.
 
 See `:help clap-keybindings` for more information.
 

--- a/autoload/clap/navigation.vim
+++ b/autoload/clap/navigation.vim
@@ -26,6 +26,10 @@ function! s:scroll(direction) abort
   let scroll_lines = getwinvar(g:clap.display.winid, '&scroll')
   if a:direction ==# 'down'
     execute 'normal!' scroll_lines.'j'
+  elseif a:direction ==# 'top'
+    normal! gg
+  elseif a:direction ==# 'bottom'
+    normal! G
   else
     execute 'normal!' scroll_lines.'k'
   endif

--- a/autoload/clap/navigation.vim
+++ b/autoload/clap/navigation.vim
@@ -86,7 +86,7 @@ function! s:on_move_safe() abort
 endfunction
 
 if has('nvim')
-  function! s:wrap_insert_move(Move, args) abort
+  function! s:wrap_move(Move, args) abort
     call g:clap.display.goto_win()
 
     call call(a:Move, a:args)
@@ -99,11 +99,11 @@ if has('nvim')
   endfunction
 
   function! clap#navigation#linewise(direction) abort
-    return s:wrap_insert_move(function('s:navigate'), [a:direction])
+    return s:wrap_move(function('s:navigate'), [a:direction])
   endfunction
 
   function! clap#navigation#scroll(direction) abort
-    return s:wrap_insert_move(function('s:scroll'), [a:direction])
+    return s:wrap_move(function('s:scroll'), [a:direction])
   endfunction
 
   function! clap#navigation#line_down() abort

--- a/autoload/clap/provider/filer.vim
+++ b/autoload/clap/provider/filer.vim
@@ -205,7 +205,7 @@ function! s:filer_on_typed() abort
   " <Tab> and <Backspace> also trigger the CursorMoved event.
   " s:filter_or_send_message() is already handled in tab and bs action,
   " on_typed handler only needs to take care of the filtering.
-  if has_key(s:filer_cache, s:current_dir)
+  if exists('s:filer_cache') && has_key(s:filer_cache, s:current_dir)
     call clap#highlight#clear()
     call s:do_filter()
   endif

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -667,6 +667,8 @@ Insert mode
 
 Normal mode
 
+Normal mode mappings are neovim only now.
+
 - Use `j`/`Down` or `k`/`Up` to navigate the result list up and down linewise.
 - Use `Ctrl-d`/`Ctrl-u`/`PageDown`/`PageUp` to scroll the result list down and up.
 - Use `gg` and `G` to scroll to the first and last item.

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -634,6 +634,7 @@ The form of `[++opt]` is `++{optname}={value}`, where {optname} is one of:
 8. Movement/Keybindings                                       *clap-movement*
                                                               *clap-keybindings*
 
+Insert mode
 
 - Use `Ctrl-j`/`Down` or `Ctrl-k`/`Up` to navigate the result list up and down linewise.
 
@@ -663,6 +664,13 @@ The form of `[++opt]` is `++{optname}={value}`, where {optname} is one of:
 
 - Use `Ctrl-u` to clear inputs.
 
+
+Normal mode
+
+- Use `j`/`Down` or `k`/`Up` to navigate the result list up and down linewise.
+- Use `Ctrl-d`/`Ctrl-u`/`PageDown`/`PageUp` to scroll the result list down and up.
+- Use `gg` and `G` to scroll to the first and last item.
+- Use `Enter` to select the entry and exit.
 
 ===============================================================================
 9. API                                                                *clap-api*

--- a/ftplugin/clap_input.vim
+++ b/ftplugin/clap_input.vim
@@ -44,26 +44,39 @@ endif
 
 inoremap <silent> <buffer> <expr> <C-E> col('.')>strlen(getline('.'))<bar><bar>pumvisible()?"\<Lt>C-E>":"\<Lt>End>"
 
-inoremap <silent> <buffer> <CR> <Esc>:call clap#handler#sink()<CR>
-
-nnoremap <silent> <buffer> <C-c> :call clap#handler#exit()<CR>
-nnoremap <silent> <buffer> <Esc> :call clap#handler#exit()<CR>
-nnoremap <silent> <buffer> <C-g> :call clap#handler#exit()<CR>
+inoremap <silent> <buffer> <CR> <Esc>:<c-u>call clap#handler#sink()<CR>
+nnoremap <silent> <buffer> <CR>      :<c-u>call clap#handler#sink()<CR>
 
 inoremap <silent> <buffer> <C-c> <Esc>:call clap#handler#exit()<CR>
-inoremap <silent> <buffer> <Esc> <Esc>:call clap#handler#exit()<CR>
-inoremap <silent> <buffer> <C-g> <Esc>:call clap#handler#exit()<CR>
+nnoremap <silent> <buffer> <C-c>      :call clap#handler#exit()<CR>
+
+inoremap <silent> <buffer> <C-g> <Esc>:<c-u>call clap#handler#exit()<CR>
+nnoremap <silent> <buffer> <C-g>      :<c-u>call clap#handler#exit()<CR>
+
+inoremap <silent> <buffer> <Down> <C-R>=clap#navigation#linewise('down')<CR>
+nnoremap <silent> <buffer> <Down> :<c-u>call clap#navigation#linewise('down')<CR>
+
+inoremap <silent> <buffer> <Up> <C-R>=clap#navigation#linewise('up')<CR>
+nnoremap <silent> <buffer> <Up> :<c-u>call clap#navigation#linewise('up')<CR>
+
+inoremap <silent> <buffer> <PageDown> <C-R>=clap#navigation#scroll('down')<CR>
+nnoremap <silent> <buffer> <PageDown> :<c-u>call clap#navigation#scroll('down')<CR>
+
+inoremap <silent> <buffer> <PageUp> <C-R>=clap#navigation#scroll('up')<CR>
+nnoremap <silent> <buffer> <PageUp> :<c-u>call clap#navigation#scroll('up')<CR>
+
+inoremap <silent> <buffer> <Tab> <C-R>=clap#handler#tab_action()<CR>
+nnoremap <silent> <buffer> <Tab> :<c-u>call clap#handler#tab_action()<CR>
+
+inoremap <silent> <buffer> <Backspace> <C-R>=clap#handler#bs_action()<CR>
 
 inoremap <silent> <buffer> <C-j> <C-R>=clap#navigation#linewise('down')<CR>
 inoremap <silent> <buffer> <C-k> <C-R>=clap#navigation#linewise('up')<CR>
 
-inoremap <silent> <buffer> <Down> <C-R>=clap#navigation#linewise('down')<CR>
-inoremap <silent> <buffer> <Up> <C-R>=clap#navigation#linewise('up')<CR>
+nnoremap <silent> <buffer> gg :<c-u>call clap#navigation#scroll('top')<CR>
+nnoremap <silent> <buffer> G  :<c-u>call clap#navigation#scroll('bottom')<CR>
 
-inoremap <silent> <buffer> <PageDown> <C-R>=clap#navigation#scroll('down')<CR>
-inoremap <silent> <buffer> <PageUp> <C-R>=clap#navigation#scroll('up')<CR>
-
-inoremap <silent> <buffer> <Tab> <C-R>=clap#handler#tab_action()<CR>
-inoremap <silent> <buffer> <Backspace> <C-R>=clap#handler#bs_action()<CR>
+nnoremap <silent> <buffer> j :<c-u>call clap#navigation#linewise('down')<CR>
+nnoremap <silent> <buffer> k :<c-u>call clap#navigation#linewise('up')<CR>
 
 call clap#util#define_open_action_mappings()

--- a/ftplugin/clap_input.vim
+++ b/ftplugin/clap_input.vim
@@ -65,6 +65,9 @@ nnoremap <silent> <buffer> <PageDown> :<c-u>call clap#navigation#scroll('down')<
 inoremap <silent> <buffer> <PageUp> <C-R>=clap#navigation#scroll('up')<CR>
 nnoremap <silent> <buffer> <PageUp> :<c-u>call clap#navigation#scroll('up')<CR>
 
+nnoremap <silent> <buffer> <C-d> :<c-u>call clap#navigation#scroll('down')<CR>
+nnoremap <silent> <buffer> <C-u> :<c-u>call clap#navigation#scroll('up')<CR>
+
 inoremap <silent> <buffer> <Tab> <C-R>=clap#handler#tab_action()<CR>
 nnoremap <silent> <buffer> <Tab> :<c-u>call clap#handler#tab_action()<CR>
 


### PR DESCRIPTION
- Add some normal mappings for neovim to explore the results easier.
- Add scroll to top/bottom function.

Changed:

-  `<Esc>` in insert mode will not exit the clap but back to the normal mode.

Ref #51