### PR TITLE
Global variable :: clap_preview_files_lines

### DIFF
--- a/autoload/clap/preview.vim
+++ b/autoload/clap/preview.vim
@@ -7,7 +7,7 @@ set cpoptions&vim
 let s:path_seperator = has('win32') ? '\' : '/'
 
 function! s:peek_file(fname, fpath) abort
-  let lines = readfile(a:fpath, '', 10)
+  let lines = readfile(a:fpath, '', get(g:, 'clap_preview_files_lines', '10'))
   call insert(lines, a:fpath)
   call g:clap.preview.show(lines)
   call g:clap.preview.set_syntax(clap#ext#into_filetype(a:fname))


### PR DESCRIPTION
# Description
When using `:Clap files` allow number of lines shown in preview to be customisable using a global variable `clap_preview_files_lines`.

# Documentation proposal
```
g:clap_preview_files_lines                              *g:clap_preview_files_lines*

  Type: |Number|
  Default: `10`

  This variable control the number of lines previewed using :Clap files
```