### PR TITLE
parse_win() ignored sink and tried to getcurline()

### DIFF
--- a/autoload/clap/provider/windows.vim
+++ b/autoload/clap/provider/windows.vim
@@ -48,7 +48,7 @@ function! s:windows.source() abort
 endfunction
 
 function! s:parse_win(line) abort
-  let tab_win = matchlist(g:clap.display.getcurline(), '^ *\([0-9]\+\) *\([0-9]\+\)')
+  let tab_win = matchlist(a:line, '^ *\([0-9]\+\) *\([0-9]\+\)')
   return [tab_win[2], tab_win[1]]
 endfunction
 


### PR DESCRIPTION
The `:Clap windows` provider's sink function passed the user's choice
down to parse_win(), which then ignored it and instead tried to fetch
the choice from the clap menu (which no longer exists at this point).

As a result, Vim throws the following exception when the user chooses
any item from the `:Clap windows` menu and thereby calls parse_win():

    vim-clap: clap#handler#sink: Vim(return):E684: list index out of range: 2, throwpoint:function clap#handler#sink[12]..350[1]..clap#rooter#run_heuristic[4]..348[3]..385[1]..<SNR>508_parse_win, line 2