### PR TITLE
Update the highlight for proj_tags #450

### DIFF
--- a/syntax/clap_proj_tags.vim
+++ b/syntax/clap_proj_tags.vim
@@ -9,7 +9,7 @@ syntax match ClapProjTagPattern /^.*$/ contains=ClapTagName,ClapProjTagKind,Clap
 hi default link ClapProjTagName Type
 hi default link ClapProjTagKind Function
 hi default link ClapProjTagPath Directory
-hi default link ClapProjTagPattern String
+hi default link ClapProjTagPattern Identifier
 hi default link ClapProjTagKindPathSeperator String
 hi default link ClapProjTagLnum Number
 hi default link ClapProjTagBrackets Comment

--- a/syntax/clap_proj_tags.vim
+++ b/syntax/clap_proj_tags.vim
@@ -9,7 +9,7 @@ syntax match ClapProjTagPattern /^.*$/ contains=ClapTagName,ClapProjTagKind,Clap
 hi default link ClapProjTagName Type
 hi default link ClapProjTagKind Function
 hi default link ClapProjTagPath Directory
-hi default link ClapProjTagPattern SpecialKey
+hi default link ClapProjTagPattern String
 hi default link ClapProjTagKindPathSeperator String
 hi default link ClapProjTagLnum Number
 hi default link ClapProjTagBrackets Comment


### PR DESCRIPTION
Improvement for 
 ['Some of the text is hard to identify in dark theme #450'](https://github.com/liuchengxu/vim-clap/issues/450)
One liner.