### PR TITLE
Document ClapFuzzyMatches highlighting group

### DIFF
--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -547,6 +547,11 @@ ClapMatches[1-8]                                                 *ClapMatches[1-
   `ClapMatches[1-8]` will be used for the matched substrings in the substring mode.
 
 
+ClapFuzzyMatches[1-12]                                     *ClapFuzzyMatches[1-12]*
+
+  `ClapFuzzyMatches[1-12]` will be used for the matched substrings in fuzzy mode.
+
+
 ClapNoMatchesFound                                        *ClapNClapNoMatchesFound*
 
   Default: `hi default link ClapNClapNoMatchesFound ErrorMsg`


### PR DESCRIPTION
This is a minor issue, but I lost an hour yesterday trying to figure out how to highlight match results in fuzzy mode. This PR documents the highlight group for fuzzy matches.