### PR TITLE
Split out Printer crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 
 ### Added
 
-- Allow `:Clap files +name-only` to filter the file name only instead of the full file path. Require you have built the Python dynamic module or uses in the cached mode.
+- Allow `:Clap files +name-only` to filter the file name only instead of the full file path. Require you have built the Python dynamic module or uses in the cached mode. ([#389](https://github.com/liuchengxu/vim-clap/pull/389))
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ CHANGELOG
 
 - Allow `:Clap files +name-only` to filter the file name only instead of the full file path. Require you have built the Python dynamic module or uses in the cached mode.
 
+### Improved
+
+- Handle the icon highlight offset on Python and Rust side.
+
 ## [0.12] 2020-04-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## [unreleased]
 
+### Added
+
+- Allow `:Clap files +name-only` to filter the file name only instead of the full file path. Require you have built the Python dynamic module or uses in the cached mode.
+
 ## [0.12] 2020-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "fuzzy_filter",
  "icon",
  "lazy_static",
+ "printer",
  "rayon",
  "regex",
  "serde",
@@ -379,6 +380,15 @@ name = "pkg-config"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
+
+[[package]]
+name = "printer"
+version = "0.1.0"
+dependencies = [
+ "icon",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "proc-macro-error"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,9 @@ dependencies = [
  "anyhow",
  "extracted_fzy",
  "fuzzy-matcher",
+ "lazy_static",
  "rayon",
+ "regex",
  "structopt",
  "subprocess",
 ]

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -42,6 +42,8 @@ Now, only `maple` binary is mandatory for getting a fast and quite responsive vi
 
 If you have installed Rust on your system, specifically, `cargo` executable exists, you can build the extra tools for a performant and nicer vim-clap using this single command `:call clap#installer#build_all()`.
 
+If you are using macOS or Linux, building the Rust deps is very convenient, just go to the clap plugin directory and run `make`.
+
 #### `maple` binary
 
 `maple` mainly serves two functions:

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -39,8 +39,16 @@ function! clap#filter#capacity() abort
 endfunction
 
 if s:can_use_python
+
+  let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history', 'filer']
+
   function! s:enable_icon() abort
-    return clap#highlight#provider_has_offset() ? v:true : v:false
+    if g:clap_enable_icon
+          \ && index(s:related_builtin_providers, g:clap.provider.id) > -1
+      return v:true
+    else
+      return v:false
+    endif
   endfunction
 
   function! s:content_filtering() abort

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -43,9 +43,17 @@ if s:can_use_python
     return clap#highlight#provider_has_offset() ? v:true : v:false
   endfunction
 
+  function! s:content_filtering() abort
+    if exists('g:__clap_builtin_content_filtering_enum')
+      return g:__clap_builtin_content_filtering_enum
+    else
+      return 'Full'
+    endif
+  endfunction
+
   function! clap#filter#sync(query, candidates) abort
     try
-      return clap#filter#sync#python#(a:query, a:candidates, winwidth(g:clap.display.winid), s:enable_icon())
+      return clap#filter#sync#python#(a:query, a:candidates, winwidth(g:clap.display.winid), s:enable_icon(), s:content_filtering())
     catch
       call clap#helper#echo_error(v:exception)
       return clap#filter#sync#viml#(a:query, a:candidates)

--- a/autoload/clap/filter/sync/python.vim
+++ b/autoload/clap/filter/sync/python.vim
@@ -53,7 +53,7 @@ if s:using_dynamic_module
     return filtered
   endfunction
 else
-  function! clap#filter#sync#python#(query, candidates, _winwidth, _enable_icon, _content_filtering) abort
+  function! clap#filter#sync#python#(query, candidates, _winwidth, enable_icon, _content_filtering) abort
     let [g:__clap_fuzzy_matched_indices, filtered] = pyxeval(s:py_fn.'()')
     return filtered
   endfunction

--- a/autoload/clap/filter/sync/python.vim
+++ b/autoload/clap/filter/sync/python.vim
@@ -44,7 +44,7 @@ endfunction
 
 if s:using_dynamic_module
   " Rust dynamic module has the feature of truncating the long lines to make fuzzy matched items visible.
-  function! clap#filter#sync#python#(query, candidates, winwidth, enable_icon) abort
+  function! clap#filter#sync#python#(query, candidates, winwidth, enable_icon, content_filtering) abort
     " If the query is empty, neovim and vim's python client might crash.
     if a:query ==# ''
       return a:candidates
@@ -53,7 +53,7 @@ if s:using_dynamic_module
     return filtered
   endfunction
 else
-  function! clap#filter#sync#python#(query, candidates, _winwidth, enable_icon) abort
+  function! clap#filter#sync#python#(query, candidates, _winwidth, _enable_icon, _content_filtering) abort
     let [g:__clap_fuzzy_matched_indices, filtered] = pyxeval(s:py_fn.'()')
     return filtered
   endfunction

--- a/autoload/clap/highlight.vim
+++ b/autoload/clap/highlight.vim
@@ -4,40 +4,10 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-" Now the added icon offset of matched items are handled in maple.
-" let s:related_maple_providers = ['files', 'git_files']
-
-let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history', 'filer']
-
 let s:default_priority = 10
 
-" The icon can interfer the matched indices of fuzzy filter, but not the
-" substring filter.
-function! s:should_check_offset() abort
-  return g:clap_enable_icon && stridx(g:clap.input.get(), ' ') == -1
-endfunction
-
-function! s:builtin_fuzzy_idx_offset() abort
-  if s:should_check_offset()
-    if g:clap.provider.id ==# 'files' && has_key(g:clap.context, 'name-only')
-      return 0
-    endif
-    if index(s:related_builtin_providers, g:clap.provider.id) > -1
-      return 2
-    else
-      return 0
-    endif
-  else
-    return 0
-  endif
-endfunction
-
-function! clap#highlight#provider_has_offset() abort
-  return s:builtin_fuzzy_idx_offset() > 0
-endfunction
-
 if has('nvim')
-  function! s:apply_add_highlight(hl_lines, offset) abort
+  function! s:apply_add_highlight(hl_lines) abort
     " Currently neovim does not have win_execute()
     " and the highlight added by nvim_buf_add_highlight()
     " can be overrided by the sign's highlight.
@@ -56,10 +26,10 @@ if has('nvim')
       let group_idx = 1
       for idx in indices
         if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
-          call add(w:clap_match_ids, clap#highlight#matchadd_char_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx))
+          call add(w:clap_match_ids, clap#highlight#matchadd_char_at(lnum, idx, 'ClapFuzzyMatches'.group_idx))
           let group_idx += 1
         else
-          call add(w:clap_match_ids, clap#highlight#matchadd_char_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group))
+          call add(w:clap_match_ids, clap#highlight#matchadd_char_at(lnum, idx, g:__clap_fuzzy_last_hl_group))
         endif
       endfor
       let lnum += 1
@@ -81,7 +51,7 @@ if has('nvim')
   endfunction
 
 else
-  function! s:apply_add_highlight(hl_lines, offset) abort
+  function! s:apply_add_highlight(hl_lines) abort
     " We do not have to clear the previous matches like neovim
     " as the previous lines have been deleted, and the associated text_props have also been removed.
     let lnum = 0
@@ -89,10 +59,10 @@ else
       let group_idx = 1
       for idx in indices
         if group_idx < g:__clap_fuzzy_matches_hl_group_cnt + 1
-          call clap#highlight#add_highlight_at(lnum, idx+a:offset, 'ClapFuzzyMatches'.group_idx)
+          call clap#highlight#add_highlight_at(lnum, idx, 'ClapFuzzyMatches'.group_idx)
           let group_idx += 1
         else
-          call clap#highlight#add_highlight_at(lnum, idx+a:offset, g:__clap_fuzzy_last_hl_group)
+          call clap#highlight#add_highlight_at(lnum, idx, g:__clap_fuzzy_last_hl_group)
         endif
       endfor
       let lnum += 1
@@ -117,14 +87,12 @@ function! clap#highlight#add_fuzzy_sync() abort
   "
   " TODO: also add highlights for the cached lines?
   let hl_lines = g:__clap_fuzzy_matched_indices[:g:clap.display.line_count()-1]
-  let offset = s:builtin_fuzzy_idx_offset()
-
-  call s:apply_add_highlight(hl_lines, offset)
+  call s:apply_add_highlight(hl_lines)
 endfunction
 
 " Used by the async job.
 function! clap#highlight#add_fuzzy_async(hl_lines) abort
-  call s:apply_add_highlight(a:hl_lines, 0)
+  call s:apply_add_highlight(a:hl_lines)
 endfunction
 
 function! clap#highlight#fg_only(group_name, cermfg, guifg) abort

--- a/autoload/clap/highlight.vim
+++ b/autoload/clap/highlight.vim
@@ -19,8 +19,14 @@ endfunction
 
 function! s:builtin_fuzzy_idx_offset() abort
   if s:should_check_offset()
-        \ && index(s:related_builtin_providers, g:clap.provider.id) > -1
+    if g:clap.provider.id ==# 'files' && has_key(g:clap.context, 'name-only')
+      return 0
+    endif
+    if index(s:related_builtin_providers, g:clap.provider.id) > -1
       return 2
+    else
+      return 0
+    endif
   else
     return 0
   endif

--- a/autoload/clap/provider/files.vim
+++ b/autoload/clap/provider/files.vim
@@ -31,6 +31,10 @@ endif
 function! s:files.source() abort
   call clap#rooter#try_set_cwd()
 
+  if has_key(g:clap.context, 'name-only')
+    let g:__clap_builtin_content_filtering_enum = 'FileNameOnly'
+  endif
+
   if has_key(g:clap.context, 'finder')
     let finder = g:clap.context.finder
     return finder.' '.join(g:clap.provider.args, ' ')
@@ -73,6 +77,12 @@ endfunction
 
 function! clap#provider#files#on_move_impl() abort
   call clap#preview#file(s:into_filename(g:clap.display.getcurline()))
+endfunction
+
+function! s:files.on_exit() abort
+  if exists('g:__clap_builtin_content_filtering_enum')
+    unlet g:__clap_builtin_content_filtering_enum
+  endif
 endfunction
 
 let s:files.sink = function('clap#provider#files#sink_impl')

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -5,4 +5,5 @@ members = [
     "extracted_fzy",
     "fuzzy_filter",
     "icon",
+    "printer"
 ]

--- a/crates/fuzzy_filter/Cargo.toml
+++ b/crates/fuzzy_filter/Cargo.toml
@@ -9,9 +9,11 @@ homepage = "https://github.com/liuchengxu/vim-clap"
 categories = ["Fuzzy Filter Library"]
 
 [dependencies]
+regex = "1"
 rayon = "1.2"
 anyhow = "1.0"
 structopt = "0.3"
+lazy_static = "1.4.0"
 fuzzy-matcher = "0.3.1"
 
 subprocess = { git = "https://github.com/hniksic/rust-subprocess", optional = true }

--- a/crates/fuzzy_filter/Cargo.toml
+++ b/crates/fuzzy_filter/Cargo.toml
@@ -18,9 +18,6 @@ subprocess = { git = "https://github.com/hniksic/rust-subprocess", optional = tr
 
 extracted_fzy = { path = "../extracted_fzy" }
 
-[target.'cfg(not(windows))'.dev-dependencies]
-termion = "1.5.1"
-
 [features]
 default = ["enable_dyn"]
 # Allow dynamic filtering

--- a/crates/fuzzy_filter/src/content_filtering.rs
+++ b/crates/fuzzy_filter/src/content_filtering.rs
@@ -1,22 +1,7 @@
+use crate::{fuzzy_indices_skim, ScorerOutput};
 use extracted_fzy::match_and_score_with_positions;
-pub use fuzzy_matcher::skim::fuzzy_indices as fuzzy_indices_skim;
 use lazy_static::lazy_static;
 use regex::Regex;
-use structopt::clap::arg_enum;
-
-// Implement arg_enum so that we could control it from the command line.
-arg_enum! {
-  #[derive(Debug, Clone)]
-  pub enum ContentFiltering {
-      Full,
-      FileNameOnly,
-      GrepExcludeFilePath,
-  }
-}
-
-// Returns the score and indices of matched chars
-// when the line is matched given the query,
-type ScorerOutput = Option<(i64, Vec<usize>)>;
 
 lazy_static! {
     // match the file path and line number of grep line.
@@ -25,7 +10,7 @@ lazy_static! {
 
 /// Make the arguments order same to Skim's `fuzzy_indices()`.
 #[inline]
-pub(super) fn fuzzy_indices_fzy(line: &str, query: &str) -> ScorerOutput {
+pub fn fuzzy_indices_fzy(line: &str, query: &str) -> ScorerOutput {
     match_and_score_with_positions(query, line).map(|(score, indices)| (score as i64, indices))
 }
 

--- a/crates/fuzzy_filter/src/lib.rs
+++ b/crates/fuzzy_filter/src/lib.rs
@@ -1,12 +1,27 @@
+mod content_filtering;
 mod source;
 
 use anyhow::Result;
+use content_filtering::*;
 use rayon::prelude::*;
 use structopt::clap::arg_enum;
 
+pub use content_filtering::fuzzy_indices_fzy;
+pub use fuzzy_matcher::skim::fuzzy_indices as fuzzy_indices_skim;
 pub use source::Source;
 #[cfg(feature = "enable_dyn")]
 pub use subprocess;
+
+// Implement arg_enum so that we could control it from the command line.
+arg_enum! {
+  /// Sometimes we hope to filter on the part of line.
+  #[derive(Debug, Clone)]
+  pub enum ContentFiltering {
+      Full,
+      FileNameOnly,
+      GrepExcludeFilePath,
+  }
+}
 
 // Implement arg_enum for using it in the command line arguments.
 arg_enum! {
@@ -21,6 +36,10 @@ arg_enum! {
 /// Tuple of (matched line text, filtering score, indices of matched elements)
 pub type FuzzyMatchedLineInfo = (String, i64, Vec<usize>);
 
+// Returns the score and indices of matched chars
+// when the line is matched given the query,
+pub type ScorerOutput = Option<(i64, Vec<usize>)>;
+
 /// Returns the ranked results after applying the fuzzy filter
 /// given the query String and filtering source.
 pub fn fuzzy_filter_and_rank<I: Iterator<Item = String>>(
@@ -33,4 +52,24 @@ pub fn fuzzy_filter_and_rank<I: Iterator<Item = String>>(
     ranked.par_sort_unstable_by(|(_, v1, _), (_, v2, _)| v2.partial_cmp(&v1).unwrap());
 
     Ok(ranked)
+}
+
+/// Returns the appropriate scorer given the algo and content_filtering strategy.
+#[inline]
+pub fn get_appropriate_scorer(
+    algo: Algo,
+    content_filtering: ContentFiltering,
+) -> impl Fn(&str, &str) -> ScorerOutput {
+    match algo {
+        Algo::Skim => match content_filtering {
+            ContentFiltering::Full => fuzzy_indices_skim,
+            ContentFiltering::FileNameOnly => apply_skim_on_file_line,
+            ContentFiltering::GrepExcludeFilePath => apply_skim_on_grep_line,
+        },
+        Algo::Fzy => match content_filtering {
+            ContentFiltering::Full => fuzzy_indices_fzy,
+            ContentFiltering::FileNameOnly => apply_fzy_on_file_line,
+            ContentFiltering::GrepExcludeFilePath => apply_fzy_on_grep_line,
+        },
+    }
 }

--- a/crates/fuzzy_filter/src/lib.rs
+++ b/crates/fuzzy_filter/src/lib.rs
@@ -23,6 +23,23 @@ arg_enum! {
   }
 }
 
+impl From<&str> for ContentFiltering {
+    fn from(filtering: &str) -> Self {
+        match filtering {
+            "Full" => Self::Full,
+            "FileNameOnly" => Self::FileNameOnly,
+            "GrepExcludeFilePath" => Self::GrepExcludeFilePath,
+            _ => Self::Full,
+        }
+    }
+}
+
+impl From<String> for ContentFiltering {
+    fn from(filtering: String) -> Self {
+        Self::from(filtering.as_str())
+    }
+}
+
 // Implement arg_enum for using it in the command line arguments.
 arg_enum! {
   /// Supported fuzzy match algorithm.

--- a/crates/fuzzy_filter/src/lib.rs
+++ b/crates/fuzzy_filter/src/lib.rs
@@ -1,7 +1,5 @@
 mod source;
 
-use std::collections::HashMap;
-
 use anyhow::Result;
 use rayon::prelude::*;
 use structopt::clap::arg_enum;
@@ -9,8 +7,6 @@ use structopt::clap::arg_enum;
 pub use source::Source;
 #[cfg(feature = "enable_dyn")]
 pub use subprocess;
-
-pub const DOTS: &str = "...";
 
 // Implement arg_enum for using it in the command line arguments.
 arg_enum! {
@@ -22,8 +18,6 @@ arg_enum! {
   }
 }
 
-/// Map of truncated line to original line.
-pub type LinesTruncatedMap = HashMap<String, String>;
 /// Tuple of (matched line text, filtering score, indices of matched elements)
 pub type FuzzyMatchedLineInfo = (String, i64, Vec<usize>);
 
@@ -39,207 +33,4 @@ pub fn fuzzy_filter_and_rank<I: Iterator<Item = String>>(
     ranked.par_sort_unstable_by(|(_, v1, _), (_, v2, _)| v2.partial_cmp(&v1).unwrap());
 
     Ok(ranked)
-}
-
-// https://stackoverflow.com/questions/51982999/slice-a-string-containing-unicode-chars
-#[inline]
-fn utf8_str_slice(line: &str, start: usize, end: usize) -> String {
-    line.chars().take(end).skip(start).collect()
-}
-
-/// Long matched lines can cause the matched items invisible.
-///
-/// [--------------------------]
-///                                              end
-/// [-------------------------------------xx--x---]
-///                     start    winwidth
-/// |~~~~~~~~~~~~~~~~~~[------------------xx--x---]
-///
-///  `start >= indices[0]`
-/// |----------[x-------------------------xx--x---]
-///
-/// |~~~~~~~~~~~~~~~~~~[----------xx--x------------------------------x-----]
-///  `last_idx - start >= winwidth`
-/// |~~~~~~~~~~~~~~~~~~~~~~~~~~~~[xx--x------------------------------x-----]
-///
-pub fn truncate_long_matched_lines<T>(
-    lines: impl IntoIterator<Item = (String, T, Vec<usize>)>,
-    winwidth: usize,
-    starting_point: Option<usize>,
-) -> (Vec<(String, T, Vec<usize>)>, LinesTruncatedMap) {
-    let mut truncated_map = HashMap::new();
-    let lines = lines
-        .into_iter()
-        .map(|(line, score, indices)| {
-            if !indices.is_empty() {
-                let last_idx = indices.last().expect("indices are non-empty; qed");
-                if *last_idx > winwidth {
-                    let mut start = *last_idx - winwidth;
-                    if start >= indices[0] || (indices.len() > 1 && *last_idx - start > winwidth) {
-                        start = indices[0];
-                    }
-                    let line_len = line.len();
-                    // [--------------------------]
-                    // [-----------------------------------------------------------------xx--x--]
-                    for _ in 0..3 {
-                        if indices[0] - start >= DOTS.len() && line_len - start >= winwidth {
-                            start += DOTS.len();
-                        } else {
-                            break;
-                        }
-                    }
-                    let trailing_dist = line_len - last_idx;
-                    if trailing_dist < indices[0] - start {
-                        start += trailing_dist;
-                    }
-                    let end = line.len();
-                    let truncated = if let Some(starting_point) = starting_point {
-                        let icon: String = line.chars().take(starting_point).collect();
-                        start += starting_point;
-                        format!("{}{}{}", icon, DOTS, utf8_str_slice(&line, start, end))
-                    } else {
-                        format!("{}{}", DOTS, utf8_str_slice(&line, start, end))
-                    };
-                    let offset = line_len - truncated.len();
-                    let truncated_indices = indices.iter().map(|x| x - offset).collect::<Vec<_>>();
-                    truncated_map.insert(truncated.clone(), line);
-                    (truncated, score, truncated_indices)
-                } else {
-                    (line, score, indices)
-                }
-            } else {
-                (line, score, indices)
-            }
-        })
-        .collect::<Vec<_>>();
-    (lines, truncated_map)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn wrap_matches(line: &str, indices: &[usize]) -> String {
-        let mut ret = String::new();
-        let mut peekable = indices.iter().peekable();
-        for (idx, ch) in line.chars().enumerate() {
-            let next_id = **peekable.peek().unwrap_or(&&line.len());
-            if next_id == idx {
-                #[cfg(not(target_os = "windows"))]
-                {
-                    ret.push_str(
-                        format!("{}{}{}", termion::style::Invert, ch, termion::style::Reset)
-                            .as_str(),
-                    );
-                }
-
-                #[cfg(target_os = "windows")]
-                {
-                    ret.push_str(format!("~{}~", ch).as_str());
-                }
-
-                peekable.next();
-            } else {
-                ret.push(ch);
-            }
-        }
-
-        ret
-    }
-
-    fn run_test<I: Iterator<Item = String>>(
-        source: Source<I>,
-        query: &str,
-        starting_point: Option<usize>,
-        winwidth: usize,
-    ) {
-        let mut ranked = source.fuzzy_filter(Algo::Fzy, query).unwrap();
-        ranked.par_sort_unstable_by(|(_, v1, _), (_, v2, _)| v2.partial_cmp(&v1).unwrap());
-
-        println!("");
-        println!("query: {:?}", query);
-
-        let (truncated_lines, truncated_map) =
-            truncate_long_matched_lines(ranked, winwidth, starting_point);
-        for (truncated_line, _score, truncated_indices) in truncated_lines.iter() {
-            println!("truncated: {}", "-".repeat(winwidth));
-            println!(
-                "truncated: {}",
-                wrap_matches(&truncated_line, &truncated_indices)
-            );
-            println!("raw_line: {}", truncated_map.get(truncated_line).unwrap());
-        }
-    }
-
-    #[test]
-    fn case1() {
-        let source: Source<_> = vec![
-        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/file.scss".into(),
-        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/another-file.scss"
-            .into(),
-        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/file.js".into(),
-        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/another-file.js"
-            .into(),
-    ]
-        .into();
-        let query = "files";
-        run_test(source, query, None, 50usize);
-    }
-
-    #[test]
-    fn case2() {
-        let source: Source<_> = vec![
-        "fuzzy-filter/target/debug/deps/librustversion-b273394e6c9c64f6.dylib.dSYM/Contents/Resources/DWARF/librustversion-b273394e6c9c64f6.dylib".into(),
-        "fuzzy-filter/target/debug/deps/librustversion-15764ff2535f190d.dylib.dSYM/Contents/Resources/DWARF/librustversion-15764ff2535f190d.dylib".into(),
-        "target/debug/deps/libstructopt_derive-3921fbf02d8d2ffe.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-3921fbf02d8d2ffe.dylib".into(),
-        "target/debug/deps/libstructopt_derive-3921fbf02d8d2ffe.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-3921fbf02d8d2ffe.dylib".into(),
-        ].into();
-        let query = "srlisresource";
-        run_test(source, query, None, 50usize);
-    }
-
-    #[test]
-    fn case3() {
-        let source: Source<_> = vec![
-        "/Users/xuliucheng/Library/Caches/Homebrew/universal-ctags--git/Units/afl-fuzz.r/github-issue-625-r.d/input.r".into()
-        ].into();
-        let query = "srcggithub";
-        run_test(source, query, None, 50usize);
-    }
-
-    #[test]
-    fn case4() {
-        let source: Source<_> = vec![
-            "        // Wait until propagation delay period after block we plan to mine on".into(),
-        ]
-        .into();
-        let query = "bmine";
-        run_test(source, query, None, 58usize);
-    }
-
-    #[test]
-    fn starting_point_should_work() {
-        let source: Source<_> = vec![
-          " crates/fuzzy_filter/target/debug/deps/librustversion-15764ff2535f190d.dylib.dSYM/Contents/Resources/DWARF/librustversion-15764ff2535f190d.dylib".into(),
-          " crates/fuzzy_filter/target/debug/deps/libstructopt_derive-5cce984f248086cc.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-5cce984f248086cc.dylib".into()
-        ].into();
-        let query = "srlisrlisrsr";
-        run_test(source, query, Some(2), 50usize);
-
-        let source: Source<_> = vec![
-          "crates/fuzzy_filter/target/debug/deps/librustversion-15764ff2535f190d.dylib.dSYM/Contents/Resources/DWARF/librustversion-15764ff2535f190d.dylib".into(),
-          "crates/fuzzy_filter/target/debug/deps/libstructopt_derive-5cce984f248086cc.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-5cce984f248086cc.dylib".into()
-        ].into();
-        let query = "srlisrlisrsr";
-        run_test(source, query, None, 50usize);
-    }
-
-    #[test]
-    fn test_print_multibyte_string_slice() {
-        let multibyte_str = "README.md:23:1:Gourinath Banda. “Scalable Real-Time Kernel for Small Embedded Systems”. En- glish. PhD thesis. Denmark: University of Southern Denmark, June 2003. URL: http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=84D11348847CDC13691DFAED09883FCB?doi=10.1.1.118.1909&rep=rep1&type=pdf.";
-        let start = 33;
-        let end = 300;
-        // println!("{}", &multibyte_str[33..300]);
-        println!("{}", utf8_str_slice(multibyte_str, start, end));
-    }
 }

--- a/crates/fuzzy_filter/src/source.rs
+++ b/crates/fuzzy_filter/src/source.rs
@@ -1,7 +1,6 @@
 use super::*;
+use crate::{fuzzy_indices_fzy, fuzzy_indices_skim};
 use anyhow::Result;
-use extracted_fzy::match_and_score_with_positions;
-use fuzzy_matcher::skim::fuzzy_indices;
 use std::io::BufRead;
 use std::path::PathBuf;
 #[cfg(feature = "enable_dyn")]
@@ -43,9 +42,8 @@ impl<I: Iterator<Item = String>> Source<I> {
     /// This is kind of synchronous filtering, can be used for multi-staged processing.
     pub fn fuzzy_filter(self, algo: Algo, query: &str) -> Result<Vec<FuzzyMatchedLineInfo>> {
         let scorer = |line: &str| match algo {
-            Algo::Skim => fuzzy_indices(line, &query),
-            Algo::Fzy => match_and_score_with_positions(&query, line)
-                .map(|(score, indices)| (score as i64, indices)),
+            Algo::Skim => fuzzy_indices_skim(line, &query),
+            Algo::Fzy => fuzzy_indices_fzy(line, &query),
         };
 
         let filtered = match self {

--- a/crates/fuzzy_filter/src/source.rs
+++ b/crates/fuzzy_filter/src/source.rs
@@ -1,8 +1,7 @@
-use crate::{Algo, FuzzyMatchedLineInfo};
+use super::*;
 use anyhow::Result;
 use extracted_fzy::match_and_score_with_positions;
 use fuzzy_matcher::skim::fuzzy_indices;
-use rayon::prelude::*;
 use std::io::BufRead;
 use std::path::PathBuf;
 #[cfg(feature = "enable_dyn")]

--- a/crates/maple_cli/src/cmd/blines.rs
+++ b/crates/maple_cli/src/cmd/blines.rs
@@ -1,4 +1,4 @@
-use crate::cmd::filter::ContentFiltering;
+use crate::ContentFiltering;
 use anyhow::Result;
 use fuzzy_filter::Source;
 use std::path::PathBuf;

--- a/crates/maple_cli/src/cmd/filter/dynamic.rs
+++ b/crates/maple_cli/src/cmd/filter/dynamic.rs
@@ -315,8 +315,7 @@ macro_rules! source_iter_file {
         // The line stream can contain invalid UTF-8 data.
         std::io::BufReader::new(std::fs::File::open($fpath)?)
             .lines()
-            .filter(|x| x.is_ok())
-            .map(|x| x.unwrap())
+            .filter_map(|x| x.ok())
             .filter_map(|line| $scorer(&line).map(|(score, indices)| (line.into(), score, indices)))
     };
 }

--- a/crates/maple_cli/src/cmd/filter/dynamic.rs
+++ b/crates/maple_cli/src/cmd/filter/dynamic.rs
@@ -1,6 +1,5 @@
-use super::scoring_line::*;
 use super::*;
-use fuzzy_filter::FuzzyMatchedLineInfo;
+use fuzzy_filter::{get_appropriate_scorer, FuzzyMatchedLineInfo};
 use icon::ICON_LEN;
 use rayon::slice::ParallelSliceMut;
 use std::io::{self, BufRead};
@@ -341,18 +340,8 @@ pub fn dyn_fuzzy_filter_and_rank<I: Iterator<Item = String>>(
 ) -> Result<()> {
     let algo = algo.unwrap_or(Algo::Fzy);
 
-    let scorer = |line: &str| match algo {
-        Algo::Skim => match content_filtering {
-            ContentFiltering::Full => fuzzy_indices_skim(line, query),
-            ContentFiltering::FileNameOnly => apply_skim_on_file_line(line, query),
-            ContentFiltering::GrepExcludeFilePath => apply_skim_on_grep_line(line, query),
-        },
-        Algo::Fzy => match content_filtering {
-            ContentFiltering::Full => fuzzy_indices_fzy(line, query),
-            ContentFiltering::FileNameOnly => apply_fzy_on_file_line(line, query),
-            ContentFiltering::GrepExcludeFilePath => apply_fzy_on_grep_line(line, query),
-        },
-    };
+    let scorer_fn = get_appropriate_scorer(algo, content_filtering);
+    let scorer = |line: &str| scorer_fn(line, query);
 
     if let Some(number) = number {
         let (total, filtered) = match source {

--- a/crates/maple_cli/src/cmd/filter/mod.rs
+++ b/crates/maple_cli/src/cmd/filter/mod.rs
@@ -1,13 +1,11 @@
 pub mod dynamic;
-mod scoring_line;
 
 pub use dynamic::dyn_fuzzy_filter_and_rank as dyn_run;
-pub use scoring_line::ContentFiltering;
 
 use std::collections::HashMap;
 
 use anyhow::Result;
-use fuzzy_filter::{fuzzy_filter_and_rank, Algo, Source};
+use fuzzy_filter::{fuzzy_filter_and_rank, Algo, ContentFiltering, Source};
 use printer::truncate_long_matched_lines;
 
 use icon::{IconPainter, ICON_LEN};

--- a/crates/maple_cli/src/cmd/filter/mod.rs
+++ b/crates/maple_cli/src/cmd/filter/mod.rs
@@ -7,7 +7,8 @@ pub use scoring_line::ContentFiltering;
 use std::collections::HashMap;
 
 use anyhow::Result;
-use fuzzy_filter::{fuzzy_filter_and_rank, truncate_long_matched_lines, Algo, Source};
+use fuzzy_filter::{fuzzy_filter_and_rank, Algo, Source};
+use printer::truncate_long_matched_lines;
 
 use icon::{IconPainter, ICON_LEN};
 

--- a/crates/maple_cli/src/cmd/grep.rs
+++ b/crates/maple_cli/src/cmd/grep.rs
@@ -1,7 +1,7 @@
 use crate::cmd::cache::CacheEntry;
-use crate::cmd::filter::ContentFiltering;
 use crate::light_command::{set_current_dir, LightCommand};
 use crate::utils::{get_cached_entry, is_git_repo, read_first_lines};
+use crate::ContentFiltering;
 use anyhow::{anyhow, Result};
 use fuzzy_filter::{subprocess, Source};
 use icon::{prepend_grep_icon, IconPainter};

--- a/crates/maple_cli/src/cmd/mod.rs
+++ b/crates/maple_cli/src/cmd/mod.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::cmd::filter::ContentFiltering;
+use crate::ContentFiltering;
 use fuzzy_filter::Algo;
 use icon::IconPainter;
 use structopt::clap::AppSettings;

--- a/crates/maple_cli/src/lib.rs
+++ b/crates/maple_cli/src/lib.rs
@@ -23,9 +23,8 @@ macro_rules! print_json_with_length {
 
 pub mod cmd;
 pub use {
-    crate::cmd::filter::ContentFiltering,
     anyhow::Result,
-    fuzzy_filter::{subprocess, Source},
+    fuzzy_filter::{subprocess, ContentFiltering, Source},
     icon::IconPainter,
     structopt::StructOpt,
 };

--- a/crates/printer/Cargo.toml
+++ b/crates/printer/Cargo.toml
@@ -1,26 +1,19 @@
 [package]
-name = "maple_cli"
+name = "printer"
 version = "0.1.0"
 authors = ["Liu-Cheng Xu <xuliuchengxlc@gmail.com>"]
 edition = "2018"
 license = "MIT"
 publish = false
 homepage = "https://github.com/liuchengxu/vim-clap"
-description = "vim-clap external filter gadget"
 
 [dependencies]
-regex = "1"
-rayon = "1.2"
 serde = { package = "serde", version = "1.0",  features = ["derive"] }
-anyhow = "1.0"
-structopt = "0.3"
-bytecount = "0.6"
 serde_json = "1.0"
-lazy_static = "1.4.0"
-fuzzy-matcher = "0.3.1"
-crossbeam-channel = "0.4"
 
 icon = { path = "../icon" }
-printer = { path = "../printer" }
+
+[target.'cfg(not(windows))'.dev-dependencies]
+rayon = "1.2"
+termion = "1.5.1"
 fuzzy_filter = { path = "../fuzzy_filter" }
-extracted_fzy = { path = "../extracted_fzy" }

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -1,0 +1,213 @@
+use std::collections::HashMap;
+
+pub const DOTS: &str = "...";
+
+/// Map of truncated line to original line.
+pub type LinesTruncatedMap = HashMap<String, String>;
+/// Tuple of (matched line text, filtering score, indices of matched elements)
+pub type FuzzyMatchedLineInfo = (String, i64, Vec<usize>);
+
+// https://stackoverflow.com/questions/51982999/slice-a-string-containing-unicode-chars
+#[inline]
+fn utf8_str_slice(line: &str, start: usize, end: usize) -> String {
+    line.chars().take(end).skip(start).collect()
+}
+
+/// Long matched lines can cause the matched items invisible.
+///
+/// [--------------------------]
+///                                              end
+/// [-------------------------------------xx--x---]
+///                     start    winwidth
+/// |~~~~~~~~~~~~~~~~~~[------------------xx--x---]
+///
+///  `start >= indices[0]`
+/// |----------[x-------------------------xx--x---]
+///
+/// |~~~~~~~~~~~~~~~~~~[----------xx--x------------------------------x-----]
+///  `last_idx - start >= winwidth`
+/// |~~~~~~~~~~~~~~~~~~~~~~~~~~~~[xx--x------------------------------x-----]
+///
+pub fn truncate_long_matched_lines<T>(
+    lines: impl IntoIterator<Item = (String, T, Vec<usize>)>,
+    winwidth: usize,
+    starting_point: Option<usize>,
+) -> (Vec<(String, T, Vec<usize>)>, LinesTruncatedMap) {
+    let mut truncated_map = HashMap::new();
+    let lines = lines
+        .into_iter()
+        .map(|(line, score, indices)| {
+            if !indices.is_empty() {
+                let last_idx = indices.last().expect("indices are non-empty; qed");
+                if *last_idx > winwidth {
+                    let mut start = *last_idx - winwidth;
+                    if start >= indices[0] || (indices.len() > 1 && *last_idx - start > winwidth) {
+                        start = indices[0];
+                    }
+                    let line_len = line.len();
+                    // [--------------------------]
+                    // [-----------------------------------------------------------------xx--x--]
+                    for _ in 0..3 {
+                        if indices[0] - start >= DOTS.len() && line_len - start >= winwidth {
+                            start += DOTS.len();
+                        } else {
+                            break;
+                        }
+                    }
+                    let trailing_dist = line_len - last_idx;
+                    if trailing_dist < indices[0] - start {
+                        start += trailing_dist;
+                    }
+                    let end = line.len();
+                    let truncated = if let Some(starting_point) = starting_point {
+                        let icon: String = line.chars().take(starting_point).collect();
+                        start += starting_point;
+                        format!("{}{}{}", icon, DOTS, utf8_str_slice(&line, start, end))
+                    } else {
+                        format!("{}{}", DOTS, utf8_str_slice(&line, start, end))
+                    };
+                    let offset = line_len - truncated.len();
+                    let truncated_indices = indices.iter().map(|x| x - offset).collect::<Vec<_>>();
+                    truncated_map.insert(truncated.clone(), line);
+                    (truncated, score, truncated_indices)
+                } else {
+                    (line, score, indices)
+                }
+            } else {
+                (line, score, indices)
+            }
+        })
+        .collect::<Vec<_>>();
+    (lines, truncated_map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fuzzy_filter::{Algo, Source};
+    use rayon::prelude::*;
+
+    fn wrap_matches(line: &str, indices: &[usize]) -> String {
+        let mut ret = String::new();
+        let mut peekable = indices.iter().peekable();
+        for (idx, ch) in line.chars().enumerate() {
+            let next_id = **peekable.peek().unwrap_or(&&line.len());
+            if next_id == idx {
+                #[cfg(not(target_os = "windows"))]
+                {
+                    ret.push_str(
+                        format!("{}{}{}", termion::style::Invert, ch, termion::style::Reset)
+                            .as_str(),
+                    );
+                }
+
+                #[cfg(target_os = "windows")]
+                {
+                    ret.push_str(format!("~{}~", ch).as_str());
+                }
+
+                peekable.next();
+            } else {
+                ret.push(ch);
+            }
+        }
+
+        ret
+    }
+
+    fn run_test<I: Iterator<Item = String>>(
+        source: Source<I>,
+        query: &str,
+        starting_point: Option<usize>,
+        winwidth: usize,
+    ) {
+        let mut ranked = source.fuzzy_filter(Algo::Fzy, query).unwrap();
+        ranked.par_sort_unstable_by(|(_, v1, _), (_, v2, _)| v2.partial_cmp(&v1).unwrap());
+
+        println!("");
+        println!("query: {:?}", query);
+
+        let (truncated_lines, truncated_map) =
+            truncate_long_matched_lines(ranked, winwidth, starting_point);
+        for (truncated_line, _score, truncated_indices) in truncated_lines.iter() {
+            println!("truncated: {}", "-".repeat(winwidth));
+            println!(
+                "truncated: {}",
+                wrap_matches(&truncated_line, &truncated_indices)
+            );
+            println!("raw_line: {}", truncated_map.get(truncated_line).unwrap());
+        }
+    }
+
+    #[test]
+    fn case1() {
+        let source: Source<_> = vec![
+        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/file.scss".into(),
+        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/another-file.scss"
+            .into(),
+        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/file.js".into(),
+        "directories/are/nested/a/lot/then/the/matched/items/will/be/invisible/another-file.js"
+            .into(),
+    ]
+        .into();
+        let query = "files";
+        run_test(source, query, None, 50usize);
+    }
+
+    #[test]
+    fn case2() {
+        let source: Source<_> = vec![
+        "fuzzy-filter/target/debug/deps/librustversion-b273394e6c9c64f6.dylib.dSYM/Contents/Resources/DWARF/librustversion-b273394e6c9c64f6.dylib".into(),
+        "fuzzy-filter/target/debug/deps/librustversion-15764ff2535f190d.dylib.dSYM/Contents/Resources/DWARF/librustversion-15764ff2535f190d.dylib".into(),
+        "target/debug/deps/libstructopt_derive-3921fbf02d8d2ffe.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-3921fbf02d8d2ffe.dylib".into(),
+        "target/debug/deps/libstructopt_derive-3921fbf02d8d2ffe.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-3921fbf02d8d2ffe.dylib".into(),
+        ].into();
+        let query = "srlisresource";
+        run_test(source, query, None, 50usize);
+    }
+
+    #[test]
+    fn case3() {
+        let source: Source<_> = vec![
+        "/Users/xuliucheng/Library/Caches/Homebrew/universal-ctags--git/Units/afl-fuzz.r/github-issue-625-r.d/input.r".into()
+        ].into();
+        let query = "srcggithub";
+        run_test(source, query, None, 50usize);
+    }
+
+    #[test]
+    fn case4() {
+        let source: Source<_> = vec![
+            "        // Wait until propagation delay period after block we plan to mine on".into(),
+        ]
+        .into();
+        let query = "bmine";
+        run_test(source, query, None, 58usize);
+    }
+
+    #[test]
+    fn starting_point_should_work() {
+        let source: Source<_> = vec![
+          " crates/fuzzy_filter/target/debug/deps/librustversion-15764ff2535f190d.dylib.dSYM/Contents/Resources/DWARF/librustversion-15764ff2535f190d.dylib".into(),
+          " crates/fuzzy_filter/target/debug/deps/libstructopt_derive-5cce984f248086cc.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-5cce984f248086cc.dylib".into()
+        ].into();
+        let query = "srlisrlisrsr";
+        run_test(source, query, Some(2), 50usize);
+
+        let source: Source<_> = vec![
+          "crates/fuzzy_filter/target/debug/deps/librustversion-15764ff2535f190d.dylib.dSYM/Contents/Resources/DWARF/librustversion-15764ff2535f190d.dylib".into(),
+          "crates/fuzzy_filter/target/debug/deps/libstructopt_derive-5cce984f248086cc.dylib.dSYM/Contents/Resources/DWARF/libstructopt_derive-5cce984f248086cc.dylib".into()
+        ].into();
+        let query = "srlisrlisrsr";
+        run_test(source, query, None, 50usize);
+    }
+
+    #[test]
+    fn test_print_multibyte_string_slice() {
+        let multibyte_str = "README.md:23:1:Gourinath Banda. “Scalable Real-Time Kernel for Small Embedded Systems”. En- glish. PhD thesis. Denmark: University of Southern Denmark, June 2003. URL: http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=84D11348847CDC13691DFAED09883FCB?doi=10.1.1.118.1909&rep=rep1&type=pdf.";
+        let start = 33;
+        let end = 300;
+        // println!("{}", &multibyte_str[33..300]);
+        println!("{}", utf8_str_slice(multibyte_str, start, end));
+    }
+}

--- a/doc/clap-support.txt
+++ b/doc/clap-support.txt
@@ -60,6 +60,10 @@ Supported Providers & Tools                                    *clap-support*
                          the git base directory or `getcwd()` . For example,
                          use `Clap files ..` to search files under the parent directory.
 
+                         `:Clap files +name-only` to filer the file name
+                         instead of the full file path. Require you have built
+                         the Python dynamic module or in the cache mode.
+
 
                                                      *:Clap-filetypes*
 :Clap filetypes          List File types.

--- a/pythonx/clap/fuzzymatch-rs/Cargo.lock
+++ b/pythonx/clap/fuzzymatch-rs/Cargo.lock
@@ -160,7 +160,9 @@ dependencies = [
  "anyhow",
  "extracted_fzy",
  "fuzzy-matcher",
+ "lazy_static",
  "rayon",
+ "regex",
  "structopt",
 ]
 

--- a/pythonx/clap/fuzzymatch-rs/Cargo.lock
+++ b/pythonx/clap/fuzzymatch-rs/Cargo.lock
@@ -170,6 +170,7 @@ version = "0.1.0"
 dependencies = [
  "extracted_fzy",
  "fuzzy_filter",
+ "printer",
  "pyo3",
 ]
 
@@ -200,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "icon"
+version = "0.1.0"
+dependencies = [
+ "lazy_static",
+ "regex",
+ "structopt",
 ]
 
 [[package]]
@@ -358,6 +368,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "printer"
+version = "0.1.0"
+dependencies = [
+ "icon",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/pythonx/clap/fuzzymatch-rs/Cargo.toml
+++ b/pythonx/clap/fuzzymatch-rs/Cargo.toml
@@ -18,6 +18,9 @@ version = "0.9.1"
 [dependencies.extracted_fzy]
 path = "../../../crates/extracted_fzy"
 
+[dependencies.printer]
+path = "../../../crates/printer"
+
 [dependencies.fuzzy_filter]
 path = "../../../crates/fuzzy_filter"
 default-features = false

--- a/pythonx/clap/fuzzymatch-rs/src/lib.rs
+++ b/pythonx/clap/fuzzymatch-rs/src/lib.rs
@@ -1,7 +1,7 @@
 #![feature(pattern)]
 
 use extracted_fzy::match_and_score_with_positions;
-use fuzzy_filter::truncate_long_matched_lines;
+use printer::truncate_long_matched_lines;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use std::collections::HashMap;

--- a/pythonx/clap/fzy.py
+++ b/pythonx/clap/fzy.py
@@ -5,24 +5,40 @@ import vim
 from clap.scorer import fzy_scorer, substr_scorer
 
 
-def apply_score(scorer, query, candidates):
+def str2bool(v):
+    #  For neovim, vim.eval("a:enable_icon") is str
+    #  For vim, vim.eval("a:enable_icon") is bool
+    if isinstance(v, bool):
+        return v
+    else:
+        return v.lower() in ("yes", "true", "t", "1")
+
+
+def apply_score(scorer, query, candidates, enable_icon):
     scored = []
 
     for c in candidates:
-        score, indices = scorer(query, c)
+        #  Skip two chars
+        if enable_icon:
+            candidate = c[2:]
+        else:
+            candidate = c
+        score, indices = scorer(query, candidate)
         if score != float("-inf"):
+            if enable_icon:
+                indices = [x + 4 for x in indices]
             scored.append({'score': score, 'indices': indices, 'text': c})
 
     return scored
 
 
-def fuzzy_match_py(query, candidates):
+def fuzzy_match_py(query, candidates, enable_icon):
     if ' ' in query:
         scorer = substr_scorer
     else:
         scorer = fzy_scorer
 
-    scored = apply_score(scorer, query, candidates)
+    scored = apply_score(scorer, query, candidates, enable_icon)
     ranked = sorted(scored, key=lambda x: x['score'], reverse=True)
 
     indices = []
@@ -35,19 +51,12 @@ def fuzzy_match_py(query, candidates):
 
 
 def clap_fzy_py():
-    return fuzzy_match_py(vim.eval("a:query"), vim.eval("a:candidates"))
+    return fuzzy_match_py(vim.eval("a:query"), vim.eval("a:candidates"),
+                          str2bool(vim.eval("a:enable_icon")))
 
 
 try:
     from clap.fuzzymatch_rs import fuzzy_match as fuzzy_match_rs
-
-    def str2bool(v):
-        #  For neovim, vim.eval("a:enable_icon") is str
-        #  For vim, vim.eval("a:enable_icon") is bool
-        if isinstance(v, bool):
-            return v
-        else:
-            return v.lower() in ("yes", "true", "t", "1")
 
     def clap_fzy_rs():
         return fuzzy_match_rs(vim.eval("a:query"), vim.eval("a:candidates"),

--- a/pythonx/clap/fzy.py
+++ b/pythonx/clap/fzy.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import vim
-
 from clap.scorer import fzy_scorer, substr_scorer
 
 
@@ -53,6 +52,7 @@ try:
     def clap_fzy_rs():
         return fuzzy_match_rs(vim.eval("a:query"), vim.eval("a:candidates"),
                               int(vim.eval("a:winwidth")),
-                              str2bool(vim.eval("a:enable_icon")))
+                              str2bool(vim.eval("a:enable_icon")),
+                              vim.eval("a:content_filtering"))
 except Exception:
     pass

--- a/release.sh
+++ b/release.sh
@@ -44,6 +44,7 @@ else
   echo 'Now run git diff to check again, then commit and tag a new version:'
   echo '    git add -u' > publish.sh
   echo "    git commit -m $next_tag" >> publish.sh
+  echo "    git push origin master" >> publish.sh
   echo "    git tag $next_tag" >> publish.sh
   echo "    git push origin $next_tag" >> publish.sh
   echo 'Run `bash publish.sh` to publish this new release'


### PR DESCRIPTION
Also support filter the file name only. You have to use the python dynamic module, or you are using the cached content with dyn filter, `:Clap files +name-only`.

`:Clap files`:

<img width="1134" alt="截屏2020-04-12 下午4 29 07" src="https://user-images.githubusercontent.com/8850248/79064368-dcf54e00-7cda-11ea-86cb-901fe3e16f77.png">

`:Clap files +name-only`:

<img width="1129" alt="截屏2020-04-12 下午4 28 53" src="https://user-images.githubusercontent.com/8850248/79064371-e7afe300-7cda-11ea-8902-2f475fc4c213.png">

Close #379

Also tweak the icon highlight offset on Python and Rust side instead of inside vim.