### PR TITLE
Fix binary installation on Windows

### DIFF
--- a/autoload/clap/installer.vim
+++ b/autoload/clap/installer.vim
@@ -7,7 +7,7 @@ set cpoptions&vim
 let s:plugin_root_dir = fnamemodify(g:clap#autoload_dir, ':h')
 
 function! s:run_term(cmd, cwd, success_info) abort
-  10new belowright bottom
+  belowright 10new bottom
   setlocal buftype=nofile winfixheight norelativenumber nonumber bufhidden=wipe
 
   function! s:OnExit(status) closure abort
@@ -106,7 +106,7 @@ endfunction
 
 function! clap#installer#download_binary() abort
   if has('win32')
-    let cmd = 'Powershell.exe -File '.s:plugin_root_dir.'\install.ps1'
+    let cmd = 'Powershell.exe -ExecutionPolicy ByPass -File "'.s:plugin_root_dir.'\install.ps1"'
   else
     let cmd = './install.sh'
   endif

--- a/autoload/clap/installer.vim
+++ b/autoload/clap/installer.vim
@@ -7,8 +7,10 @@ set cpoptions&vim
 let s:plugin_root_dir = fnamemodify(g:clap#autoload_dir, ':h')
 
 function! s:run_term(cmd, cwd, success_info) abort
-  belowright 10new bottom
+  belowright 10new
   setlocal buftype=nofile winfixheight norelativenumber nonumber bufhidden=wipe
+
+  let bufnr = bufnr('')
 
   function! s:OnExit(status) closure abort
     if a:status == 0
@@ -29,8 +31,6 @@ function! s:run_term(cmd, cwd, success_info) abort
           \ 'exit_cb': {job, status -> s:OnExit(status)},
           \})
   endif
-
-  let bufnr = bufnr('')
 
   normal! G
 

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -16,10 +16,10 @@ let s:maple_bin_prebuilt = fnamemodify(g:clap#autoload_dir, ':h').'/bin/maple'.s
 
 " Check the local built.
 if executable(s:maple_bin_localbuilt)
-  let s:maple_bin = s:maple_bin_localbuilt
+  let s:maple_bin = '"' . s:maple_bin_localbuilt . '"'
 " Check the prebuilt binary.
 elseif executable(s:maple_bin_prebuilt)
-  let s:maple_bin = s:maple_bin_prebuilt
+  let s:maple_bin = '"' . s:maple_bin_prebuilt . '"'
 elseif executable('maple')
   let s:maple_bin = 'maple'
 else

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -240,7 +240,7 @@ function! clap#maple#ripgrep_forerunner_subcommand() abort
     let global_opt .= ' --no-cache'
   endif
 
-  return printf('%s %s ripgrep-forerunner --cmd-dir %s', s:maple_bin, global_opt, clap#rooter#working_dir())
+  return printf('%s %s ripgrep-forerunner --cmd-dir "%s"', s:maple_bin, global_opt, clap#rooter#working_dir())
 endfunction
 
 function! clap#maple#blines_subcommand(query) abort

--- a/install.ps1
+++ b/install.ps1
@@ -5,6 +5,8 @@ $APP = 'maple'
 $url = "https://github.com/liuchengxu/vim-clap/releases/download/$version/$APP-"
 $output = "$PSScriptRoot\bin\$APP.exe"
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 if ([Environment]::Is64BitOperatingSystem) {
   $url += 'x86_64-pc-windows-msvc'
 } else {


### PR DESCRIPTION
Fix #404 

- Quote the path to install.ps1 so that it will handle spaces correctly.
- Add `-ExecutionPolicy ByPass`  as a parameter to powershell to be able to execute powershell script when by default win10 prevent you to do this.
- Add Tls12 to security protocol to be able to download the pre-built binary.