### PR TITLE
feat(filer): jump directly up to parent directory

### DIFF
--- a/autoload/clap/handler.vim
+++ b/autoload/clap/handler.vim
@@ -101,6 +101,13 @@ function! clap#handler#tab_action() abort
   return clap#selection#toggle()
 endfunction
 
+function! clap#handler#stab_action() abort
+  if has_key(g:clap.provider._(), 'stab_action')
+    call g:clap.provider._().stab_action()
+  endif
+  return ''
+endfunction
+
 function! clap#handler#bs_action() abort
   if has_key(g:clap.provider._(), 'bs_action')
     call g:clap.provider._().bs_action()

--- a/autoload/clap/provider/filer.vim
+++ b/autoload/clap/provider/filer.vim
@@ -108,6 +108,11 @@ function! s:filter_or_send_message() abort
   endif
 endfunction
 
+function! s:stab_action() abort
+  call g:clap.input.set('')
+  call s:bs_action()
+endfunction
+
 function! s:bs_action() abort
   call clap#highlight#clear()
 
@@ -269,6 +274,7 @@ let s:filer.on_move = function('s:filer_on_move')
 let s:filer.on_typed = function('s:filer_on_typed')
 let s:filer.bs_action = function('s:bs_action')
 let s:filer.tab_action = function('s:tab_action')
+let s:filer.stab_action = function('s:stab_action')
 let s:filer.source_type = g:__t_rpc
 let s:filer.on_no_matches = function('s:filer_on_no_matches')
 let g:clap#provider#filer# = s:filer

--- a/ftplugin/clap_input.vim
+++ b/ftplugin/clap_input.vim
@@ -60,6 +60,7 @@ inoremap <silent> <buffer> <PageDown> <C-R>=clap#navigation#scroll('down')<CR>
 inoremap <silent> <buffer> <PageUp>   <C-R>=clap#navigation#scroll('up')<CR>
 
 inoremap <silent> <buffer> <Tab>       <C-R>=clap#handler#tab_action()<CR>
+inoremap <silent> <buffer> <S-Tab>     <C-R>=clap#handler#stab_action()<CR>
 inoremap <silent> <buffer> <Backspace> <C-R>=clap#handler#bs_action()<CR>
 
 inoremap <silent> <buffer> <C-j> <C-R>=clap#navigation#linewise('down')<CR>


### PR DESCRIPTION
Loving this plugin so far, but one thing that slows me down a bit is when I'm using `filer` and I want to jump to the parent but I've typed some characters already, so I have to press `BS` a bunch first to get rid of the characters. I *think* `ivy` had a feature where you could directly jump to the parent and I *think* it was bound to `<S-Tab>`. (I might be imagining this)

This PR introduces that feature. I know `<S-Tab>` is bound to `invoke` in insert mode, which would be confusing in this case, so probably the actual keybinding needs to change.

What do you think?