### PR TITLE
Fix file preview and Clap filer in vim8

### DIFF
--- a/autoload/clap/job/daemon.vim
+++ b/autoload/clap/job/daemon.vim
@@ -78,10 +78,13 @@ if has('nvim')
     call chansend(s:job_id, a:msg."\n")
   endfunction
 
+  function! s:job_exists() abort
+    return s:job_id > 0
+  endfunction
 else
 
   function! s:out_cb(channel, message) abort
-    if s:job_id > 0 && a:channel == s:job_channel
+    if s:job_exists() && a:channel == s:job_channel
       if a:message =~# '^Content-length:' || a:message ==# ''
         return
       endif
@@ -94,7 +97,7 @@ else
   endfunction
 
   function! s:err_cb(channel, message) abort
-    if s:job_id > 0 && clap#job#vim8_job_id_of(a:channel) == s:job_id
+    if s:job_exists() && clap#job#vim8_job_id_of(a:channel) == s:job_id
       call clap#helper#echo_error(a:message)
     endif
   endfunction
@@ -114,10 +117,14 @@ else
   function! clap#job#daemon#send_message(msg) abort
     call ch_sendraw(s:job, a:msg."\n")
   endfunction
+
+  function! s:job_exists() abort
+    return s:job_id > -1
+  endfunction
 endif
 
 function! clap#job#daemon#stop() abort
-  if s:job_id > 0
+  if s:job_exists()
     call clap#job#stop(s:job_id)
     let s:job_id = -1
   endif

--- a/autoload/clap/job/stdio.vim
+++ b/autoload/clap/job/stdio.vim
@@ -86,6 +86,9 @@ if has('nvim')
     call chansend(s:job_id, a:msg."\n")
   endfunction
 
+  function! s:job_exists() abort
+    return s:job_id > 0
+  endfunction
 else
 
   function! s:out_cb(channel, message) abort
@@ -129,10 +132,14 @@ else
   function! clap#job#stdio#send_message(msg) abort
     call ch_sendraw(s:job, a:msg."\n")
   endfunction
+
+  function! s:job_exists() abort
+    return s:job_id > -1
+  endfunction
 endif
 
 function! clap#job#stdio#stop_service() abort
-  if s:job_id > 0
+  if s:job_exists()
     call clap#job#stop(s:job_id)
     let s:job_id = -1
   endif


### PR DESCRIPTION
When `job_start()` was first called by vim-clap in vim8, preview and Clap filer were not working.
The reason is that the job id in vim8 starts at 0, but the condition of whether the job exists or not is wrong.

To check the first id of the job in vim8, I ran the following command to verify it.
```
vim -u NONE -U NONE
echo ch_info(job_getchannel(job_start('ls')))
```
The above command outputs the following

```
{'status': 'open', 'id': 0, 'in_io': 'pipe', 'err_mode': 'NL', 'in_status': 'open', 'out_io': 'pipe', 'err_io': 'pipe', 'err_status': 'open', 'out_timeout': 2000, 'out_status': 'open', 'out_mode':
 'NL', 'in_mode': 'NL', 'in_timeout': 2000, 'err_timeout': 2000}
```

So I changed the conditions for the existence of job in vim8.