### PR TITLE
Fix `:Clap install-binary` does not work correctly on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## [unreleased]
 
+### Fixed
+
+- Fix `:Clap install-binary` does not work correctly on Windows.
+
 ## [0.20] 2020-08-06
 
 ### Added

--- a/autoload/clap/installer.vim
+++ b/autoload/clap/installer.vim
@@ -25,7 +25,11 @@ function! s:run_term(cmd, cwd, success_info) abort
           \ 'on_exit': {job, status -> s:OnExit(status)},
           \})
   else
-    call term_start(a:cmd, {
+    let cmd = a:cmd
+    if has('win32')
+      let cmd = 'cmd.exe /c '.cmd
+    endif
+    call term_start(cmd, {
           \ 'curwin': 1,
           \ 'cwd': a:cwd,
           \ 'exit_cb': {job, status -> s:OnExit(status)},
@@ -38,9 +42,9 @@ function! s:run_term(cmd, cwd, success_info) abort
 endfunction
 
 if has('win32')
-  let s:from = '.\fuzzymatch-rs\target\release\libfuzzymatch_rs.dll'
-  let s:to = 'libfuzzymatch_rs.pyd'
-  let s:rust_ext_cmd = printf('cargo +nightly build --release && copy %s %s', s:from, s:to)
+  let s:from = '.\fuzzymatch-rs\target\release\fuzzymatch_rs.dll'
+  let s:to = 'fuzzymatch_rs.pyd'
+  let s:rust_ext_cmd = printf('pushd fuzzymatch-rs && cargo build --release && popd && copy %s %s', s:from, s:to)
   let s:rust_ext_cwd = s:plugin_root_dir.'\pythonx\clap'
   let s:prebuilt_maple_binary = s:plugin_root_dir.'\bin\maple.exe'
   let s:maple_cargo_toml = s:plugin_root_dir.'\Cargo.toml'
@@ -112,7 +116,7 @@ function! clap#installer#install(try_download) abort
     endif
     " Since v0.14 maple itself is able to download the latest release binary.
     if executable(s:prebuilt_maple_binary) && s:current_version >= 14
-      let cmd = [s:prebuilt_maple_binary, 'upgrade', '--download']
+      let cmd = s:prebuilt_maple_binary.' upgrade --download'
       call s:run_term(cmd, s:plugin_root_dir, 'download the latest prebuilt maple binary successfully')
     else
       call clap#installer#download_binary()


### PR DESCRIPTION
On Windows:
* Vim's `term_start()` executes a command directly (not on a shell), so you need to add `cmd.exe /c` to the command if you use `&&` etc.
* Still using nightly Rust.
* `cargo build` runs on wrong directory when building Python dynamic module.
* The name of the built dynamic module is wrong.

This is a PR to fix them.