### PR TITLE
Pass args to bufname to resolve nvim error

### DIFF
--- a/autoload/clap/provider/yanks.vim
+++ b/autoload/clap/provider/yanks.vim
@@ -29,7 +29,7 @@ function! clap#provider#yanks#collect() abort
 
   call filter(s:yank_history, 'v:val != last_yanked')
   call insert(s:yank_history, last_yanked)
-  let s:yank_info_map[last_yanked] = { 'syntax': getbufvar('', '&syntax'), 'bufname': bufname() }
+  let s:yank_info_map[last_yanked] = { 'syntax': getbufvar('', '&syntax'), 'bufname': bufname("%") }
 
   " Trim yank entries(purge old ones)
   if len(s:yank_history) > s:max_yanks

--- a/autoload/clap/provider/yanks.vim
+++ b/autoload/clap/provider/yanks.vim
@@ -29,7 +29,7 @@ function! clap#provider#yanks#collect() abort
 
   call filter(s:yank_history, 'v:val != last_yanked')
   call insert(s:yank_history, last_yanked)
-  let s:yank_info_map[last_yanked] = { 'syntax': getbufvar('', '&syntax'), 'bufname': bufname("%") }
+  let s:yank_info_map[last_yanked] = { 'syntax': getbufvar('', '&syntax'), 'bufname': bufname('%') }
 
   " Trim yank entries(purge old ones)
   if len(s:yank_history) > s:max_yanks


### PR DESCRIPTION
My setup: NVIM v0.3.7

After updating my install after not doing so for a few months, I started seeing an error every time I launched `nvim` and yanked: `Error not enough arguments passed to bufname`. It looks like the change that is biting me was made here: https://github.com/liuchengxu/vim-clap/pull/324

I read the nvim docs, and while it does say ["If {expr} is omitted the current buffer is used."](https://neovim.io/doc/user/eval.html#bufname()), that has not been true in my experience. 

I added a small change, which resolves the issue for me, and I believe preserves the intended functionality, judging by this line in the nvim docs: [""" or "%" can be used for the current buffer..."](https://neovim.io/doc/user/eval.html#bufname()). 

Thought I would try to contribute back to the community with my small fix, or at least leave a trail in case someone else runs into the same problem as me. 