### PR TITLE
Fix typo/bug g:get_opaque_line -> s:get_opaque_line

### DIFF
--- a/autoload/clap/selection.vim
+++ b/autoload/clap/selection.vim
@@ -82,7 +82,7 @@ function! clap#selection#try_open(action) abort
 
     call g:clap.start.goto_win()
     let open_cmd = g:clap_open_action[a:action]
-    for line in g:get_opaque_lines()
+    for line in s:get_opaque_lines()
       execute open_cmd line
     endfor
     call clap#_exit()


### PR DESCRIPTION
Fixes plugins like `vim-mrufiles`.