### PR TITLE
Fix history provider open action support

### DIFF
--- a/autoload/clap/provider/history.vim
+++ b/autoload/clap/provider/history.vim
@@ -28,7 +28,12 @@ function! s:history_sink(selected) abort
   else
     let fpath = a:selected
   endif
-  execute 'edit' fpath
+
+  if has_key(g:clap, 'open_action')
+    execute g:clap.open_action fpath
+  else
+    execute 'edit' fpath
+  endif
 endfunction
 
 let s:history.syntax = 'clap_files'


### PR DESCRIPTION
History provider supports open action, but action is not used in sink func.