### PR TITLE
Split out matchers

### DIFF
--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -19,6 +19,7 @@
 
 mod algo;
 mod line_splitter;
+mod matchers;
 
 pub use algo::*;
 pub use line_splitter::*;

--- a/crates/matcher/src/matchers/file_name.rs
+++ b/crates/matcher/src/matchers/file_name.rs
@@ -1,0 +1,21 @@
+use super::MatchItem;
+use pattern::file_name_only;
+
+#[derive(Clone, Debug)]
+pub struct FileNameMatcher<'a>(&'a str);
+
+impl<'a> MatchItem<'a> for FileNameMatcher<'a> {
+    fn display(&self) -> &'a str {
+        self.0
+    }
+
+    fn match_text(&self) -> Option<(&'a str, usize)> {
+        file_name_only(self.0)
+    }
+}
+
+impl<'a> From<&'a str> for FileNameMatcher<'a> {
+    fn from(inner: &'a str) -> Self {
+        Self(inner)
+    }
+}

--- a/crates/matcher/src/matchers/file_name.rs
+++ b/crates/matcher/src/matchers/file_name.rs
@@ -5,7 +5,7 @@ use pattern::file_name_only;
 pub struct FileNameMatcher<'a>(&'a str);
 
 impl<'a> MatchItem<'a> for FileNameMatcher<'a> {
-    fn display(&self) -> &'a str {
+    fn display_text(&self) -> &'a str {
         self.0
     }
 

--- a/crates/matcher/src/matchers/grep.rs
+++ b/crates/matcher/src/matchers/grep.rs
@@ -5,7 +5,7 @@ use pattern::strip_grep_filepath;
 pub struct GrepMatcher<'a>(&'a str);
 
 impl<'a> MatchItem<'a> for GrepMatcher<'a> {
-    fn display(&self) -> &'a str {
+    fn display_text(&self) -> &'a str {
         self.0
     }
 

--- a/crates/matcher/src/matchers/grep.rs
+++ b/crates/matcher/src/matchers/grep.rs
@@ -1,0 +1,21 @@
+use super::MatchItem;
+use pattern::strip_grep_filepath;
+
+#[derive(Clone, Debug)]
+pub struct GrepMatcher<'a>(&'a str);
+
+impl<'a> MatchItem<'a> for GrepMatcher<'a> {
+    fn display(&self) -> &'a str {
+        self.0
+    }
+
+    fn match_text(&self) -> Option<(&'a str, usize)> {
+        strip_grep_filepath(self.0)
+    }
+}
+
+impl<'a> From<&'a str> for GrepMatcher<'a> {
+    fn from(inner: &'a str) -> Self {
+        Self(inner)
+    }
+}

--- a/crates/matcher/src/matchers/mod.rs
+++ b/crates/matcher/src/matchers/mod.rs
@@ -1,0 +1,16 @@
+mod file_name;
+mod grep;
+mod tag_name;
+
+pub use self::file_name::FileNameMatcher;
+pub use self::grep::GrepMatcher;
+pub use self::tag_name::TagNameMatcher;
+
+pub trait MatchItem<'a> {
+    /// Returns the text for displaying.
+    fn display(&self) -> &'a str;
+
+    // Currently we only take care of matching one piece.
+    /// Returns the text for matching and the offset (in byte) of it begins.
+    fn match_text(&self) -> Option<(&'a str, usize)>;
+}

--- a/crates/matcher/src/matchers/mod.rs
+++ b/crates/matcher/src/matchers/mod.rs
@@ -8,7 +8,7 @@ pub use self::tag_name::TagNameMatcher;
 
 pub trait MatchItem<'a> {
     /// Returns the text for displaying.
-    fn display(&self) -> &'a str;
+    fn display_text(&self) -> &'a str;
 
     // Currently we only take care of matching one piece.
     /// Returns the text for matching and the offset (in byte) of it begins.

--- a/crates/matcher/src/matchers/tag_name.rs
+++ b/crates/matcher/src/matchers/tag_name.rs
@@ -5,7 +5,7 @@ use pattern::tag_name_only;
 pub struct TagNameMatcher<'a>(&'a str);
 
 impl<'a> MatchItem<'a> for TagNameMatcher<'a> {
-    fn display(&self) -> &'a str {
+    fn display_text(&self) -> &'a str {
         self.0
     }
 

--- a/crates/matcher/src/matchers/tag_name.rs
+++ b/crates/matcher/src/matchers/tag_name.rs
@@ -1,0 +1,21 @@
+use super::MatchItem;
+use pattern::tag_name_only;
+
+#[derive(Clone, Debug)]
+pub struct TagNameMatcher<'a>(&'a str);
+
+impl<'a> MatchItem<'a> for TagNameMatcher<'a> {
+    fn display(&self) -> &'a str {
+        self.0
+    }
+
+    fn match_text(&self) -> Option<(&'a str, usize)> {
+        tag_name_only(self.0).map(|s| (s, 0))
+    }
+}
+
+impl<'a> From<&'a str> for TagNameMatcher<'a> {
+    fn from(inner: &'a str) -> Self {
+        Self(inner)
+    }
+}


### PR DESCRIPTION
Introduce a trait `MatchItem` for various needs of getting the matching
text from the origin line.