### PR TITLE
fix git_diff_files not running from project root (#506)

### DIFF
--- a/autoload/clap/provider/git_diff_files.vim
+++ b/autoload/clap/provider/git_diff_files.vim
@@ -46,7 +46,7 @@ function! s:git_diff_files_on_move() abort
 endfunction
 
 let s:git_diff_files.sink = 'e'
-let s:git_diff_files.enable_rooter = v:true
+let s:git_diff_files.enable_rooter = v:false
 let s:git_diff_files.on_move = function('s:git_diff_files_on_move')
 
 let g:clap#provider#git_diff_files# = s:git_diff_files


### PR DESCRIPTION
Closes #506 

`systemlist(git ...)` doesn't seem to respect `enable_rooter`, both diff files and previews are retrieved from the current directory, not from the project root. So `enable_rooter` doesn't really run the needed `source` command from the project root, and it misleads the `sink`.

Stop running `source` from the project root seems a simple solution. It works well for me no matter vim is started from the project root or not.
