### PR TITLE
Update clap.txt

### DIFF
--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -808,8 +808,8 @@ Change default keybindings                      *change-clap-default-keybindings
   `clap_input`, e.g,
   >
   " For example, use <C-n>/<C-p> instead of <C-j>/<C-k> to navigate the result.
-  autocmd FileType clap_input inoremap <silent> <buffer> <C-n> <C-R>=clap#handler#navigate_result('down')<CR>
-  autocmd FileType clap_input inoremap <silent> <buffer> <C-p> <C-R>=clap#handler#navigate_result('up')<CR>
+  autocmd FileType clap_input inoremap <silent> <buffer> <C-n> <C-R>=clap#navigation#linewise('down')<CR>
+  autocmd FileType clap_input inoremap <silent> <buffer> <C-p> <C-R>=clap#navigation#linewise('up')<CR>
 <
   For Vim, please use |g:clap_popup_move_manager|.
   >


### PR DESCRIPTION
The current documentation to change keybindings for insert-mode scroll in a clap window did not work on my system.

This works -- but it doesn't remove the functionality of <C-j> (i.e. i can use either <C-n> or <C-j>, and likewise <C-p> or <C-k>)