### PR TITLE
Block cursor for popup filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ CHANGELOG
 - Now you can use `:Clap grep ++query=@visual` to search the visual selection. ([#336](https://github.com/liuchengxu/vim-clap/pull/336))
 - Ensure the long matched elements from the filter always at least partially visible. ([#330](https://github.com/liuchengxu/vim-clap/pull/330))
 - Use file name as the preview header for `Clap grep`, `Clap marks` and `Clap jumps`.
+- Use block-style cursor for vim's popup when `g:clap_popup_cursor_shape == ''`. The default value has been changed to that.
 
 ## [0.8] 2020-02-21
 

--- a/autoload/clap/popup/move_manager.vim
+++ b/autoload/clap/popup/move_manager.vim
@@ -195,7 +195,8 @@ function! s:hl_cursor() abort
 endfunction
 
 function! s:mock_input() abort
-  let input = s:strpart_input(0, s:cursor_idx).s:cursor_shape.s:strpart_input(s:cursor_idx)
+  " The trailing space is for block cursor
+  let input = s:strpart_input(0, s:cursor_idx).s:cursor_shape.s:strpart_input(s:cursor_idx).' '
   let input_winid = g:clap#popup#input.winid
   call popup_settext(input_winid, input)
   call win_execute(input_winid, 'noautocmd call s:hl_cursor()')

--- a/autoload/clap/popup/move_manager.vim
+++ b/autoload/clap/popup/move_manager.vim
@@ -7,7 +7,7 @@ set cpoptions&vim
 let s:input = ''
 let s:input_timer = -1
 let s:input_delay = get(g:, 'clap_popup_input_delay', 100)
-let s:cursor_shape = get(g:, 'clap_popup_cursor_shape', '|')
+let s:cursor_shape = get(g:, 'clap_popup_cursor_shape', '')
 let s:cursor_length = strlen(s:cursor_shape)
 
 let s:move_manager = {}

--- a/autoload/clap/popup/move_manager.vim
+++ b/autoload/clap/popup/move_manager.vim
@@ -139,6 +139,7 @@ let s:move_manager["\<C-E>"] = s:move_manager.ctrl_e
 let s:move_manager["\<End>"] = s:move_manager.ctrl_e
 let s:move_manager["\<BS>"] = s:move_manager.bs
 let s:move_manager["\<C-H>"] = s:move_manager.bs
+let s:move_manager["\<Del>"] = s:move_manager.ctrl_d
 let s:move_manager["\<C-D>"] = s:move_manager.ctrl_d
 let s:move_manager["\<C-G>"] = s:move_manager["\<Esc>"]
 let s:move_manager["\<C-U>"] = s:move_manager.ctrl_u

--- a/autoload/clap/themes.vim
+++ b/autoload/clap/themes.vim
@@ -172,7 +172,7 @@ function! s:init_theme() abort
     call s:apply_default_theme()
   endif
 
-  if !s:is_nvim && get(g:, 'clap_popup_cursor_shape', '|') ==# ''
+  if !s:is_nvim && get(g:, 'clap_popup_cursor_shape', '') ==# ''
     " block cursor
     call s:reverse_PopupCursor()
   endif

--- a/autoload/clap/themes.vim
+++ b/autoload/clap/themes.vim
@@ -144,6 +144,23 @@ function! s:make_preview_EndOfBuffer_invisible() abort
         \ )
 endfunction
 
+function! s:reverse_PopupCursor() abort
+  if !hlexists('ClapSearchText')
+    return
+  endif
+  let ctermbg = s:extract('ClapSearchText', 'bg', 'cterm')
+  let guibg = s:extract('ClapSearchText', 'bg', 'gui')
+  let ctermfg = s:extract('ClapSearchText', 'fg', 'cterm')
+  let guifg = s:extract('ClapSearchText', 'fg', 'gui')
+  execute printf(
+        \ 'hi ClapPopupCursor guifg=%s ctermfg=%s ctermbg=%s guibg=%s cterm=bold,reverse gui=bold,reverse',
+        \ guifg,
+        \ ctermfg,
+        \ ctermbg,
+        \ guibg,
+        \ )
+endfunction
+
 function! s:init_theme() abort
   if &background ==# 'dark'
     hi ClapDefaultPreview ctermbg=237 guibg=#3E4452
@@ -153,6 +170,11 @@ function! s:init_theme() abort
 
   if !exists('s:palette') || !s:paint_is_ok()
     call s:apply_default_theme()
+  endif
+
+  if !s:is_nvim && get(g:, 'clap_popup_cursor_shape', '|') ==# ''
+    " block cursor
+    call s:reverse_PopupCursor()
   endif
 
   call s:hi_clap_symbol()

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -160,9 +160,10 @@ g:clap_maple_delay                                          *g:clap_maple_delay*
 g:clap_popup_cursor_shape                            *g:clap_popup_cursor_shape*
 
   Type: |String|
-  Default: `'|'`
+  Default: `''`
 
   This variable controls the mocked cursor shape in the popup window of vim.
+  If empty, the cursor will be block style.
 
 
 g:clap_on_move_delay                                      *g:clap_on_move_delay*


### PR DESCRIPTION
* Make the cursor in popup filter block-shaped when `g:clap_popup_cursor_shape == ''`.
* I feel it deserves to be default, so make it default.
* I noticed `<Del>` does not work in popup filter, so make it work as it works on neovim.

before:
![before](https://user-images.githubusercontent.com/4504807/75619378-6e42b200-5bbe-11ea-8f31-21c441d097b6.gif)

after:
![after](https://user-images.githubusercontent.com/4504807/75619379-726ecf80-5bbe-11ea-8e42-a5a987e4fce6.gif)
