### PR TITLE
fix(git_diff_files): Fix Diff Preview Height

### DIFF
--- a/autoload/clap/provider/git_diff_files.vim
+++ b/autoload/clap/provider/git_diff_files.vim
@@ -28,7 +28,7 @@ function! s:git_diff_files_on_move() abort
   let command = systemlist(diff.' '.filediff)
 
   if !empty(command)
-    if command[0]=~#"^fatal"
+    if command[0]=~#'^fatal'
       let command = systemlist(diff.' -- '.filediff)
       if empty(command)
         let command = systemlist(diff.' --cached -- '.filediff)

--- a/autoload/clap/provider/git_diff_files.vim
+++ b/autoload/clap/provider/git_diff_files.vim
@@ -23,8 +23,7 @@ endfunction
 
 function! s:git_diff_files_on_move() abort
   let diff = 'git --no-pager diff -U0'
-  let pipetail = '| tail -n +5'
-  let filediff = g:clap.display.getcurline().pipetail
+  let filediff = g:clap.display.getcurline()
   let command = systemlist(diff.' '.filediff)
 
   if !empty(command)
@@ -39,7 +38,7 @@ function! s:git_diff_files_on_move() abort
   endif
 
   if !empty(command)
-    call g:clap.preview.show(command[:10])
+    call g:clap.preview.show(command[:15])
   else
     call g:clap.preview.show([''])
   endif

--- a/autoload/clap/provider/git_diff_files.vim
+++ b/autoload/clap/provider/git_diff_files.vim
@@ -22,8 +22,27 @@ function! s:git_diff_files.source() abort
 endfunction
 
 function! s:git_diff_files_on_move() abort
-  let filediff = systemlist('git diff '.g:clap.display.getcurline())
-  call g:clap.preview.show(filediff)
+  let diff = 'git --no-pager diff -U0'
+  let pipetail = '| tail -n +5'
+  let filediff = g:clap.display.getcurline().pipetail
+  let command = systemlist(diff.' '.filediff)
+
+  if !empty(command)
+    if command[0]=~#"^fatal"
+      let command = systemlist(diff.' -- '.filediff)
+      if empty(command)
+        let command = systemlist(diff.' --cached -- '.filediff)
+      endif
+    endif
+  else
+    let command = systemlist(diff.' --cached '.filediff)
+  endif
+
+  if !empty(command)
+    call g:clap.preview.show(command[:10])
+  else
+    call g:clap.preview.show([''])
+  endif
   call g:clap.preview.set_syntax('diff')
 endfunction
 


### PR DESCRIPTION
fixes #401

- Enable max height for preview window
  - https://github.com/liuchengxu/vim-clap/issues/401#issuecomment-614634857
- Truncate git index using `tail`
- Truncate amount of lines displayed in unified format using `-U0`
- Check for multiple types of diff types
  - Modified
  - Deleted staged and unstaged
  - Added staged and unstaged
  - Added or deleted with no content
  - Comparing tip and index with current branch
    - ` --cached file`
    - ` -- file`