### PR TITLE
Show new file as explicit entry in filer

### DIFF
--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -63,9 +63,24 @@ else
   endfunction
 endif
 
-function! clap#filter#on_typed(FilterFn, query, candidates) abort
+function! clap#filter#on_typed(FilterFn, query, candidates, ...) abort
   let l:lines = a:FilterFn(a:query, a:candidates)
 
+  let l:query_prefix = get(a:, 1, v:false)
+  if l:query_prefix !=# v:false
+    let l:found = v:false
+    let l:entry_start_index = g:clap_enable_icon ? 4 : 0
+    for line in l:lines
+      if line[(l:entry_start_index):] ==# a:query
+        let l:found = v:true
+        break
+      endif
+    endfor
+    if !l:found
+      let query_entry = l:query_prefix.a:query
+      let l:lines = l:lines + [query_entry]
+    endif
+  endif
   if empty(l:lines)
     let l:lines = [g:clap_no_matches_msg]
     let g:__clap_has_no_matches = v:true

--- a/autoload/clap/provider/filer.vim
+++ b/autoload/clap/provider/filer.vim
@@ -116,9 +116,9 @@ function! s:do_filter() abort
     call g:clap.display.set_lines(candidates)
     call g:clap#display_win.shrink_if_undersize()
   else
-    let query_entry = g:clap_enable_icon ? ' '.query : query
+    let query_prefix = '+ '
     call clap#filter#on_typed(
-      \ function('clap#filter#sync'), query, candidates + [query_entry]
+      \ function('clap#filter#sync'), query, candidates, query_prefix
     \ )
   endif
 endfunction

--- a/syntax/clap_filer.vim
+++ b/syntax/clap_filer.vim
@@ -5,5 +5,3 @@ hi TNormal ctermfg=249 ctermbg=NONE guifg=#b2b2b2 guibg=NONE
 execute 'syntax match ClapFile' '/.*[^\/]$/' 'contains='.join(clap#icon#add_head_hl_groups(), ',')
 
 hi default link ClapFile TNormal
-
-call clap#provider#filer#hi_empty_dir()


### PR DESCRIPTION
This makes filer always shows an entry for the query itself in the file
list, which makes editing a new file more explicit.

Before, if the query didn't match anything "NO MATCHES FOUND" is shown
and if you press enter, clap opens a buffer named the current query.
It also wasn't possible to open a new buffer this way if the directory
was empty. A buffer with the name "Directory is empty" is opened no
matter what the input is.

Now, the current query is always shown as a file that can be opened,
which, at least for me, feels more intuitive and matches behavior of
similar interfaces (e.g. Helm find files in emacs).
This also works in empty directories. If you tab to an empty directory
and press enter with the empty query, the directory itself is opened.