### PR TITLE
fix: trigger autocmmands correctly when restoring window

### DIFF
--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -182,12 +182,13 @@ endfunction
 
 " Sometimes we don't need to go back to the start window, hence clap#_exit() is extracted.
 function! clap#exit() abort
-  call clap#_exit()
+  noautocmd call clap#_exit()
 
   " NOTE: Need to go back to the start window
   if win_getid() != g:clap.start.winid
     call g:clap.start.goto_win()
   endif
+  doautocmd WinEnter
 endfunction
 
 function! clap#should_use_raw_cwd() abort

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -182,12 +182,8 @@ endfunction
 
 " Sometimes we don't need to go back to the start window, hence clap#_exit() is extracted.
 function! clap#exit() abort
+  noautocmd call g:clap.start.goto_win()
   noautocmd call clap#_exit()
-
-  " NOTE: Need to go back to the start window
-  if win_getid() != g:clap.start.winid
-    call g:clap.start.goto_win()
-  endif
   doautocmd WinEnter
 endfunction
 

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -155,7 +155,7 @@ function! clap#_exit() abort
   call clap#job#regular#forerunner#stop()
   call clap#maple#clean_up()
 
-  call g:clap.close_win()
+  noautocmd call g:clap.close_win()
 
   let g:clap.is_busy = 0
   let g:clap.display.cache = []
@@ -182,9 +182,8 @@ endfunction
 
 " Sometimes we don't need to go back to the start window, hence clap#_exit() is extracted.
 function! clap#exit() abort
-  noautocmd call g:clap.start.goto_win()
-  noautocmd call clap#_exit()
-  doautocmd WinEnter
+  call g:clap.start.goto_win()
+  call clap#_exit()
 endfunction
 
 function! clap#should_use_raw_cwd() abort

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -8,7 +8,7 @@ let s:is_nvim = has('nvim')
 let s:cat_or_type = has('win32') ? 'type' : 'cat'
 
 function! s:_goto_win() dict abort
-  noautocmd call win_gotoid(self.winid)
+  call win_gotoid(self.winid)
 endfunction
 
 function! s:_getbufvar(varname) dict abort

--- a/autoload/clap/provider/blines.vim
+++ b/autoload/clap/provider/blines.vim
@@ -9,7 +9,6 @@ let s:blines = {}
 function! s:blines.sink(selected) abort
   let lnum = matchstr(a:selected, '^\s*\(\d\+\) ')
   let lnum = str2nr(trim(lnum))
-  call g:clap.start.goto_win()
   " Push the current position to the jumplist
   normal! m'
   silent call cursor(lnum, 1)

--- a/autoload/clap/provider/buffers.vim
+++ b/autoload/clap/provider/buffers.vim
@@ -52,7 +52,6 @@ function! s:extract_bufnr(line) abort
 endfunction
 
 function! s:buffers_sink(selected) abort
-  call g:clap.start.goto_win()
   let b = s:extract_bufnr(a:selected)
   if has_key(g:clap, 'open_action')
     execute g:clap.open_action

--- a/autoload/clap/provider/colors.vim
+++ b/autoload/clap/provider/colors.vim
@@ -23,10 +23,10 @@ endfunction
 " Preview the colorscheme on move
 function! s:colors.on_move() abort
   " This is neccessary
-  call g:clap.start.goto_win()
+  noautocmd call g:clap.start.goto_win()
   execute 'color' g:clap.display.getcurline()
   do Syntax
-  call g:clap.input.goto_win()
+  noautocmd call g:clap.input.goto_win()
 endfunction
 
 function! s:colors.sink(selected) abort
@@ -39,7 +39,7 @@ endfunction
 
 function! s:colors.on_exit() abort
   if get(s:, 'should_restore_color', v:true)
-    call g:clap.start.goto_win()
+    noautocmd call g:clap.start.goto_win()
     execute 'color' trim(s:old_color)
     let &background = s:old_bg
     let s:should_restore_color = v:true


### PR DESCRIPTION
![clap-bug](https://user-images.githubusercontent.com/1423607/97816516-d7a22580-1c63-11eb-9436-602f77335fe2.gif)

This fixes a bug that I noticed in [barbar.nvim](https://github.com/romgrk/barbar.nvim). Barbar has a feature that a new buffer is opened next in order to the current buffer. The current clap behavior for restoring the current window is:
 - Close clap window, letting vim decide which window to focus back *triggering autocommands*
 - If the window isn't the right one, switch windows *without triggering autocmd* (`clap.start.goto_win()`)

This makes it that the last current buffer from any other plugin's perspective is the one to which vim focused back. This solves the issue.