### PR TITLE
feat(git_diff_files): Enable Git Diff Preview

### DIFF
--- a/autoload/clap/provider/git_diff_files.vim
+++ b/autoload/clap/provider/git_diff_files.vim
@@ -21,8 +21,15 @@ function! s:git_diff_files.source() abort
   endif
 endfunction
 
+function! s:git_diff_files_on_move() abort
+  let filediff = systemlist('git diff '.g:clap.display.getcurline())
+  call g:clap.preview.show(filediff)
+  call g:clap.preview.set_syntax('diff')
+endfunction
+
 let s:git_diff_files.sink = 'e'
 let s:git_diff_files.enable_rooter = v:true
+let s:git_diff_files.on_move = function('s:git_diff_files_on_move')
 
 let g:clap#provider#git_diff_files# = s:git_diff_files
 


### PR DESCRIPTION
- Enable `git diff` preview for `on_move` for `git_diff_files` provider.
- Set function as local variable if need to extend to `on_enter` event.