### PR TITLE
Add the providers defined using gloabl variable in providers provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 - Allow user to always download the prebuilt binary. #531
 - Support smartcase fitlering for fzy algo and it's the default behavior. #541 @romgrk
 - Add initial support for fzy lua, neovim-nightly or vim compiled with lua is required. #599
+- Add the providers defined via global variable into the `providers` provider, which means you can see the global variable type providers when you call `:Clap` now. But you have to define `description` explicitly otherwise they won't be found. #605
+    ```vim
+    let g:clap_provider_tasks = {
+              \ 'source': function('TaskListSource'),
+              \ 'sink': function('TaskListSink'),
+              \ 'description': 'List various tasks',
+              \ }
+    ```
 
 ### Improved
 

--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ See `:help clap-highlights` for more information.
 
 ```vim
 " `:Clap quick_open` to open some dotfiles quickly.
-" If you want to show this provider when you call `:Clap`, `description` is neccessary.
+" `description` is actually optional, but if you want to show this provider
+" when you call `:Clap`, the `description` is neccessary.
 let g:clap_provider_quick_open = {
       \ 'source': ['~/.vimrc', '~/.spacevim', '~/.bashrc', '~/.tmux.conf'],
       \ 'sink': 'e',

--- a/README.md
+++ b/README.md
@@ -283,9 +283,11 @@ See `:help clap-highlights` for more information.
 
 ```vim
 " `:Clap quick_open` to open some dotfiles quickly.
+" If you want to show this provider when you call `:Clap`, `description` is neccessary.
 let g:clap_provider_quick_open = {
       \ 'source': ['~/.vimrc', '~/.spacevim', '~/.bashrc', '~/.tmux.conf'],
       \ 'sink': 'e',
+      \ 'description': 'Quick open some dotfiles',
       \ }
 ```
 

--- a/autoload/clap/provider/providers.vim
+++ b/autoload/clap/provider/providers.vim
@@ -15,6 +15,7 @@ endfunction
 function! s:providers.source() abort
   if !exists('s:global_source')
     let s:global_source = []
+
     for autoload_provider in split(globpath(&runtimepath, 'autoload/clap/provider/*.vim'), "\n")
       let provider_id = fnamemodify(autoload_provider, ':t:r')
       if file_readable(autoload_provider)
@@ -28,6 +29,22 @@ function! s:providers.source() abort
       else
         call add(s:global_source, provider_id.':')
       endif
+    endfor
+
+    " `description` is required, otherwise we can't distinguish whether the variable name
+    " like `g:clap_provider_yanks_history` is a name of some provider or merely a control
+    " variable of a provider.
+    let maybe_user_var_providers = filter(keys(g:), 'v:val =~# "^clap_provider_"')
+    for maybe_var_provider in maybe_user_var_providers
+      try
+        let evaled = eval('g:'.maybe_var_provider)
+        if type(evaled) == v:t_dict
+          let provider_id = matchstr(maybe_var_provider, 'clap_provider_\zs\(.*\)')
+          call add(s:global_source, provider_id.': '.evaled['description'])
+        endif
+      catch
+        " Ignore
+      endtry
     endfor
   endif
   return s:global_source


### PR DESCRIPTION
Add the providers defined via global variable into the `providers` provider, which means you can see the global variable type providers when you call `:Clap` now. But you have to define `description` explicitly otherwise they won't be found, for example,

```vim
    let g:clap_provider_tasks = {
              \ 'source': function('TaskListSource'),
              \ 'sink': function('TaskListSink'),
              \ 'description': 'List various tasks',
              \ }
```