### PR TITLE
Fix default to nospell in display and preview windows

### DIFF
--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -58,6 +58,7 @@ function! g:clap#floating_win#display.open() abort
   silent let s:display_winid = nvim_open_win(s:display_bufnr, v:true, s:display_opts)
 
   call setwinvar(s:display_winid, '&winhl', s:display_winhl)
+  call setwinvar(s:display_winid, '&spell', 0)
   call matchadd('ClapNoMatchesFound', g:__clap_no_matches_pattern, 10, 1001, {'window': s:display_winid})
   " call setwinvar(s:display_winid, '&winblend', 15)
 
@@ -276,6 +277,7 @@ function! s:create_preview_win(height) abort
   endif
   silent let s:preview_winid = nvim_open_win(s:preview_bufnr, v:false, opts)
 
+  call setwinvar(s:preview_winid, '&spell', 0)
   call setwinvar(s:preview_winid, '&winhl', s:preview_winhl)
   " call setwinvar(s:preview_winid, '&winblend', 15)
 

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -52,6 +52,7 @@ function! s:create_display() abort
 
     let g:clap#popup#display.width = s:display_opts.width
 
+    call setwinvar(s:display_winid, '&spell', 0)
     call win_execute(s:display_winid, 'call s:execute_in_display()')
     call popup_hide(s:display_winid)
 
@@ -126,6 +127,7 @@ function! s:create_preview() abort
       let preview_opts.maxwidth -= 2
     endif
     let s:preview_winid = popup_create([], preview_opts)
+    call setwinvar(s:preview_winid, '&spell', 0)
     call popup_hide(s:preview_winid)
     call win_execute(s:preview_winid, 'setlocal nonumber')
     let g:clap#popup#preview.winid = s:preview_winid


### PR DESCRIPTION
a18bcf3 only partially fixes #400; this PR also defaults to `nospell` for the display and preview windows.