### PR TITLE
Add on_move_async property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
 - Python dynamic module now can be compiled using stable Rust. ([#471](https://github.com/liuchengxu/vim-clap/pull/471))
 - Add `windows` preview support. ([#473](https://github.com/liuchengxu/vim-clap/pull/473))
 - Impl `commits` and `bcommits` provider. ([#477](https://github.com/liuchengxu/vim-clap/pull/477)) @ray-x
+- Add new provider property `on_move_async`. ([#481](https://github.com/liuchengxu/vim-clap/pull/481))
 
 ### Fixed
 

--- a/PROVIDER.md
+++ b/PROVIDER.md
@@ -66,6 +66,7 @@ Field                 | Type                | Required      | Has default implem
 `filter`              | Funcref             | **mandatory** | **Yes**
 `on_typed`            | Funcref             | **mandatory** | **Yes**
 `on_move`             | Funcref             | optional      | No
+`on_move_async`       | Funcref             | optional      | No
 `on_enter`            | Funcref             | optional      | No
 `on_exit`             | Funcref             | optional      | No
 `support_open_action` | Bool                | optional      | **Yes** if the `sink` is `e`/`edit`/`edit!`
@@ -99,6 +100,8 @@ Field                 | Type                | Required      | Has default implem
 - `on_typed`: reference to function to filter the `source`.
 
 - `on_move`: when navigating the result list, can be used for the preview purpose, see [clap/provider/colors](autoload/clap/provider/colors.vim).
+
+- `on_move_async`: async preview implementation, normally done by the Rust binary maple, see [autoload/clap/provider/filer.vim](autoload/clap/provider/filer.vim).
 
 - `on_enter`: when entering the clap window, can be used for recording the current state.
 

--- a/autoload/clap/impl/on_move.vim
+++ b/autoload/clap/impl/on_move.vim
@@ -37,10 +37,7 @@ if clap#maple#is_available()
   endfunction
 
   function! s:dispatch_on_move_impl() abort
-    if g:clap.provider.id ==# 'filer'
-      call g:clap.provider._().on_move()
-      return
-    elseif index(s:async_preview_implemented, g:clap.provider.id) > -1
+    if index(s:async_preview_implemented, g:clap.provider.id) > -1
       return clap#client#call_on_move('on_move', function('s:handle_on_move_result'))
     endif
     call s:sync_run_with_delay()
@@ -55,7 +52,9 @@ function! clap#impl#on_move#invoke() abort
   if get(g:, '__clap_has_no_matches', v:false)
     return
   endif
-  if has_key(g:clap.provider._(), 'on_move')
+  if has_key(g:clap.provider._(), 'on_move_async')
+    call g:clap.provider._().on_move_async()
+  elseif has_key(g:clap.provider._(), 'on_move')
     call s:dispatch_on_move_impl()
   endif
 endfunction

--- a/autoload/clap/provider/bcommits.vim
+++ b/autoload/clap/provider/bcommits.vim
@@ -21,6 +21,10 @@ function! s:bcommits.on_move() abort
   call clap#provider#commits#on_move_common(s:into_git_diff_cmd(cur_line))
 endfunction
 
+function! s:bcommits.on_move_async() abort
+  call clap#client#call_on_move('on_move', function('clap#provider#commits#on_move_callback'))
+endfunction
+
 function! s:bcommits.sink(line) abort
   call clap#provider#commits#sink_inner('!'.s:into_git_diff_cmd(a:line))
 endfunction

--- a/autoload/clap/provider/commits.vim
+++ b/autoload/clap/provider/commits.vim
@@ -55,6 +55,16 @@ function! s:commits.on_move() abort
   call clap#provider#commits#on_move_common('git show '.rev)
 endfunction
 
+function! clap#provider#commits#on_move_callback(result) abort
+  let lines = a:result.lines
+  call clap#preview#show_lines(lines, 'diff', -1)
+  call clap#preview#highlight_header()
+endfunction
+
+function! s:commits.on_move_async() abort
+  call clap#client#call_on_move('on_move', function('clap#provider#commits#on_move_callback'))
+endfunction
+
 function! clap#provider#commits#sink_inner(bang_cmd) abort
   vertical botright new
   setlocal buftype=nofile bufhidden=wipe noswapfile nomodeline

--- a/autoload/clap/provider/filer.vim
+++ b/autoload/clap/provider/filer.vim
@@ -230,7 +230,7 @@ function! s:filer_handle_on_move_result(result) abort
   endif
 endfunction
 
-function! s:filer_on_move() abort
+function! s:filer.on_move_async() abort
   call clap#client#call_on_move('filer/on_move', function('s:filer_handle_on_move_result'), {'cwd': s:current_dir})
 endfunction
 
@@ -261,7 +261,6 @@ endfunction
 let s:filer.init = function('s:start_rpc_service')
 let s:filer.sink = function('s:filer_sink')
 let s:filer.syntax = 'clap_filer'
-let s:filer.on_move = function('s:filer_on_move')
 let s:filer.on_typed = function('s:filer_on_typed')
 let s:filer.bs_action = function('s:bs_action')
 let s:filer.tab_action = function('s:tab_action')

--- a/crates/stdio_server/src/filer.rs
+++ b/crates/stdio_server/src/filer.rs
@@ -88,6 +88,7 @@ impl HandleMessage for FilerMessageHandler {
                     msg_id: msg.id,
                     size: provider_id.get_preview_size(),
                     provider_id,
+                    context,
                     inner: OnMove::Filer(path),
                 };
                 on_move_handler.handle().unwrap();

--- a/crates/stdio_server/src/session/context.rs
+++ b/crates/stdio_server/src/session/context.rs
@@ -13,6 +13,14 @@ pub struct SessionContext {
     pub source_list: Arc<Mutex<Option<Vec<String>>>>,
 }
 
+impl SessionContext {
+    // Executes the command `cmd` and returns the raw bytes of stdout.
+    pub fn execute(&self, cmd: &str) -> Result<Vec<u8>> {
+        let out = utility::execute_at(cmd, Some(&self.cwd))?;
+        Ok(out.stdout)
+    }
+}
+
 impl From<Message> for SessionContext {
     fn from(msg: Message) -> Self {
         log::debug!("recv msg for SessionContext: {:?}", msg);

--- a/crates/stdio_server/src/session/handler/on_move.rs
+++ b/crates/stdio_server/src/session/handler/on_move.rs
@@ -20,6 +20,7 @@ pub fn as_absolute_path<P: AsRef<Path>>(path: P) -> Result<String> {
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub enum OnMove {
+    Commit(String),
     Files(PathBuf),
     Filer(PathBuf),
     History(PathBuf),
@@ -55,8 +56,7 @@ impl OnMove {
             }
             "filer" => unreachable!("filer has been handled ahead"),
             "proj_tags" => {
-                let (lnum, p) =
-                    extract_proj_tags(&curline).context("Couldn't extract proj tags")?;
+                let (lnum, p) = extract_proj_tags(&curline).context("can not extract proj tags")?;
                 let mut path: PathBuf = context.cwd.clone().into();
                 path.push(&p);
                 Self::ProjTags { path, lnum }
@@ -69,15 +69,19 @@ impl OnMove {
                 Self::Grep { path, lnum }
             }
             "blines" => {
-                let lnum = extract_blines_lnum(&curline).context("Couldn't extract buffer lnum")?;
+                let lnum = extract_blines_lnum(&curline).context("can not extract buffer lnum")?;
                 let path = context.start_buffer_path.clone().into();
                 Self::BLines { path, lnum }
             }
             "tags" => {
                 let lnum =
-                    extract_buf_tags_lnum(&curline).context("Couldn't extract buffer tags")?;
+                    extract_buf_tags_lnum(&curline).context("can not extract buffer tags")?;
                 let path = context.start_buffer_path.clone().into();
                 Self::BufferTags { path, lnum }
+            }
+            "commits" | "bcommits" => {
+                let rev = parse_rev(&curline).context("can not extract rev")?;
+                Self::Commit(rev.into())
             }
             _ => {
                 return Err(anyhow!(
@@ -91,15 +95,16 @@ impl OnMove {
     }
 }
 
-pub struct OnMoveHandler {
+pub struct OnMoveHandler<'a> {
     pub msg_id: u64,
     pub provider_id: ProviderId,
     pub size: usize,
     pub inner: OnMove,
+    pub context: &'a SessionContext,
 }
 
-impl OnMoveHandler {
-    pub fn try_new(msg: Message, context: &SessionContext) -> anyhow::Result<Self> {
+impl<'a> OnMoveHandler<'a> {
+    pub fn try_new(msg: Message, context: &'a SessionContext) -> anyhow::Result<Self> {
         let msg_id = msg.id;
         let provider_id = context.provider_id.clone();
         let curline = msg.get_curline(&provider_id)?;
@@ -109,6 +114,7 @@ impl OnMoveHandler {
                 msg_id,
                 size: provider_id.get_preview_size(),
                 provider_id,
+                context,
                 inner: OnMove::Filer(path),
             });
         }
@@ -116,6 +122,7 @@ impl OnMoveHandler {
             msg_id,
             size: provider_id.get_preview_size(),
             provider_id,
+            context,
             inner: OnMove::new(curline, context)?,
         })
     }
@@ -136,6 +143,9 @@ impl OnMoveHandler {
             Files(path) | Filer(path) | History(path) => {
                 self.preview_file(&path)?;
             }
+            Commit(rev) => {
+                self.show_commit(rev)?;
+            }
         }
 
         Ok(())
@@ -148,6 +158,20 @@ impl OnMoveHandler {
                 "provider_id": provider_id,
                 "result": result
         }));
+    }
+
+    fn show_commit(&self, rev: &str) -> Result<()> {
+        let stdout = self.context.execute(&format!("git show {}", rev))?;
+        let stdout_str = String::from_utf8_lossy(&stdout);
+        let lines = stdout_str
+            .split('\n')
+            .take(self.provider_id.get_preview_size() * 2)
+            .collect::<Vec<_>>();
+        self.send_response(json!({
+          "event": "on_move",
+          "lines": lines,
+        }));
+        Ok(())
     }
 
     fn preview_file_at<P: AsRef<Path>>(&self, path: P, lnum: usize) {

--- a/crates/stdio_server/src/types.rs
+++ b/crates/stdio_server/src/types.rs
@@ -96,6 +96,8 @@ impl Message {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ProviderId(String);
 
+const NO_ICON_PROVIDERS: [&str; 3] = ["blines", "commits", "bcommits"];
+
 impl ProviderId {
     pub fn as_str(&self) -> &str {
         &self.0
@@ -118,7 +120,7 @@ impl ProviderId {
     /// Returns true if the provider can have icon.
     #[inline]
     pub fn has_icon_support(&self) -> bool {
-        &self.0 != "blines"
+        !NO_ICON_PROVIDERS.contains(&self.as_str())
     }
 }
 


### PR DESCRIPTION
- Add a general `on_move_async` for clap provider.
- Imple async preview for `commits` and `bcommits` using `on_move_async`.
- Change `on_move` of `filer` to `on_move_async`.