### PR TITLE
Use List instead of String in job cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## [unreleased]
 
+### Fixed
+
+- When cmd in `job(cmd)` is a String, the path containing spaces could be problematic on Windows(GVim). Use List instead. ([#407](https://github.com/liuchengxu/vim-clap/pull/407))
+
 ## [0.13] 2020-04-20
 
 ### Added

--- a/autoload/clap/debugging.vim
+++ b/autoload/clap/debugging.vim
@@ -46,7 +46,8 @@ function! clap#debugging#info() abort
 
   if maple_binary isnot v:null
     echohl Type | echo '           maple info: ' | echohl NONE
-    let maple_version = system(maple_binary.' version')
+    " Note: maple_binary has to be quoted, otherwise error happens when the path contains spaces.
+    let maple_version = system(printf('"%s" version', maple_binary))
     if v:shell_error
       echohl Normal | echon 'fail to fetch version info' | echohl NONE
     else

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -18,11 +18,7 @@ function! s:jobstop() abort
 endfunction
 
 function! s:put_raw_lines(lines) abort
-  if s:has_converter
-    let lines = map(a:lines, 's:Converter(v:val)')
-  else
-    let lines = a:lines
-  endif
+  let lines = s:Converter isnot v:null ? map(a:lines, 's:Converter(v:val)') : a:lines
 
   " Set or append lines
   if s:did_set_lines
@@ -268,18 +264,13 @@ function! s:prepare_job_start(cmd) abort
   let s:cache_size = 0
   let s:loaded_size = 0
   let s:dropped_size = 0
+  let s:vim_output = []
   let g:clap.display.cache = []
-  let s:preload_is_complete = v:false
   let s:did_set_lines = v:false
+  let s:preload_is_complete = v:false
 
   let s:cmd = a:cmd
-
-  let s:vim_output = []
-
-  let s:has_converter = has_key(g:clap.provider._(), 'converter')
-  if s:has_converter
-    let s:Converter = g:clap.provider._().converter
-  endif
+  let s:Converter = has_key(g:clap.provider._(), 'converter') ? g:clap.provider._().converter : v:null
 endfunction
 
 function! s:job_strart_with_delay() abort

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -218,7 +218,6 @@ else
   endfunction
 
   function! s:job_start(cmd) abort
-    " let job = job_start(clap#job#wrap_cmd(a:cmd), {
     let job = job_start(a:cmd, {
           \ 'in_io': 'null',
           \ 'err_cb': function('s:err_cb'),

--- a/autoload/clap/dispatcher.vim
+++ b/autoload/clap/dispatcher.vim
@@ -218,7 +218,8 @@ else
   endfunction
 
   function! s:job_start(cmd) abort
-    let job = job_start(clap#job#wrap_cmd(a:cmd), {
+    " let job = job_start(clap#job#wrap_cmd(a:cmd), {
+    let job = job_start(a:cmd, {
           \ 'in_io': 'null',
           \ 'err_cb': function('s:err_cb'),
           \ 'out_cb': function('s:out_cb'),

--- a/autoload/clap/filter/async/dyn.vim
+++ b/autoload/clap/filter/async/dyn.vim
@@ -48,7 +48,7 @@ function! clap#filter#async#dyn#from_tempfile(tempfile) abort
 endfunction
 
 function! s:grep_cmd_common() abort
-  return ['--number', s:DYN_ITEMS_TO_SHOW, '--winwidth', winwidth(g:clap.display.winid), 'grep', '', g:clap.input.get()]
+  return ['--number', s:DYN_ITEMS_TO_SHOW, '--winwidth', winwidth(g:clap.display.winid), 'grep', '""', g:clap.input.get()]
 endfunction
 
 function! clap#filter#async#dyn#start_grep() abort

--- a/autoload/clap/filter/async/dyn.vim
+++ b/autoload/clap/filter/async/dyn.vim
@@ -48,7 +48,7 @@ function! clap#filter#async#dyn#from_tempfile(tempfile) abort
 endfunction
 
 function! s:grep_cmd_common() abort
-  return ['--number', s:DYN_ITEMS_TO_SHOW, '--winwidth', winwidth(g:clap.display.winid), 'grep', '""', g:clap.input.get()]
+  return ['--number', s:DYN_ITEMS_TO_SHOW, '--winwidth', winwidth(g:clap.display.winid), 'grep', g:clap.input.get()]
 endfunction
 
 function! clap#filter#async#dyn#start_grep() abort

--- a/autoload/clap/filter/async/dyn.vim
+++ b/autoload/clap/filter/async/dyn.vim
@@ -30,53 +30,42 @@ function! clap#filter#async#dyn#from_tempfile(tempfile) abort
   let s:last_query = g:clap.input.get()
 
   if g:clap_enable_icon && index(['files', 'git_files'], g:clap.provider.id) > -1
-    let enable_icon_opt = '--icon-painter=File'
+    let enable_icon_opt = ['--icon-painter=File']
   else
-    let enable_icon_opt = ''
+    let enable_icon_opt = []
   endif
 
   if g:clap.provider.id ==# 'files' && has_key(g:clap.context, 'name-only')
-    let content_filtering = '--content-filtering=FileNameOnly'
+    let content_filtering = ['--content-filtering=FileNameOnly']
   elseif g:clap.provider.id ==# 'proj_tags'
-    let content_filtering = '--content-filtering=TagNameOnly'
+    let content_filtering = ['--content-filtering=TagNameOnly']
   else
-    let content_filtering = ''
+    let content_filtering = []
   endif
 
-  let filter_cmd = printf('%s --number %d --winwidth %d filter "%s" --input "%s" %s',
-        \ enable_icon_opt,
-        \ s:DYN_ITEMS_TO_SHOW,
-        \ winwidth(g:clap.display.winid),
-        \ g:clap.input.get(),
-        \ a:tempfile,
-        \ content_filtering,
-        \ )
-  call clap#job#stdio#start_service(function('s:handle_message'), clap#maple#build_cmd(filter_cmd))
+  let filter_cmd = clap#maple#build_cmd_list(enable_icon_opt + ['--number', s:DYN_ITEMS_TO_SHOW, '--winwidth', winwidth(g:clap.display.winid), 'filter', g:clap.input.get(), '--input', a:tempfile] + content_filtering)
+  call clap#job#stdio#start_service(function('s:handle_message'), filter_cmd)
+endfunction
+
+function! s:grep_cmd_common() abort
+  return ['--number', s:DYN_ITEMS_TO_SHOW, '--winwidth', winwidth(g:clap.display.winid), 'grep', '', g:clap.input.get()]
 endfunction
 
 function! clap#filter#async#dyn#start_grep() abort
   let s:last_query = g:clap.input.get()
-  let grep_cmd = printf('%s --number %d --winwidth %d grep "" "%s" --cmd-dir "%s"',
-        \ g:clap_enable_icon ? '--icon-painter=Grep' : '',
-        \ s:DYN_ITEMS_TO_SHOW,
-        \ winwidth(g:clap.display.winid),
-        \ g:clap.input.get(),
-        \ clap#rooter#working_dir(),
-        \ )
-  call clap#job#stdio#start_service(function('s:handle_message'), clap#maple#build_cmd(grep_cmd))
+  let subcmd = g:clap_enable_icon ? ['--icon-painter=Grep'] : []
+  let grep_cmd = clap#maple#build_cmd_list(subcmd + s:grep_cmd_common() + ['--cmd-dir', clap#rooter#working_dir()])
+  call clap#job#stdio#start_service(function('s:handle_message'), grep_cmd)
 endfunction
 
 function! clap#filter#async#dyn#grep_from_cache(tempfile) abort
   let s:last_query = g:clap.input.get()
-  let grep_cmd = printf('%s %s --number %d --winwidth %d grep "" "%s" --input "%s"',
-        \ g:clap_enable_icon ? '--icon-painter=Grep' : '',
-        \ has_key(g:clap.context, 'no-cache') ? '--no-cache' : '',
-        \ s:DYN_ITEMS_TO_SHOW,
-        \ winwidth(g:clap.display.winid),
-        \ g:clap.input.get(),
-        \ a:tempfile
-        \ )
-  call clap#job#stdio#start_service(function('s:handle_message'), clap#maple#build_cmd(grep_cmd))
+  let subcmd = g:clap_enable_icon ? ['--icon-painter=Grep'] : []
+  if has_key(g:clap.context, 'no-cache')
+    call add(subcmd, '--no-cache')
+  endif
+  let grep_cmd = clap#maple#build_cmd_list(subcmd + s:grep_cmd_common() + ['--input', a:tempfile])
+  call clap#job#stdio#start_service(function('s:handle_message'), grep_cmd)
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/filter/async/external.vim
+++ b/autoload/clap/filter/async/external.vim
@@ -48,7 +48,7 @@ endfunction
 
 function! s:cmd_of(ext_filter) abort
   if a:ext_filter ==# 'maple'
-    return clap#maple#sync_filter_subcommand(g:clap.input.get())
+    return clap#maple#sync_filter_command(g:clap.input.get())
   else
     return printf(s:ext_cmd[a:ext_filter], g:clap.input.get())
   endif

--- a/autoload/clap/filter/sync/viml.vim
+++ b/autoload/clap/filter/sync/viml.vim
@@ -9,11 +9,7 @@ let s:pattern_builder = {}
 
 function! s:pattern_builder._force_case() abort
   " Smart case
-  if self.input =~? '\u'
-    return '\C'
-  else
-    return '\c'
-  endif
+  return self.input =~? '\u' ? '\C' : '\c'
 endfunction
 
 function! s:pattern_builder.smartcase() abort

--- a/autoload/clap/forerunner.vim
+++ b/autoload/clap/forerunner.vim
@@ -141,19 +141,19 @@ else
 endif
 
 if clap#maple#is_available()
-  function! s:run_maple_subcommand(sub_cmd) abort
+  function! s:run_maple_command(sub_cmd) abort
     let s:chunks = []
     let g:__clap_current_forerunner_status = g:clap_forerunner_status_sign.running
     call clap#spinner#refresh()
     call s:start_maple(a:sub_cmd)
   endfunction
 
-  function! clap#forerunner#start_subcommand(cmd) abort
-    call s:run_maple_subcommand(a:cmd)
+  function! clap#forerunner#start_command(cmd) abort
+    call s:run_maple_command(a:cmd)
   endfunction
 
   function! clap#forerunner#start(cmd) abort
-    call s:run_maple_subcommand(clap#maple#forerunner_exec_subcommand(a:cmd))
+    call s:run_maple_command(clap#maple#forerunner_exec_command(a:cmd))
   endfunction
 else
   function! clap#forerunner#start(cmd) abort

--- a/autoload/clap/highlight.vim
+++ b/autoload/clap/highlight.vim
@@ -129,8 +129,7 @@ function! clap#highlight#matchadd_substr(patterns) abort
 
   " As most 8 submatches, ClapMatches[1-8]
   try
-    call map(a:patterns[1:8],
-          \ {key, val -> add(w:clap_match_ids, matchadd('ClapMatches'.(key+1), val, s:default_priority -1))})
+    call map(a:patterns[1:8], 'add(w:clap_match_ids, matchadd("ClapMatches".(v:key+1), v:val, s:default_priority - 1))')
   catch
     return
   endtry

--- a/autoload/clap/impl.vim
+++ b/autoload/clap/impl.vim
@@ -98,10 +98,7 @@ function! s:on_typed_async_impl() abort
 
   if clap#filter#async#external#using_maple()
     if g:clap.provider.id ==# 'blines'
-      let source_file = expand('#'.g:clap.start.bufnr.':p')
-      let blines_cmd = clap#maple#blines_subcommand(g:clap.input.get())
-      let maple_cmd = printf('%s %s', blines_cmd, source_file)
-      call clap#filter#async#dyn#start_directly(maple_cmd)
+      call clap#filter#async#dyn#start_directly(clap#maple#blines_command())
       return
     endif
 

--- a/autoload/clap/job.vim
+++ b/autoload/clap/job.vim
@@ -37,6 +37,7 @@ else
     return ch_info(job_getchannel(a:job))['id']
   endfunction
 
+  " wrap_cmd is only neccessary when cmd is a String, otherwise vim panics.
   if has('win32')
     function! clap#job#wrap_cmd(cmd) abort
       return &shell . ' ' . &shellcmdflag . ' ' . a:cmd
@@ -47,8 +48,8 @@ else
     endfunction
   endif
 
-  function! clap#job#start_buffered(cmd, CloseCallback) abort
-    let job = job_start(clap#job#wrap_cmd(a:cmd), {
+  function! clap#job#start_buffered(cmd_list, CloseCallback) abort
+    let job = job_start(a:cmd_list, {
           \ 'in_io': 'null',
           \ 'close_cb': a:CloseCallback,
           \ 'noblock': 1,

--- a/autoload/clap/job/stdio.vim
+++ b/autoload/clap/job/stdio.vim
@@ -59,10 +59,10 @@ if has('nvim')
         call s:handle_stdout(a:data)
       elseif a:event ==# 'stderr'
         " Ignore the error
-        " if a:data == ['']
-          " return
-        " endif
-        " call clap#helper#echo_error('on_event:'.string(a:data))
+        if a:data == ['']
+          return
+        endif
+        call clap#helper#echo_error('on_event:'.string(a:data))
       endif
     endif
   endfunction
@@ -140,15 +140,10 @@ endfunction
 function! clap#job#stdio#start_dyn_filter_service(MessageHandler, cmd) abort
   let s:MessageHandler = a:MessageHandler
 
-  let filter_cmd = printf('%s --number 100 --winwidth %d filter "%s" --cmd "%s" --cmd-dir "%s"',
-        \ g:clap_enable_icon ? '--icon-painter=File' : '',
-        \ winwidth(g:clap.display.winid),
-        \ g:clap.input.get(),
-        \ a:cmd,
-        \ clap#rooter#working_dir(),
-        \ )
+  let filter_cmd = g:clap_enable_icon ? ['--icon-painter=File'] : []
+  let filter_cmd += ['--number', '100', '--winwidth', winwidth(g:clap.display.winid), 'filter', g:clap.input.get(), '--cmd', a:cmd, '--cmd-dir', clap#rooter#working_dir()]
 
-  call s:start_service_job(clap#maple#build_cmd(filter_cmd))
+  call s:start_service_job(clap#maple#build_cmd_list(filter_cmd))
   return
 endfunction
 

--- a/autoload/clap/job/stdio.vim
+++ b/autoload/clap/job/stdio.vim
@@ -101,9 +101,9 @@ else
     endif
   endfunction
 
-  function! s:start_service_job(cmd) abort
+  function! s:start_service_job(cmd_list) abort
     call clap#job#stdio#stop_service()
-    let s:job = job_start(clap#job#wrap_cmd(a:cmd), {
+    let s:job = job_start(a:cmd_list, {
           \ 'err_cb': function('s:err_cb'),
           \ 'out_cb': function('s:out_cb'),
           \ 'noblock': 1,

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -16,10 +16,10 @@ let s:maple_bin_prebuilt = fnamemodify(g:clap#autoload_dir, ':h').'/bin/maple'.s
 
 " Check the local built.
 if executable(s:maple_bin_localbuilt)
-  let s:maple_bin = '"' . s:maple_bin_localbuilt . '"'
+  let s:maple_bin = s:maple_bin_localbuilt
 " Check the prebuilt binary.
 elseif executable(s:maple_bin_prebuilt)
-  let s:maple_bin = '"' . s:maple_bin_prebuilt . '"'
+  let s:maple_bin = s:maple_bin_prebuilt
 elseif executable('maple')
   let s:maple_bin = 'maple'
 else
@@ -178,105 +178,87 @@ endfunction
 
 let s:can_enable_icon = ['files', 'git_files']
 
-function! clap#maple#get_enable_icon_opt() abort
+function! clap#maple#forerunner_exec_command(cmd) abort
+  " No global --number option.
   if g:clap_enable_icon
         \ && index(s:can_enable_icon, g:clap.provider.id) > -1
-    return '--icon-painter=File'
+    let global_opt = ['--icon-painter=File']
   else
-    return ''
+    let global_opt = []
   endif
-endfunction
-
-function! clap#maple#forerunner_exec_subcommand(cmd) abort
-  " No global --number option.
-  let global_opt = clap#maple#get_enable_icon_opt()
 
   if has_key(g:clap.context, 'no-cache')
-    let global_opt .= ' --no-cache'
+    call add(global_opt, '--no-cache')
   endif
 
-  let subcommand = printf('exec "%s" --cmd-dir "%s" --output-threshold %d',
-        \ a:cmd,
-        \ clap#rooter#working_dir(),
-        \ clap#filter#capacity(),
-        \ )
+  let subcommand = ['exec', a:cmd, '--cmd-dir', clap#rooter#working_dir(), '--output-threshold', clap#filter#capacity()]
 
-  return printf('%s %s %s', s:maple_bin, global_opt, subcommand)
+  return [s:maple_bin] + global_opt + subcommand
 endfunction
 
 " Returns the filtered results after the input stream is complete.
-function! clap#maple#sync_filter_subcommand(query) abort
-  let global_opt = '--number '.g:clap.display.preload_capacity.' --winwidth '.winwidth(g:clap.display.winid)
+function! clap#maple#sync_filter_command(query) abort
+  let global_opt = ['--number', g:clap.display.preload_capacity, '--winwidth', winwidth(g:clap.display.winid)]
 
   if g:clap.provider.id ==# 'files' && g:clap_enable_icon
-    let global_opt .= ' --icon-painter=File'
+    call add(global_opt, '--icon-painter=File')
   endif
 
-  let cmd = printf('%s %s filter "%s" --sync', s:maple_bin, global_opt, a:query)
-
-  return cmd
+  return [s:maple_bin] + global_opt + ['filter', a:query, '--sync']
 endfunction
 
-function! clap#maple#tags_forerunner_subcommand() abort
-  if has_key(g:clap.context, 'no-cache')
-    let global_opt = ' --no-cache'
-  else
-    let global_opt = ''
-  endif
-
-  return printf('%s %s tags "" "%s" --forerunner', s:maple_bin, global_opt, clap#rooter#working_dir())
+function! clap#maple#tags_forerunner_command() abort
+  let global_opt = has_key(g:clap.context, 'no-cache') ? ['--no-cache'] : []
+  return [s:maple_bin] + global_opt + ['tags', '', clap#rooter#working_dir(), '--forerunner']
 endfunction
 
-function! clap#maple#ripgrep_forerunner_subcommand() abort
-  " let global_opt = '--number '.g:clap.display.preload_capacity
+function! clap#maple#ripgrep_forerunner_command() abort
   " TODO: add max_output
-  if g:clap_enable_icon
-    let global_opt = '--icon-painter=Grep'
-  else
-    let global_opt = ''
-  endif
+  let global_opt = g:clap_enable_icon ? ['--icon-painter=Grep'] : []
 
   if has_key(g:clap.context, 'no-cache')
-    let global_opt .= ' --no-cache'
+    call add(global_opt, '--no-cache')
   endif
 
-  return printf('%s %s ripgrep-forerunner --cmd-dir "%s"', s:maple_bin, global_opt, clap#rooter#working_dir())
+  return [s:maple_bin] + global_opt + ['ripgrep-forerunner', '--cmd-dir', clap#rooter#working_dir()]
 endfunction
 
-function! clap#maple#blines_subcommand(query) abort
-  let global_opt = '--number '.g:clap.display.preload_capacity.' --winwidth '.winwidth(g:clap.display.winid)
-  return printf('%s %s blines "%s"', s:maple_bin, global_opt, a:query)
+function! clap#maple#blines_command() abort
+  let blines_subcmd = ['--number', g:clap.display.preload_capacity, '--winwidth', winwidth(g:clap.display.winid), 'blines', g:clap.input.get(), expand('#'.g:clap.start.bufnr.':p')]
+  return [s:maple_bin] + blines_subcmd
 endfunction
 
 function! clap#maple#run_exec(cmd) abort
-  let global_opt = '--number '.g:clap.display.preload_capacity
+  let global_opt = ['--number', g:clap.display.preload_capacity]
   if g:clap.provider.id ==# 'files' && g:clap_enable_icon
-    let global_opt .= ' --icon-painter=File'
+    call add(global_opt, '--icon-painter=File')
   endif
-
-  let subcommand = printf('exec "%s" --cmd-dir "%s"', a:cmd, clap#rooter#working_dir())
-
-  call clap#maple#job_start(printf('%s %s %s', s:maple_bin, global_opt, subcommand))
+  let subcommand = ['exec', a:cmd, '--cmd-dir', clap#rooter#working_dir()]
+  call clap#maple#job_start([s:maple_bin] + global_opt + subcommand)
 endfunction
 
 function! clap#maple#run_sync_grep(cmd, query, enable_icon, glob) abort
-  let global_opt = '--number '.g:clap.display.preload_capacity
+  let global_opt = ['--number', g:clap.display.preload_capacity]
+
   if a:enable_icon
-    let global_opt .= ' --icon-painter=Grep'
+    call add(global_opt, '--icon-painter=Grep')
   endif
 
-  let cmd = substitute(a:cmd, '"', "'", 'g')
-  let subcommand = printf('grep "%s" "%s" --sync --cmd-dir "%s"', cmd, a:query, clap#rooter#working_dir())
+  let subcommand = ['grep', a:cmd, a:query, '--sync', '--cmd-dir', clap#rooter#working_dir()]
 
   if a:glob isnot v:null
-    let subcommand .= printf(' --glob "%s"', a:glob)
+    let subcommand += ['--glob', a:glob]
   endif
 
-  call clap#maple#job_start(printf('%s %s %s', s:maple_bin, global_opt, subcommand))
+  call clap#maple#job_start([s:maple_bin] + global_opt + subcommand)
 endfunction
 
-function! clap#maple#build_cmd(cmd) abort
-  return printf('%s %s', s:maple_bin, a:cmd)
+function! clap#maple#build_cmd(...) abort
+  return [s:maple_bin] + a:000
+endfunction
+
+function! clap#maple#build_cmd_list(cmd_list) abort
+  return insert(a:cmd_list, s:maple_bin)
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -244,7 +244,7 @@ function! clap#maple#run_sync_grep(cmd, query, enable_icon, glob) abort
     call add(global_opt, '--icon-painter=Grep')
   endif
 
-  let subcommand = ['grep', a:cmd, a:query, '--sync', '--cmd-dir', clap#rooter#working_dir()]
+  let subcommand = ['grep', a:query, '--sync', '--grep-cmd', a:cmd, '--cmd-dir', clap#rooter#working_dir()]
 
   if a:glob isnot v:null
     let subcommand += ['--glob', a:glob]

--- a/autoload/clap/provider/filer.vim
+++ b/autoload/clap/provider/filer.vim
@@ -202,11 +202,7 @@ function! s:smart_concatenate(cur_dir, curline) abort
 endfunction
 
 function! s:filer_sink(selected) abort
-  if g:clap_enable_icon
-    let curline = a:selected[4:]
-  else
-    let curline = a:selected
-  endif
+  let curline = g:clap_enable_icon ? a:selected[4:] : a:selected
   execute 'edit' s:smart_concatenate(s:current_dir, curline)
 endfunction
 

--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -308,7 +308,7 @@ endif
 function! s:grep.init() abort
   if clap#maple#is_available()
     call clap#rooter#try_set_cwd()
-    call clap#forerunner#start_subcommand(clap#maple#ripgrep_forerunner_subcommand())
+    call clap#forerunner#start_command(clap#maple#ripgrep_forerunner_command())
   endif
 endfunction
 

--- a/autoload/clap/provider/grep2.vim
+++ b/autoload/clap/provider/grep2.vim
@@ -24,7 +24,7 @@ function! s:grep2.init() abort
   call clap#provider#grep#inject_icon_appended(g:clap_enable_icon)
   if clap#maple#is_available()
     call clap#rooter#try_set_cwd()
-    call clap#forerunner#start_subcommand(clap#maple#ripgrep_forerunner_subcommand())
+    call clap#forerunner#start_command(clap#maple#ripgrep_forerunner_command())
   endif
 endfunction
 

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -15,7 +15,7 @@ if clap#maple#is_available() && clap#filter#sync#python#has_dynamic_module()
     call writefile([join(s:get_doc_tags(), ','), &runtimepath], tmp)
     let helptags_cmd = clap#maple#build_cmd('helptags', tmp)
     " Currently the source has to be a String even we use List in job arguments.
-    return join(helptags_cmd, ' ')
+    return printf('"%s" %s', helptags_cmd[0], join(helptags_cmd[1:], ' '))
   endfunction
 
   function! s:help_tags_sink(line) abort

--- a/autoload/clap/provider/help_tags.vim
+++ b/autoload/clap/provider/help_tags.vim
@@ -13,7 +13,9 @@ if clap#maple#is_available() && clap#filter#sync#python#has_dynamic_module()
   function! s:help_tags_source() abort
     let tmp = tempname()
     call writefile([join(s:get_doc_tags(), ','), &runtimepath], tmp)
-    return clap#maple#build_cmd('helptags '.tmp)
+    let helptags_cmd = clap#maple#build_cmd('helptags', tmp)
+    " Currently the source has to be a String even we use List in job arguments.
+    return join(helptags_cmd, ' ')
   endfunction
 
   function! s:help_tags_sink(line) abort

--- a/autoload/clap/provider/proj_tags.vim
+++ b/autoload/clap/provider/proj_tags.vim
@@ -17,7 +17,8 @@ function! s:proj_tags.on_typed() abort
     endif
     call clap#filter#on_typed(function('clap#filter#sync'), query, g:__clap_forerunner_result)
   else
-    let cmd = clap#maple#build_cmd(printf('tags "%s" "%s"', g:clap.input.get(), clap#rooter#working_dir()))
+    " let cmd = clap#maple#build_cmd(printf('tags "%s" "%s"', g:clap.input.get(), clap#rooter#working_dir()))
+    let cmd = clap#maple#build_cmd('tags', g:clap.input.get(), clap#rooter#working_dir())
     call clap#filter#async#dyn#start_directly(cmd)
   endif
 endfunction
@@ -26,7 +27,7 @@ function! s:proj_tags.init() abort
   let g:__clap_builtin_content_filtering_enum = 'TagNameOnly'
   if clap#maple#is_available()
     call clap#rooter#try_set_cwd()
-    call clap#forerunner#start_subcommand(clap#maple#tags_forerunner_subcommand())
+    call clap#forerunner#start_command(clap#maple#tags_forerunner_command())
   endif
 endfunction
 

--- a/autoload/clap/provider/proj_tags.vim
+++ b/autoload/clap/provider/proj_tags.vim
@@ -17,9 +17,7 @@ function! s:proj_tags.on_typed() abort
     endif
     call clap#filter#on_typed(function('clap#filter#sync'), query, g:__clap_forerunner_result)
   else
-    " let cmd = clap#maple#build_cmd(printf('tags "%s" "%s"', g:clap.input.get(), clap#rooter#working_dir()))
-    let cmd = clap#maple#build_cmd('tags', g:clap.input.get(), clap#rooter#working_dir())
-    call clap#filter#async#dyn#start_directly(cmd)
+    call clap#filter#async#dyn#start_directly(clap#maple#build_cmd('tags', g:clap.input.get(), clap#rooter#working_dir()))
   endif
 endfunction
 

--- a/crates/maple_cli/src/cmd/cache.rs
+++ b/crates/maple_cli/src/cmd/cache.rs
@@ -30,20 +30,22 @@ pub struct Cache {
 impl Cache {
     pub fn run(&self) -> Result<()> {
         let cache_dir = clap_cache_dir();
-        let cache_dir_str = cache_dir.clone().into_os_string().into_string().unwrap();
         if self.purge {
             remove_dir_contents(&cache_dir)?;
-            println!("Current cache directory {} has been purged", cache_dir_str);
+            println!(
+                "Current cache directory {} has been purged",
+                cache_dir.display()
+            );
             return Ok(());
         }
         if self.list {
-            self.list(cache_dir)?;
+            self.list(&cache_dir)?;
         }
         Ok(())
     }
 
-    fn list(&self, cache_dir: PathBuf) -> Result<()> {
-        let cache_dir_str = cache_dir.clone().into_os_string().into_string().unwrap();
+    fn list(&self, cache_dir: &PathBuf) -> Result<()> {
+        let cache_dir_str = cache_dir.display();
         println!("Current cache directory:");
         println!("\t{}\n", cache_dir_str);
         if self.list {


### PR DESCRIPTION
Fix the issue of job cmd when `cmd` is String and it contains spaces.

Initially reported in https://github.com/liuchengxu/vim-clap/issues/404#issuecomment-615959962.

cc @ErrEoE @TissueFluid 