### PR TITLE
[WIP] Smart-case

### DIFF
--- a/crates/matcher/extracted_fzy/src/lib.rs
+++ b/crates/matcher/extracted_fzy/src/lib.rs
@@ -10,9 +10,20 @@ use crate::scoring_utils::*;
 pub type MatchWithPositions = (Score, Vec<usize>);
 
 pub fn match_and_score_with_positions(needle: &str, haystack: &str) -> Option<MatchWithPositions> {
-    match matches(needle, haystack) {
+    let is_case_sensitive = match needle.chars().find(|c| c.is_uppercase()) {
+        Some(_) => true,
+        None => false,
+    };
+    let haystack_opt = if is_case_sensitive {
+        None
+    } else {
+        Some(haystack.to_lowercase())
+    };
+    let haystack_str = haystack_opt.as_deref().unwrap_or(haystack);
+
+    match matches(needle, haystack_str) {
         Some(needle_length) => {
-            let (score, positions) = score_with_positions(needle, needle_length, haystack);
+            let (score, positions) = score_with_positions(needle, needle_length, haystack_str);
             Some((score, positions))
         }
         None => None,
@@ -157,14 +168,10 @@ fn calculate_score(
     (D, M)
 }
 
-/// Compares two characters case-insensitively
+/// Compares two characters
 #[inline(always)]
 fn eq(a: char, b: char) -> bool {
-    match a {
-        _ if a == b => true,
-        _ if a.is_ascii() || b.is_ascii() => a.eq_ignore_ascii_case(&b),
-        _ => a.to_lowercase().eq(b.to_lowercase()),
-    }
+    a == b
 }
 
 fn compute_bonus(haystack: &str, haystack_length: usize) -> Vec<Score> {

--- a/crates/matcher/extracted_fzy/src/lib.rs
+++ b/crates/matcher/extracted_fzy/src/lib.rs
@@ -10,20 +10,15 @@ use crate::scoring_utils::*;
 pub type MatchWithPositions = (Score, Vec<usize>);
 
 pub fn match_and_score_with_positions(needle: &str, haystack: &str) -> Option<MatchWithPositions> {
-    let is_case_sensitive = match needle.chars().find(|c| c.is_uppercase()) {
-        Some(_) => true,
-        None => false,
-    };
-    let haystack_opt = if is_case_sensitive {
-        None
+    let haystack = if needle.chars().any(|c| c.is_uppercase()) {
+        haystack.into()
     } else {
-        Some(haystack.to_lowercase())
+        haystack.to_lowercase()
     };
-    let haystack = haystack_opt.as_deref().unwrap_or(haystack);
 
-    match matches(needle, haystack) {
+    match matches(needle, &haystack) {
         Some(needle_length) => {
-            let (score, positions) = score_with_positions(needle, needle_length, haystack);
+            let (score, positions) = score_with_positions(needle, needle_length, &haystack);
             Some((score, positions))
         }
         None => None,

--- a/crates/matcher/extracted_fzy/src/lib.rs
+++ b/crates/matcher/extracted_fzy/src/lib.rs
@@ -19,11 +19,11 @@ pub fn match_and_score_with_positions(needle: &str, haystack: &str) -> Option<Ma
     } else {
         Some(haystack.to_lowercase())
     };
-    let haystack_str = haystack_opt.as_deref().unwrap_or(haystack);
+    let haystack = haystack_opt.as_deref().unwrap_or(haystack);
 
-    match matches(needle, haystack_str) {
+    match matches(needle, haystack) {
         Some(needle_length) => {
-            let (score, positions) = score_with_positions(needle, needle_length, haystack_str);
+            let (score, positions) = score_with_positions(needle, needle_length, haystack);
             Some((score, positions))
         }
         None => None,

--- a/crates/matcher/extracted_fzy/src/lib.rs
+++ b/crates/matcher/extracted_fzy/src/lib.rs
@@ -232,3 +232,29 @@ impl Matrix {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn case_insensitive() {
+        let result = match_and_score_with_positions("def", "abc DEF ghi");
+        assert_eq!(result, Some((552, vec![4, 5, 6])));
+
+        let result = match_and_score_with_positions("def", "abc def ghi");
+        assert_eq!(result, Some((552, vec![4, 5, 6])));
+
+        let result = match_and_score_with_positions("xyz", "abc def ghi");
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn smart_case() {
+        let result = match_and_score_with_positions("Def", "abc Def ghi");
+        assert_eq!(result, Some((552, vec![4, 5, 6])));
+
+        let result = match_and_score_with_positions("Def", "abc def ghi");
+        assert_eq!(result, None);
+    }
+}

--- a/pythonx/clap/scorer.py
+++ b/pythonx/clap/scorer.py
@@ -74,7 +74,9 @@ def compute(niddle, haystack):
     """
     n, m = len(niddle), len(haystack)
     bonus_score = bonus(haystack)
-    niddle, haystack = niddle.lower(), haystack.lower()
+
+    if niddle.islower():
+        haystack = haystack.lower()
 
     if n == 0 or n == m:
         return SCORE_MAX, list(range(n))
@@ -147,7 +149,9 @@ def score(niddle, haystack):
     """
     n, m = len(niddle), len(haystack)
     bonus_score = bonus(haystack)
-    niddle, haystack = niddle.lower(), haystack.lower()
+
+    if niddle.islower():
+        haystack = haystack.lower()
 
     if n == 0 or n == m:
         return SCORE_MAX, list(range(n))


### PR DESCRIPTION
Hey,

This PR is a request for feedback regarding the implementation of smart-case filtering. As a reminder, in vim the `'smartcase'` option makes searching with a lower-case input case-insensitive, but whenever the input contains an uppercase letter the search becomes case-sensitive. This improves results a lot when there is a known upper-case letter in the filter input.

This is also listed as a [possible improvement](https://github.com/jhawthorn/fzy/blob/master/ALGORITHM.md#case-sensitivity) to the original fzy algorithm.

Without smart-case, the desired target in placed in 12th position by the scoring function:
![Screenshot from 2020-10-14 19-07-01](https://user-images.githubusercontent.com/1423607/96054834-8e269d80-0e50-11eb-9842-9d5ced90dc1e.png)

With smart-case, the target in first position without unwanted targets:
![Screenshot from 2020-10-14 19-07-19](https://user-images.githubusercontent.com/1423607/96054841-9088f780-0e50-11eb-858e-a173f30b9c24.png)


This PR is a proof of concept, it only implements the filtering in the python scorer and is not optional. If you want to accept this PR I'll finish the implementation, here are more questions/comments:
 - IIUC, the filtering is done in `pythonx/clap/scorer.py`, `autoload/clap/filter/sync/viml.vim` and `autoload/clap/filter/async/dyn.vim`. Are there other places where the filtering mechanism should be updated?
 - I don't think this should be made optional, because case-insensitivity can be achieved by simply not using upper-case letters which is more costly in terms of typing, so no user should be doing it.