### PR TITLE
Improve command provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Improved
 
+- Command provider has a better rendering and let's the user add arguments #570
 - Fix the sluggish of vim when the preview lines are awfully long. #543
 
 ### Fixed

--- a/autoload/clap/provider/command.vim
+++ b/autoload/clap/provider/command.vim
@@ -8,14 +8,6 @@ set cpoptions&vim
 let s:command_header   = v:null
 let s:command_list = []
 
-function! s:right_pad(s, n)
-    return a:s . repeat(' ', a:n - len(a:s))
-endfunction
-
-function! s:left_pad(s, n)
-    return repeat(' ', a:n - len(a:s)) . a:s
-endfunction
-
 function! s:sink(selected) abort
   " :h command, note the characters in the first two columns
   let cmd = matchstr(a:selected, '\v^\s*\S+\s+\zs\S+')
@@ -50,7 +42,7 @@ let g:clap#provider#command# = s:command
 
 " Helpers
 
-function! s:parse_command (input)
+function! s:parse_command(input) abort
   let bang = stridx(a:input[0:3], '!') != -1
   let input = a:input[4:]
   let name = matchstr(input, '\v^\S+')
@@ -72,6 +64,14 @@ endfunc
 "   \ 'function', 'help', 'highlight', 'history', 'locale', 'mapclear', 'mapping',
 "   \ 'menu', 'messages', 'option', 'packadd', 'shellcmd', 'sign', 'syntax', 'syntime',
 "   \ 'tag', 'tag_listfiles', 'user', 'var', 'custom,\S+', 'customlist,\S+' ]
+
+function! s:right_pad(s, n) abort
+    return a:s . repeat(' ', a:n - len(a:s))
+endfunction
+
+function! s:left_pad(s, n) abort
+    return repeat(' ', a:n - len(a:s)) . a:s
+endfunction
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/autoload/clap/provider/command.vim
+++ b/autoload/clap/provider/command.vim
@@ -12,9 +12,13 @@ function! s:right_pad(s, n)
     return a:s . repeat(' ', a:n - len(a:s))
 endfunction
 
+function! s:left_pad(s, n)
+    return repeat(' ', a:n - len(a:s)) . a:s
+endfunction
+
 function! s:sink(selected) abort
   " :h command, note the characters in the first two columns
-  let cmd = matchstr(a:selected, '^[!"|b ]*\zs\(\w*\)\ze ')
+  let cmd = matchstr(a:selected, '\v^\s*\S+\s+\zs\S+')
   let list = split(execute('command ' . cmd), "\n")
   let command = s:parse_command(list[1])
   if command.args ==# '0'
@@ -25,12 +29,15 @@ function! s:sink(selected) abort
 endfunction
 
 function! s:source() abort
+  let margin = 9
   let list = split(execute('command'), "\n")
   let s:command_header = list[0]
   let s:command_list = list[1:]
   call map(s:command_list, {key, val -> s:parse_command(val)})
   return map(copy(s:command_list), {key, val ->
-    \ s:right_pad(val.name, 30) . ' ' . printf('[%s] %s', val.args, val.rest)})
+        \ s:left_pad(printf('[%s] ', val.args), margin)
+        \ . s:right_pad(val.name, 30)
+        \ . ' ' . val.rest})
 endfunction
 
 
@@ -38,7 +45,6 @@ let s:command = {}
 let s:command.syntax = 'clap_command'
 let s:command.source = function('s:source')
 let s:command.sink = function('s:sink')
-let s:command.on_enter = function('s:on_enter')
 
 let g:clap#provider#command# = s:command
 

--- a/autoload/clap/provider/command.vim
+++ b/autoload/clap/provider/command.vim
@@ -4,21 +4,68 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-let s:command = {}
 
-function! s:command.sink(selected) abort
+let s:command_header   = v:null
+let s:command_list = []
+
+function! s:right_pad(s, n)
+    return a:s . repeat(' ', a:n - len(a:s))
+endfunction
+
+function! s:sink(selected) abort
   " :h command, note the characters in the first two columns
   let cmd = matchstr(a:selected, '^[!"|b ]*\zs\(\w*\)\ze ')
-  execute cmd
+  let list = split(execute('command ' . cmd), "\n")
+  let command = s:parse_command(list[1])
+  if command.args ==# '0'
+    execute cmd
+  else
+    call feedkeys(':' . cmd . ' ', 'n')
+  end
 endfunction
 
-function! s:command.source() abort
-  return split(execute('command'), "\n")
+function! s:source() abort
+  let list = split(execute('command'), "\n")
+  let s:command_header = list[0]
+  let s:command_list = list[1:]
+  call map(s:command_list, {key, val -> s:parse_command(val)})
+  return map(copy(s:command_list), {key, val ->
+    \ s:right_pad(val.name, 30) . ' ' . printf('[%s] %s', val.args, val.rest)})
 endfunction
 
+
+let s:command = {}
 let s:command.syntax = 'clap_command'
+let s:command.source = function('s:source')
+let s:command.sink = function('s:sink')
+let s:command.on_enter = function('s:on_enter')
 
 let g:clap#provider#command# = s:command
+
+" Helpers
+
+function! s:parse_command (input)
+  let bang = stridx(a:input[0:3], '!') != -1
+  let input = a:input[4:]
+  let name = matchstr(input, '\v^\S+')
+  let input = input[len(name):]
+  let args = matchstr(input, '\v\s+\S+')
+  let input = input[len(args):]
+  let args = trim(args)
+  let rest = trim(input)
+  " let input = trim(input)
+  " let input = input[len(args):]
+  " let [sequence, address, complete] = matchlist(input, '\v *(\S+)? *(\S+) *')
+  return { 'name': name, 'bang': bang, 'args': args, 'rest': rest }
+endfunc
+
+" NOTE: in case we want to do something with this eventually...
+" let complete_patterns = [
+"   \ 'arglist', 'augroup', 'buffer', 'behave', 'color', 'command', 'compiler', 'cscope',
+"   \ 'dir', 'environment', 'event', 'expression', 'file', 'file_in_path', 'filetype',
+"   \ 'function', 'help', 'highlight', 'history', 'locale', 'mapclear', 'mapping',
+"   \ 'menu', 'messages', 'option', 'packadd', 'shellcmd', 'sign', 'syntax', 'syntime',
+"   \ 'tag', 'tag_listfiles', 'user', 'var', 'custom,\S+', 'customlist,\S+' ]
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/syntax/clap_command.vim
+++ b/syntax/clap_command.vim
@@ -1,7 +1,13 @@
-syntax match ClapCommand           /^[!"|b ]*\zs\u\w* / nextgroup=ClapCommandArgs skipwhite
-syntax match ClapCommandArgs       /\[[1?*+]\]/
-syntax match ClapCommandArgsNone   /\[0\]/
 
-hi default link ClapCommand         Function
-hi default link ClapCommandArgs     Keyword
-hi default link ClapCommandArgsNone WarningMsg
+syntax match  ClapCommand                /\v^\s+\S+\s+\S+\s+/   contains=ClapCommandArgs,ClapCommandArgsNone
+syntax match  ClapCommandArgs            /\v\[[1?*+]\]\s+/      contained nextgroup=ClapCommandName
+syntax match  ClapCommandArgsNone        /\v\[0\]\s+/           contained nextgroup=ClapCommandNameI
+syntax match  ClapCommandName            /\v\u\w+/              contained skipwhite nextgroup=ClapCommandRest
+syntax match  ClapCommandNameI           /\v\u\w+/              contained skipwhite nextgroup=ClapCommandRest
+syntax match  ClapCommandRest            /\v.+$/                contained skipwhite
+
+hi default link ClapCommandArgs          Keyword
+hi default link ClapCommandArgsNone      Keyword
+hi default link ClapCommandName          ModeMsg
+hi default link ClapCommandNameI         WarningMsg
+hi default link ClapCommandRest          Comment

--- a/syntax/clap_command.vim
+++ b/syntax/clap_command.vim
@@ -2,8 +2,8 @@
 syntax match  ClapCommand                /\v^\s+\S+\s+\S+\s+/   contains=ClapCommandArgs,ClapCommandArgsNone
 syntax match  ClapCommandArgs            /\v\[[1?*+]\]\s+/      contained nextgroup=ClapCommandName
 syntax match  ClapCommandArgsNone        /\v\[0\]\s+/           contained nextgroup=ClapCommandNameI
-syntax match  ClapCommandName            /\v\u\w+/              contained skipwhite nextgroup=ClapCommandRest
-syntax match  ClapCommandNameI           /\v\u\w+/              contained skipwhite nextgroup=ClapCommandRest
+syntax match  ClapCommandName            /\v\u\w*/              contained skipwhite nextgroup=ClapCommandRest
+syntax match  ClapCommandNameI           /\v\u\w*/              contained skipwhite nextgroup=ClapCommandRest
 syntax match  ClapCommandRest            /\v.+$/                contained skipwhite
 
 hi default link ClapCommandArgs          Keyword

--- a/syntax/clap_command.vim
+++ b/syntax/clap_command.vim
@@ -1,5 +1,7 @@
-syntax match ClapCommand /^[!"|b ]*\zs\u\w* /
-syntax match ClapCommandHeader /Name        Args       Address   Complete  Definition/
+syntax match ClapCommand           /^[!"|b ]*\zs\u\w* / nextgroup=ClapCommandArgs skipwhite
+syntax match ClapCommandArgs       /\[[1?*+]\]/
+syntax match ClapCommandArgsNone   /\[0\]/
 
-hi default link ClapCommand Function
-hi default link ClapCommandHeader Title
+hi default link ClapCommand         Function
+hi default link ClapCommandArgs     Keyword
+hi default link ClapCommandArgsNone WarningMsg


### PR DESCRIPTION
Quick improvements for the default `command` provider:
 - Style: Parse & render each command instead of feeding `execute('command')` directly into clap
 - Behavior: if a command has 0 arguments, it is executed immediately; otherwise, the user is put in command-mode with `:CommandName<space>` pre-filled so they can enter additional arguments
 - Style: commands with 0 arguments have their argument highlighted with `WarningMsg` to denote they will be executed immediately

@liuchengxu This is ready for merging as it is, I wanted to do more but the rest can wait.

Before:
![Screenshot from 2020-10-26 17-04-48](https://user-images.githubusercontent.com/1423607/97228504-6965ea80-17ad-11eb-89d6-766c36324f1f.png)

After:
![Screenshot from 2020-10-26 16-55-40](https://user-images.githubusercontent.com/1423607/97228133-d4fb8800-17ac-11eb-8918-8010b644ae87.png)
