### PR TITLE
Global variable :: clap_preview_grep_lines

### DIFF
--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -210,7 +210,7 @@ function! s:grep_on_move() abort
           \ 'filetype': clap#ext#into_filetype(fpath)
           \ }
   endif
-  let [start, end, hi_lnum] = clap#preview#get_line_range(lnum, 5)
+  let [start, end, hi_lnum] = clap#preview#get_line_range(lnum, get(g:, 'clap_preview_grep_lines', '5'))
   let preview_lines = s:preview_cache[fpath]['lines'][start : end]
   call insert(preview_lines, fpath)
   let hi_lnum += 1


### PR DESCRIPTION
# Description

When using :Clap grep allow number of lines shown in preview to be customisable using a global variable clap_preview_grep_lines.

# Documentation proposal

```
g:clap_preview_grep_lines                              *g:clap_preview_grep_lines*

  Type: |Number|
  Default: `5`

  This variable control the number of lines previewed using :Clap grep
```