### PR TITLE
Don't show Clap windows in `:Clap windows`

### DIFF
--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -310,7 +310,7 @@ function! s:init_input() abort
     endfunction
 
     function! input.clear() abort
-      call popup_settext(g:clap#popup#input.winid, '')
+      call popup_settext(self.winid, '')
     endfunction
   endif
 

--- a/autoload/clap/popup.vim
+++ b/autoload/clap/popup.vim
@@ -6,7 +6,6 @@ set cpoptions&vim
 
 let g:clap#popup#preview = {}
 let g:clap#popup#display = {}
-let g:clap#popup#input = {}
 
 " TODO use a flexiable width
 let s:indicator_width = 18
@@ -251,7 +250,7 @@ function! s:create_input() abort
     if s:exists_deoplete
       call deoplete#custom#buffer_option('auto_complete', v:false)
     endif
-    let g:clap#popup#input.winid = s:input_winid
+    let g:clap.input.winid = s:input_winid
   endif
 endfunction
 

--- a/autoload/clap/popup/move_manager.vim
+++ b/autoload/clap/popup/move_manager.vim
@@ -199,7 +199,7 @@ endfunction
 function! s:mock_input() abort
   " The trailing space is for block cursor
   let input = s:strpart_input(0, s:cursor_idx).s:cursor_shape.s:strpart_input(s:cursor_idx).' '
-  let input_winid = g:clap#popup#input.winid
+  let input_winid = g:clap.input.winid
   call popup_settext(input_winid, input)
   call win_execute(input_winid, 'noautocmd call s:hl_cursor()')
 endfunction

--- a/autoload/clap/provider/windows.vim
+++ b/autoload/clap/provider/windows.vim
@@ -12,13 +12,10 @@ function! s:jump(t, w) abort
 endfunction
 
 function! s:get_clap_winids() abort
-  let clap_winids = []
-  for clap_win in ['display', 'input', 'spinner', 'preview']
-    let clap_win_var = 'g:clap.' . clap_win . '.winid'
-    if exists(clap_win_var)
-      call add(clap_winids, g:clap[clap_win].winid)
-    endif
-  endfor
+  let clap_winids = map(filter(
+          \ ['display', 'input', 'spinner', 'preview'],
+          \ 'exists("g:clap.".v:val.".winid")'),
+      \ 'g:clap[v:val].winid')
   if exists('g:__clap_indicator_bufnr')
     call extend(clap_winids, win_findbuf(g:__clap_indicator_bufnr))
   endif

--- a/autoload/clap/provider/windows.vim
+++ b/autoload/clap/provider/windows.vim
@@ -11,24 +11,45 @@ function! s:jump(t, w) abort
   execute a:w.'wincmd w'
 endfunction
 
-function! s:format_win(tab, win, buf) abort
-  let modified = getbufvar(a:buf, '&modified')
-  let name = bufname(a:buf)
+function! s:get_clap_winids() abort
+  let clap_winids = []
+  for clap_win in ['display', 'input', 'spinner', 'preview']
+    let clap_win_var = 'g:clap.' . clap_win . '.winid'
+    if exists(clap_win_var)
+      call add(clap_winids, g:clap[clap_win].winid)
+    endif
+  endfor
+  if exists('g:__clap_indicator_bufnr')
+    call extend(clap_winids, win_findbuf(g:__clap_indicator_bufnr))
+  endif
+
+  return clap_winids
+endfunction
+
+function! s:format_win(winid) abort
+  let buf = winbufnr(a:winid)
+  let modified = getbufvar(buf, '&modified')
+  let name = bufname(buf)
   let name = empty(name) ? '[No Name]' : name
-  let active = tabpagewinnr(a:tab) == a:win
+  let active = a:winid == g:clap.start.winid
   return (active? '> ' : '  ') . name . (modified? ' [+]' : '')
 endfunction
 
 function! s:windows.source() abort
+  let clap_winids = s:get_clap_winids()
   let lines = []
   for t in range(1, tabpagenr('$'))
-    let buffers = tabpagebuflist(t)
-    for w in range(1, len(buffers))
+    for w in range(1, tabpagewinnr(t, '$'))
+      " Skip Clap windows
+      let winid = win_getid(w, t)
+      if index(clap_winids, winid) != -1
+        continue
+	  endif
       call add(lines,
         \ printf('%s %s  %s',
             \ printf('%3d', t),
             \ printf('%3d', w),
-            \ s:format_win(t, w, buffers[w-1])
+            \ s:format_win(winid)
             \ )
             \ )
     endfor


### PR DESCRIPTION
Uses window IDs instead of buffers. Also fixes active window display.