### PR TITLE
fix: resize on neovim

### DIFF
--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -11,8 +11,6 @@ let g:clap#floating_win#display = {}
 let g:clap#floating_win#spinner = {}
 let g:clap#floating_win#preview = {}
 
-let s:is_open = v:false
-
 let s:shadow_bufnr = nvim_create_buf(v:false, v:true)
 
 let s:spinner_bufnr = nvim_create_buf(v:false, v:true)
@@ -83,27 +81,6 @@ function! g:clap#floating_win#display.open() abort
         \ '&signcolumn': 'yes',
         \ '&foldcolumn': 0,
         \ })
-endfunction
-
-function! clap#floating_win#redo_layout() abort
-  if !s:is_open
-    return
-  end
-  let s:display_opts = clap#layout#calc()
-  call nvim_win_set_config(s:display_winid, s:display_opts)
-  call nvim_win_set_config(s:spinner_winid, s:get_config_spinner())
-  call nvim_win_set_config(s:input_winid, s:get_config_input())
-  call nvim_win_set_config(s:indicator_winid, s:get_config_indicator())
-  if s:symbol_width > 0
-    call nvim_win_set_config(s:symbol_left_winid, s:get_config_border_left())
-    call nvim_win_set_config(s:symbol_right_winid, s:get_config_border_right())
-  endif
-  let max_size = s:max_preview_size()
-  if max_size <= 2
-    call g:clap#floating_win#preview.close()
-  else
-    call nvim_win_set_config(s:preview_winid, s:get_config_preview(max_size))
-  endif
 endfunction
 
 function! g:clap#floating_win#display.shrink_if_undersize() abort
@@ -437,8 +414,6 @@ function! clap#floating_win#open() abort
   call g:clap.provider.try_set_syntax()
   call g:clap.provider.on_enter()
 
-  let s:is_open = v:true
-
   silent doautocmd <nomodeline> User ClapOnEnter
 
   startinsert
@@ -457,8 +432,6 @@ endfunction
 function! clap#floating_win#close() abort
   let &winheight = s:save_winheight
   silent! autocmd! ClapEnsureAllClosed
-
-  let s:is_open = v:false
 
   if s:symbol_width > 0
     call s:win_close(s:symbol_left_winid)

--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -11,6 +11,8 @@ let g:clap#floating_win#display = {}
 let g:clap#floating_win#spinner = {}
 let g:clap#floating_win#preview = {}
 
+let s:is_open = v:false
+
 let s:shadow_bufnr = nvim_create_buf(v:false, v:true)
 
 let s:spinner_bufnr = nvim_create_buf(v:false, v:true)
@@ -84,6 +86,9 @@ function! g:clap#floating_win#display.open() abort
 endfunction
 
 function! clap#floating_win#redo_layout() abort
+  if !s:is_open
+    return
+  end
   let s:display_opts = clap#layout#calc()
   call nvim_win_set_config(s:display_winid, s:display_opts)
   call nvim_win_set_config(s:spinner_winid, s:get_config_spinner())
@@ -432,6 +437,8 @@ function! clap#floating_win#open() abort
   call g:clap.provider.try_set_syntax()
   call g:clap.provider.on_enter()
 
+  let s:is_open = v:true
+
   silent doautocmd <nomodeline> User ClapOnEnter
 
   startinsert
@@ -450,6 +457,8 @@ endfunction
 function! clap#floating_win#close() abort
   let &winheight = s:save_winheight
   silent! autocmd! ClapEnsureAllClosed
+
+  let s:is_open = v:false
 
   if s:symbol_width > 0
     call s:win_close(s:symbol_left_winid)

--- a/autoload/clap/init.vim
+++ b/autoload/clap/init.vim
@@ -67,15 +67,6 @@ function! clap#init#() abort
   if clap#maple#is_available()
     call clap#job#daemon#start(function('clap#client#handle'))
   endif
-
-  " This augroup should be retained after closing vim-clap for the benefit
-  " of next run.
-  if !exists('#ClapResize')
-    augroup ClapResize
-      autocmd!
-      autocmd VimResized * call clap#layout#on_resized()
-    augroup END
-  endif
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/layout.vim
+++ b/autoload/clap/layout.vim
@@ -77,10 +77,6 @@ if s:is_nvim
           \ 'relative': 'win',
           \ }
   endfunction
-
-  function! clap#layout#on_resized() abort
-    call clap#floating_win#redo_layout()
-  endfunction
 else
   function! s:user_layout() abort
     let layout = extend(copy(s:default_layout), g:clap_layout)
@@ -111,12 +107,6 @@ else
           \ 'row': s:calc(height, s:default_layout.row) + row,
           \ 'col': s:calc(width, s:default_layout.col) + col,
           \ }
-  endfunction
-
-  function! clap#layout#on_resized() abort
-    " FIXME resize window if vim-clap is visible
-    " Vim's popup has a fixed option which makes the preview window tolerable.
-    " Ref #454
   endfunction
 endif
 


### PR DESCRIPTION
Closes #516 

Pros:
 - Resizing while clap is closed now works
Cons:
 - Resizing while clap is open now segfaults (neovim bug)

I think it's still preferable to do this, I'm guessing most people don't resize while clap is open.

Source:
```
(gdb) f 4
#4  0x000056238641ce93 in msg_scroll_flush () at ../src/nvim/message.c:2229
2229	    assert(pos_delta >= 0);
```
Known issue: https://github.com/neovim/neovim/issues/12432