### PR TITLE
Initial support for fzy lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ target
 testdata.txt
 publish.sh
 crates/Cargo.lock
+pythonx/clap/fuzzymatch_rs.so
 
 !.editorconfig
 !.travis.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `g:clap_popup_move_manager` so that Vim users can override the default mappings easily. #536
 - Allow user to always download the prebuilt binary. #531
 - Support smartcase fitlering for fzy algo and it's the default behavior. #541 @romgrk
+- Add initial support for fzy lua. #599
 
 ### Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add `g:clap_popup_move_manager` so that Vim users can override the default mappings easily. #536
 - Allow user to always download the prebuilt binary. #531
 - Support smartcase fitlering for fzy algo and it's the default behavior. #541 @romgrk
-- Add initial support for fzy lua. #599
+- Add initial support for fzy lua, neovim-nightly or vim compiled with lua is required. #599
 
 ### Improved
 

--- a/autoload/clap/debugging.vim
+++ b/autoload/clap/debugging.vim
@@ -59,7 +59,11 @@ function! clap#debugging#info() abort
   echohl Normal | echon has('python3')           | echohl NONE
 
   echohl Type   | echo 'has py dynamic module: '                | echohl NONE
-  echohl Normal | echon clap#filter#sync#python#has_dynamic_module() | echohl NONE
+  try
+    echohl Normal | echon clap#filter#sync#python#has_dynamic_module() | echohl NONE
+  catch
+    echohl Normal | echon 'ERROR: '.v:exception | echohl NONE
+  endtry
 
   echohl Type   | echo '            has ctags: '                | echohl NONE
   if executable('ctags')
@@ -71,6 +75,9 @@ function! clap#debugging#info() abort
   else
     echohl Normal | echon 'ctags not found'    | echohl NONE
   endif
+
+  echohl Type   | echo '    Current sync impl: '   | echohl NONE
+  echohl Normal | echon clap#filter#current_impl() | echohl NONE
 
   echohl Type   | echo '     Current FileType: ' | echohl NONE
   echohl Normal | echon &filetype                | echohl NONE

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -46,10 +46,12 @@ function! s:enable_icon() abort
 endfunction
 
 if s:can_use_lua
+  let s:current_filter_impl = 'Lua'
   function! clap#filter#sync(query, candidates) abort
     return clap#filter#sync#lua#(a:query, a:candidates, -1, s:enable_icon(), -1)
   endfunction
 elseif s:can_use_python
+  let s:current_filter_impl = 'Python'
   function! s:line_splitter() abort
     return exists('g:__clap_builtin_line_splitter_enum') ? g:__clap_builtin_line_splitter_enum : 'Full'
   endfunction
@@ -63,6 +65,7 @@ elseif s:can_use_python
     endtry
   endfunction
 else
+  let s:current_filter_impl = 'VimL'
   function! clap#filter#sync(query, candidates) abort
     return clap#filter#sync#viml#(a:query, a:candidates)
   endfunction
@@ -96,6 +99,10 @@ function! clap#filter#on_typed(FilterFn, query, candidates) abort
       call g:clap.display.add_highlight()
     endif
   endif
+endfunction
+
+function! clap#filter#current_impl() abort
+  return s:current_filter_impl
 endfunction
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -20,7 +20,7 @@ let s:can_use_lua = has('nvim-0.5') || has('lua') ? v:true : v:false
 
 if exists('g:clap_builtin_fuzzy_filter_threshold')
   let s:builtin_filter_capacity = g:clap_builtin_fuzzy_filter_threshold
-elseif s:has_py_dynamic_module
+elseif s:can_use_lua || s:has_py_dynamic_module
   let s:builtin_filter_capacity = 30000
 else
   let s:builtin_filter_capacity = 10000

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -16,8 +16,7 @@ if has('python3') || has('python')
   endtry
 endif
 
-" TODO: require nvim 0.5?
-let s:can_use_lua = has('nvim') || has('lua') ? v:true : v:false
+let s:can_use_lua = has('nvim-0.5') || has('lua') ? v:true : v:false
 
 if exists('g:clap_builtin_fuzzy_filter_threshold')
   let s:builtin_filter_capacity = g:clap_builtin_fuzzy_filter_threshold

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -16,6 +16,8 @@ if has('python3') || has('python')
   endtry
 endif
 
+let s:can_use_lua = has('nvim') || has('lua') ? v:true : v:false
+
 if exists('g:clap_builtin_fuzzy_filter_threshold')
   let s:builtin_filter_capacity = g:clap_builtin_fuzzy_filter_threshold
 elseif s:has_py_dynamic_module
@@ -32,19 +34,22 @@ function! clap#filter#capacity() abort
   return s:builtin_filter_capacity
 endfunction
 
-if s:can_use_python
+let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history', 'filer']
 
-  let s:related_builtin_providers = ['tags', 'buffers', 'files', 'git_files', 'history', 'filer']
+function! s:enable_icon() abort
+  if g:clap_enable_icon
+        \ && index(s:related_builtin_providers, g:clap.provider.id) > -1
+    return v:true
+  else
+    return v:false
+  endif
+endfunction
 
-  function! s:enable_icon() abort
-    if g:clap_enable_icon
-          \ && index(s:related_builtin_providers, g:clap.provider.id) > -1
-      return v:true
-    else
-      return v:false
-    endif
+if s:can_use_lua
+  function! clap#filter#sync(query, candidates) abort
+    return clap#filter#sync#lua#(a:query, a:candidates, -1, s:enable_icon(), -1)
   endfunction
-
+elseif s:can_use_python
   function! s:line_splitter() abort
     return exists('g:__clap_builtin_line_splitter_enum') ? g:__clap_builtin_line_splitter_enum : 'Full'
   endfunction

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -16,6 +16,7 @@ if has('python3') || has('python')
   endtry
 endif
 
+" TODO: require nvim 0.5?
 let s:can_use_lua = has('nvim') || has('lua') ? v:true : v:false
 
 if exists('g:clap_builtin_fuzzy_filter_threshold')

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -1,0 +1,16 @@
+" Author: liuchengxu <xuliuchengxlc@gmail.com>
+" Description: Lua implementation of fzy filter algorithm.
+
+function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
+  let g:_clap_lua_query = a:query
+  let g:_clap_lua_candidates = a:candidates
+  let g:_clap_lua_enable_icon = a:enable_icon
+
+lua << EOF
+local fzy_filter = require('fzy_filter')
+vim.g.__clap_fuzzy_matched_indices, vim.g._clap_lua_filtered =
+    fzy_filter.do_fuzzy_match(vim.g._clap_lua_query, vim.g._clap_lua_candidates, vim.g._clap_lua_enable_icon)
+EOF
+
+  return g:_clap_lua_filtered
+endfunction

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -34,11 +34,11 @@ for i = #candidates-1, 0, -1 do
   table.insert(lines, candidates[i])
 end
 
-_clap_fuzzy_matched_indices, _clap_lua_filtered =
+matched_indices, _clap_lua_filtered =
     fzy_filter.do_fuzzy_match(vim.eval('a:query'), lines, vim.eval('a:enable_icon'))
 
 __clap_fuzzy_matched_indices = {}
-for i, v1 in ipairs(_clap_fuzzy_matched_indices) do
+for i, v1 in ipairs(matched_indices) do
   local joint_indices = ''
   for _, v2 in ipairs(v1) do
     joint_indices = joint_indices .. v2 .. ','

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -6,6 +6,7 @@ set cpoptions&vim
 
 " TODO: Older neovim & Vim support?
 if has('nvim')
+
   function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
     let g:_clap_lua_query = a:query
     let g:_clap_lua_candidates = a:candidates
@@ -19,7 +20,9 @@ EOF
 
     return g:_clap_lua_filtered
   endfunction
+
 else
+
   function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
 lua << EOF
 local fzy_filter = require('fzy_filter')
@@ -33,12 +36,28 @@ end
 
 _clap_fuzzy_matched_indices, _clap_lua_filtered =
     fzy_filter.do_fuzzy_match(vim.eval('a:query'), lines, vim.eval('a:enable_icon'))
+
+__clap_fuzzy_matched_indices = {}
+for i, v1 in ipairs(_clap_fuzzy_matched_indices) do
+  local joint_indices = ''
+  for _, v2 in ipairs(v1) do
+    joint_indices = joint_indices .. v2 .. ','
+  end
+  table.insert(__clap_fuzzy_matched_indices, joint_indices)
+end
 EOF
 
     " TODO: vim.list() can not work with a List of List.
-    " echom string(luaeval('vim.list(_clap_fuzzy_matched_indices)'))
+    " echom string(luaeval('vim.list(__clap_fuzzy_matched_indices)'))
+
+    let g:__clap_fuzzy_matched_indices = []
+    for joint_indices in luaeval('vim.list(__clap_fuzzy_matched_indices)')
+      call add(g:__clap_fuzzy_matched_indices, map(split(joint_indices, ','), 'str2nr(v:val)'))
+    endfor
+
     return luaeval('vim.list(_clap_lua_filtered)')
   endfunction
+
 endif
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -22,6 +22,10 @@ EOF
 
 else
 
+  function! s:deconstrcut(joint_indices) abort
+    return map(split(a:joint_indices, ','), 'str2nr(v:val)')
+  endfunction
+
   function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
 lua << EOF
 local fzy_filter = require('fzy_filter')
@@ -49,10 +53,7 @@ EOF
     " TODO: vim.list() can not work with a List of List.
     " echom string(luaeval('vim.list(__clap_fuzzy_matched_indices)'))
 
-    let g:__clap_fuzzy_matched_indices = []
-    for joint_indices in luaeval('vim.list(__clap_fuzzy_matched_indices)')
-      call add(g:__clap_fuzzy_matched_indices, map(split(joint_indices, ','), 'str2nr(v:val)'))
-    endfor
+    let g:__clap_fuzzy_matched_indices = map(luaeval('vim.list(__clap_fuzzy_matched_indices)'), 's:deconstrcut(v:val)')
 
     return luaeval('vim.list(_clap_lua_filtered)')
   endfunction

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -4,6 +4,7 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
+" TODO: Older neovim & Vim support?
 function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
   let g:_clap_lua_query = a:query
   let g:_clap_lua_candidates = a:candidates

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -1,6 +1,9 @@
 " Author: liuchengxu <xuliuchengxlc@gmail.com>
 " Description: Lua implementation of fzy filter algorithm.
 
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
 function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
   let g:_clap_lua_query = a:query
   let g:_clap_lua_candidates = a:candidates
@@ -14,3 +17,6 @@ EOF
 
   return g:_clap_lua_filtered
 endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -4,8 +4,7 @@
 let s:save_cpo = &cpoptions
 set cpoptions&vim
 
-" TODO: Older neovim & Vim support?
-if has('nvim')
+if has('nvim-0.5')
 
   function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
     let g:_clap_lua_query = a:query

--- a/autoload/clap/filter/sync/lua.vim
+++ b/autoload/clap/filter/sync/lua.vim
@@ -5,10 +5,11 @@ let s:save_cpo = &cpoptions
 set cpoptions&vim
 
 " TODO: Older neovim & Vim support?
-function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
-  let g:_clap_lua_query = a:query
-  let g:_clap_lua_candidates = a:candidates
-  let g:_clap_lua_enable_icon = a:enable_icon
+if has('nvim')
+  function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
+    let g:_clap_lua_query = a:query
+    let g:_clap_lua_candidates = a:candidates
+    let g:_clap_lua_enable_icon = a:enable_icon
 
 lua << EOF
 local fzy_filter = require('fzy_filter')
@@ -16,8 +17,29 @@ vim.g.__clap_fuzzy_matched_indices, vim.g._clap_lua_filtered =
     fzy_filter.do_fuzzy_match(vim.g._clap_lua_query, vim.g._clap_lua_candidates, vim.g._clap_lua_enable_icon)
 EOF
 
-  return g:_clap_lua_filtered
-endfunction
+    return g:_clap_lua_filtered
+  endfunction
+else
+  function! clap#filter#sync#lua#(query, candidates, _winwidth, enable_icon, _line_splitter) abort
+lua << EOF
+local fzy_filter = require('fzy_filter')
+
+local candidates = vim.eval('a:candidates')
+
+local lines = {}
+for i = #candidates-1, 0, -1 do
+  table.insert(lines, candidates[i])
+end
+
+_clap_fuzzy_matched_indices, _clap_lua_filtered =
+    fzy_filter.do_fuzzy_match(vim.eval('a:query'), lines, vim.eval('a:enable_icon'))
+EOF
+
+    " TODO: vim.list() can not work with a List of List.
+    " echom string(luaeval('vim.list(_clap_fuzzy_matched_indices)'))
+    return luaeval('vim.list(_clap_lua_filtered)')
+  endfunction
+endif
 
 let &cpoptions = s:save_cpo
 unlet s:save_cpo

--- a/lua/fzy_filter.lua
+++ b/lua/fzy_filter.lua
@@ -1,0 +1,73 @@
+local fzy = require("fzy_impl")
+
+local fzy_filter = {}
+
+local function dump(o)
+    if type(o) == "table" then
+        local s = "{ "
+        for k, v in pairs(o) do
+            if type(k) ~= "number" then
+                k = '"' .. k .. '"'
+            end
+            s = s .. "[" .. k .. "] = " .. dump(v) .. ","
+        end
+        return s .. "} "
+    else
+        return tostring(o)
+    end
+end
+
+local function apply_fzy(query, candidates, enable_icon)
+    matches = {}
+
+    for _, c in pairs(candidates) do
+        raw_c = c
+
+        -- Skip two chars, icon + one Space
+        if enable_icon then
+            c = string.sub(c, 5)
+            offset = 3
+        else
+            offset = -1
+        end
+
+        -- Enable case_sensitive
+        if fzy.has_match(query, c, true) then
+            positions, score = fzy.positions(query, c)
+            if score ~= fzy.get_score_min() then
+                adjusted_positions = {}
+                for i, v in ipairs(positions) do
+                    adjusted_positions[i] = v + offset
+                end
+                table.insert(matches, {text = raw_c, score = score, indices = adjusted_positions})
+            end
+        end
+    end
+
+    return matches
+end
+
+local function compare(a, b)
+    return a[2]["score"] > b[2]["score"]
+end
+
+function fzy_filter.do_fuzzy_match(query, candidates, enable_icon)
+    scored = apply_fzy(query, candidates, enable_icon)
+
+    ranked = {}
+    for k, v in pairs(scored) do
+        table.insert(ranked, {k, v})
+    end
+    table.sort(ranked, compare)
+
+    indices = {}
+    filtered = {}
+    for k, v in pairs(ranked) do
+        table.insert(indices, v[2].indices)
+        table.insert(filtered, v[2].text)
+    end
+
+    return indices, filtered
+end
+
+return fzy_filter

--- a/lua/fzy_filter.lua
+++ b/lua/fzy_filter.lua
@@ -18,6 +18,11 @@ local function dump(o)
 end
 
 local function apply_fzy(query, candidates, enable_icon)
+    if string.match(query, '%u') then
+        case_sensitive = true
+    else
+        case_sensitive = false
+    end
     matches = {}
 
     for _, c in pairs(candidates) do
@@ -32,7 +37,7 @@ local function apply_fzy(query, candidates, enable_icon)
         end
 
         -- Enable case_sensitive
-        if fzy.has_match(query, c, true) then
+        if fzy.has_match(query, c, case_sensitive) then
             positions, score = fzy.positions(query, c)
             if score ~= fzy.get_score_min() then
                 adjusted_positions = {}

--- a/lua/fzy_impl.lua
+++ b/lua/fzy_impl.lua
@@ -1,0 +1,277 @@
+-- Borrowed from https://github.com/swarn/fzy-lua
+--
+-- The lua implementation of the fzy string matching algorithm
+
+local SCORE_GAP_LEADING = -0.005
+local SCORE_GAP_TRAILING = -0.005
+local SCORE_GAP_INNER = -0.01
+local SCORE_MATCH_CONSECUTIVE = 1.0
+local SCORE_MATCH_SLASH = 0.9
+local SCORE_MATCH_WORD = 0.8
+local SCORE_MATCH_CAPITAL = 0.7
+local SCORE_MATCH_DOT = 0.6
+local SCORE_MAX = math.huge
+local SCORE_MIN = -math.huge
+local MATCH_MAX_LENGTH = 1024
+
+local fzy = {}
+
+-- Check if `needle` is a subsequence of the `haystack`.
+--
+-- Usually called before `score` or `positions`.
+--
+-- Args:
+--   needle (string)
+--   haystack (string)
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   bool
+function fzy.has_match(needle, haystack, case_sensitive)
+  if not case_sensitive then
+    needle = string.lower(needle)
+    haystack = string.lower(haystack)
+  end
+
+  local j = 1
+  for i = 1, string.len(needle) do
+    j = string.find(haystack, needle:sub(i, i), j, true)
+    if not j then
+      return false
+    else
+      j = j + 1
+    end
+  end
+
+  return true
+end
+
+local function is_lower(c)
+  return c:match("%l")
+end
+
+local function is_upper(c)
+  return c:match("%u")
+end
+
+local function precompute_bonus(haystack)
+  local match_bonus = {}
+
+  local last_char = "/"
+  for i = 1, string.len(haystack) do
+    local this_char = haystack:sub(i, i)
+    if last_char == "/" or last_char == "\\" then
+      match_bonus[i] = SCORE_MATCH_SLASH
+    elseif last_char == "-" or last_char == "_" or last_char == " " then
+      match_bonus[i] = SCORE_MATCH_WORD
+    elseif last_char == "." then
+      match_bonus[i] = SCORE_MATCH_DOT
+    elseif is_lower(last_char) and is_upper(this_char) then
+      match_bonus[i] = SCORE_MATCH_CAPITAL
+    else
+      match_bonus[i] = 0
+    end
+
+    last_char = this_char
+  end
+
+  return match_bonus
+end
+
+local function compute(needle, haystack, D, M, case_sensitive)
+  -- Note that the match bonuses must be computed before the arguments are
+  -- converted to lowercase, since there are bonuses for camelCase.
+  local match_bonus = precompute_bonus(haystack)
+  local n = string.len(needle)
+  local m = string.len(haystack)
+
+  if not case_sensitive then
+    needle = string.lower(needle)
+    haystack = string.lower(haystack)
+  end
+
+  -- Because lua only grants access to chars through substring extraction,
+  -- get all the characters from the haystack once now, to reuse below.
+  local haystack_chars = {}
+  for i = 1, m do
+    haystack_chars[i] = haystack:sub(i, i)
+  end
+
+  for i = 1, n do
+    D[i] = {}
+    M[i] = {}
+
+    local prev_score = SCORE_MIN
+    local gap_score = i == n and SCORE_GAP_TRAILING or SCORE_GAP_INNER
+    local needle_char = needle:sub(i, i)
+
+    for j = 1, m do
+      if needle_char == haystack_chars[j] then
+        local score = SCORE_MIN
+        if i == 1 then
+          score = ((j - 1) * SCORE_GAP_LEADING) + match_bonus[j]
+        elseif j > 1 then
+          local a = M[i - 1][j - 1] + match_bonus[j]
+          local b = D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE
+          score = math.max(a, b)
+        end
+        D[i][j] = score
+        prev_score = math.max(score, prev_score + gap_score)
+        M[i][j] = prev_score
+      else
+        D[i][j] = SCORE_MIN
+        prev_score = prev_score + gap_score
+        M[i][j] = prev_score
+      end
+    end
+  end
+end
+
+-- Compute a matching score.
+--
+-- Args:
+--   needle (string): must be a subequence of `haystack`, or the result is
+--     undefined.
+--   haystack (string)
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   number: higher scores indicate better matches. See also `get_score_min`
+--     and `get_score_max`.
+function fzy.score(needle, haystack, case_sensitive)
+  local n = string.len(needle)
+  local m = string.len(haystack)
+
+  if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
+    return SCORE_MIN
+  elseif n == m then
+    return SCORE_MAX
+  else
+    local D = {}
+    local M = {}
+    compute(needle, haystack, D, M, case_sensitive)
+    return M[n][m]
+  end
+end
+
+-- Compute the locations where fzy matches a string.
+--
+-- Determine where each character of the `needle` is matched to the `haystack`
+-- in the optimal match.
+--
+-- Args:
+--   needle (string): must be a subequence of `haystack`, or the result is
+--     undefined.
+--   haystack (string)
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   {int,...}: indices, where `indices[n]` is the location of the `n`th
+--     character of `needle` in `haystack`.
+--   number: the same matching score returned by `score`
+function fzy.positions(needle, haystack, case_sensitive)
+  local n = string.len(needle)
+  local m = string.len(haystack)
+
+  if n == 0 or m == 0 or m > MATCH_MAX_LENGTH or n > m then
+    return {}, SCORE_MIN
+  elseif n == m then
+    local consecutive = {}
+    for i = 1, n do
+      consecutive[i] = i
+    end
+    return consecutive, SCORE_MAX
+  end
+
+  local D = {}
+  local M = {}
+  compute(needle, haystack, D, M, case_sensitive)
+
+  local positions = {}
+  local match_required = false
+  local j = m
+  for i = n, 1, -1 do
+    while j >= 1 do
+      if D[i][j] ~= SCORE_MIN and (match_required or D[i][j] == M[i][j]) then
+        match_required = (i ~= 1) and (j ~= 1) and (
+        M[i][j] == D[i - 1][j - 1] + SCORE_MATCH_CONSECUTIVE)
+        positions[i] = j
+        j = j - 1
+        break
+      else
+        j = j - 1
+      end
+    end
+  end
+
+  return positions, M[n][m]
+end
+
+-- Apply `has_match` and `positions` to an array of haystacks.
+--
+-- Args:
+--   needle (string)
+--   haystack ({string, ...})
+--   case_sensitive (bool, optional): defaults to false
+--
+-- Returns:
+--   {{idx, positions, score}, ...}: an array with one entry per matching line
+--     in `haystacks`, each entry giving the index of the line in `haystacks`
+--     as well as the equivalent to the return value of `positions` for that
+--     line.
+function fzy.filter(needle, haystacks, case_sensitive)
+  local result = {}
+
+  for i, line in ipairs(haystacks) do
+    if fzy.has_match(needle, line, case_sensitive) then
+      local p, s = fzy.positions(needle, line, case_sensitive)
+      table.insert(result, {i, p, s})
+    end
+  end
+
+  return result
+end
+
+-- The lowest value returned by `score`.
+--
+-- In two special cases:
+--  - an empty `needle`, or
+--  - a `needle` or `haystack` larger than than `get_max_length`,
+-- the `score` function will return this exact value, which can be used as a
+-- sentinel. This is the lowest possible score.
+function fzy.get_score_min()
+  return SCORE_MIN
+end
+
+-- The score returned for exact matches. This is the highest possible score.
+function fzy.get_score_max()
+  return SCORE_MAX
+end
+
+-- The maximum size for which `fzy` will evaluate scores.
+function fzy.get_max_length()
+  return MATCH_MAX_LENGTH
+end
+
+-- The minimum score returned for normal matches.
+--
+-- For matches that don't return `get_score_min`, their score will be greater
+-- than than this value.
+function fzy.get_score_floor()
+  return MATCH_MAX_LENGTH * SCORE_GAP_INNER
+end
+
+-- The maximum score for non-exact matches.
+--
+-- For matches that don't return `get_score_max`, their score will be less than
+-- this value.
+function fzy.get_score_ceiling()
+  return MATCH_MAX_LENGTH * SCORE_MATCH_CONSECUTIVE
+end
+
+-- The name of the currently-running implmenetation, "lua" or "native".
+function fzy.get_implementation_name()
+  return "lua"
+end
+
+return fzy


### PR DESCRIPTION
Close #565

Thanks to https://github.com/swarn/fzy-lua, the basic fzy Lua support in clap is much easier. The next step might be adding a user-friendly way to also support your https://github.com/romgrk/fzy-lua-native @romgrk . Let me know if you have any ideas about that.

~I have tested this PR against the latest neovim, but not sure I'll spend more time making it work with the older neovim and vim.~

Now it works with both latest neovim and vim.