### PR TITLE
Add a bonus for matches in filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add `g:clap_force_matchfuzzy` to use the builtin `matchfuzzy()` when filtering in sync way. #607
 - Support `+name-only` for Lua sync filter. #612
+- Add a bonus for the match in the filename when the source item is a path, but you can only have this when you are using Python dynamic module or the Rust backend. #614.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add `g:clap_force_matchfuzzy` to use the builtin `matchfuzzy()` when filtering in sync way. #607
+- Add `g:clap_force_python` to always use the Python sync filter as some improvements are only implemented on the Rust side and you need the Python dynamic module to use that. #614
 - Support `+name-only` for Lua sync filter. #612
 - Add a bonus for the match in the filename when the source item is a path, but you can only have this when you are using Python dynamic module or the Rust backend. #614.
 

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -85,7 +85,7 @@ if get(g:, 'clap_force_matchfuzzy', v:false)
   function! clap#filter#sync(query, candidates) abort
     return clap#filter#matchfuzzy(a:query, a:candidates)
   endfunction
-elseif s:can_use_lua
+elseif s:can_use_lua && !get(g:, 'clap_force_python', v:false)
   let s:current_filter_impl = 'Lua'
   function! clap#filter#sync(query, candidates) abort
     return clap#filter#sync#lua#(a:query, a:candidates, -1, s:enable_icon(), s:match_type())

--- a/autoload/clap/filter.vim
+++ b/autoload/clap/filter.vim
@@ -45,6 +45,14 @@ function! s:enable_icon() abort
   endif
 endfunction
 
+function! clap#filter#get_bonus_type() abort
+  if index(['files', 'git_files', 'filer'], g:clap.provider.id) > -1
+    return 'FileName'
+  else
+    return 'None'
+  endif
+endfunction
+
 function! clap#filter#matchfuzzy(query, candidates) abort
   " `result` could be a list of two lists, or a list of three
   " lists(newer vim).
@@ -66,6 +74,8 @@ function! s:match_type() abort
   return exists('g:__clap_match_type_enum') ? g:__clap_match_type_enum : 'Full'
 endfunction
 
+let s:can_use_lua = v:false
+
 if get(g:, 'clap_force_matchfuzzy', v:false)
   let s:current_filter_impl = 'VimL'
   if !exists('*matchfuzzypos')
@@ -84,7 +94,7 @@ elseif s:can_use_python
   let s:current_filter_impl = 'Python'
   function! clap#filter#sync(query, candidates) abort
     try
-      return clap#filter#sync#python#(a:query, a:candidates, winwidth(g:clap.display.winid), s:enable_icon(), s:match_type())
+      return clap#filter#sync#python#(a:query, a:candidates, winwidth(g:clap.display.winid), s:enable_icon(), s:match_type(), clap#filter#get_bonus_type())
     catch
       call clap#helper#echo_error(v:exception.', throwpoint:'.v:throwpoint)
       return clap#filter#sync#viml#(a:query, a:candidates)

--- a/autoload/clap/filter/sync/python.vim
+++ b/autoload/clap/filter/sync/python.vim
@@ -44,7 +44,7 @@ endfunction
 
 if s:using_dynamic_module
   " Rust dynamic module has the feature of truncating the long lines to make fuzzy matched items visible.
-  function! clap#filter#sync#python#(query, candidates, winwidth, enable_icon, match_type) abort
+  function! clap#filter#sync#python#(query, candidates, winwidth, enable_icon, match_type, bonus) abort
     " If the query is empty, neovim and vim's python client might crash.
     if a:query ==# ''
       return a:candidates
@@ -53,7 +53,7 @@ if s:using_dynamic_module
     return filtered
   endfunction
 else
-  function! clap#filter#sync#python#(query, candidates, _winwidth, enable_icon, _match_type) abort
+  function! clap#filter#sync#python#(query, candidates, _winwidth, enable_icon, _match_type, _bonus) abort
     let [g:__clap_fuzzy_matched_indices, filtered] = pyxeval(s:py_fn.'()')
     return filtered
   endfunction

--- a/autoload/clap/maple.vim
+++ b/autoload/clap/maple.vim
@@ -64,8 +64,11 @@ endfunction
 function! clap#maple#sync_filter_command(query) abort
   let global_opt = ['--number', g:clap.display.preload_capacity, '--winwidth', winwidth(g:clap.display.winid)]
 
-  if g:clap.provider.id ==# 'files' && g:clap_enable_icon
-    call add(global_opt, '--icon-painter=File')
+  if g:clap.provider.id ==# 'files'
+    call add(global_opt, printf('--bonus=%s', clap#filter#get_bonus_type()))
+    if g:clap_enable_icon
+      call add(global_opt, '--icon-painter=File')
+    endif
   endif
 
   return [s:maple_bin] + global_opt + ['filter', a:query, '--sync']

--- a/autoload/clap/provider/filer.vim
+++ b/autoload/clap/provider/filer.vim
@@ -322,7 +322,7 @@ function! s:filer_handle_on_move_response(result, error) abort
 endfunction
 
 function! s:filer.on_move_async() abort
-  if g:clap.display.getcurline() =~# s:CREATE_FILE
+  if stridx(g:clap.display.getcurline(), s:CREATE_FILE) > -1
     call g:clap.preview.hide()
     return
   endif

--- a/crates/filter/src/dynamic.rs
+++ b/crates/filter/src/dynamic.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant};
 use rayon::slice::ParallelSliceMut;
 
 use icon::{IconPainter, ICON_LEN};
-use matcher::MatchType;
+use matcher::{Bonus, MatchType};
 use utility::{println_json, println_json_with_length};
 
 use super::*;
@@ -347,13 +347,14 @@ pub fn dyn_run<I: Iterator<Item = SourceItem>>(
     winwidth: Option<usize>,
     icon_painter: Option<IconPainter>,
     match_type: MatchType,
+    bonus: Bonus,
 ) -> Result<()> {
     let algo = if query.contains(' ') {
         Algo::SubString
     } else {
         algo.unwrap_or(Algo::Fzy)
     };
-    let scoring_matcher = matcher::Matcher::new(algo, match_type);
+    let scoring_matcher = matcher::Matcher::new(algo, match_type, bonus);
     let scorer = |item: &SourceItem| scoring_matcher.do_match(item, query);
     if let Some(number) = number {
         let (total, mut filtered) = match source {
@@ -461,6 +462,7 @@ mod tests {
             None,
             None,
             MatchType::Full,
+            Bonus::None,
         )
         .unwrap()
     }

--- a/crates/filter/src/lib.rs
+++ b/crates/filter/src/lib.rs
@@ -10,7 +10,7 @@ mod dynamic;
 mod source;
 
 use anyhow::Result;
-use matcher::Algo;
+use matcher::{Algo, Bonus, MatchType, Matcher};
 use rayon::prelude::*;
 use source_item::SourceItem;
 
@@ -29,8 +29,11 @@ pub fn sync_run<I: Iterator<Item = SourceItem>>(
     query: &str,
     source: Source<I>,
     algo: Algo,
+    match_type: MatchType,
+    bonus: Bonus,
 ) -> Result<Vec<FilterResult>> {
-    let mut ranked = source.filter(algo, query)?;
+    let matcher = Matcher::new(algo, match_type, bonus);
+    let mut ranked = source.filter(matcher, query)?;
 
     ranked.par_sort_unstable_by(|(_, v1, _), (_, v2, _)| v2.partial_cmp(&v1).unwrap());
 

--- a/crates/maple_cli/src/cmd/blines.rs
+++ b/crates/maple_cli/src/cmd/blines.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
-use filter::{matcher::MatchType, Source};
+use filter::{
+    matcher::{Bonus, MatchType},
+    Source,
+};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
@@ -32,6 +35,7 @@ impl Blines {
             winwidth,
             None,
             MatchType::Full,
+            Bonus::None,
         )
     }
 }

--- a/crates/maple_cli/src/cmd/filter.rs
+++ b/crates/maple_cli/src/cmd/filter.rs
@@ -73,6 +73,8 @@ impl Filter {
             &self.query,
             self.generate_source(),
             self.algo.clone().unwrap_or(Algo::Fzy),
+            self.match_type.clone().unwrap_or(MatchType::Full),
+            self.bonus.clone().unwrap_or_default(),
         )?;
 
         printer::print_sync_filter_results(ranked, number, winwidth, icon_painter);

--- a/crates/maple_cli/src/cmd/filter.rs
+++ b/crates/maple_cli/src/cmd/filter.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use filter::{
-    matcher::{Algo, MatchType},
+    matcher::{Algo, Bonus, MatchType},
     subprocess, Source,
 };
 use icon::IconPainter;
@@ -34,6 +34,10 @@ pub struct Filter {
     /// Apply the filter on the full line content or parial of it.
     #[structopt(short, long, possible_values = &MatchType::variants(), case_insensitive = true)]
     match_type: Option<MatchType>,
+
+    /// Add a bonus to the score of base matching algorithm.
+    #[structopt(short, long, possible_values = &Bonus::variants(), case_insensitive = true)]
+    bonus: Option<Bonus>,
 
     /// Synchronous filtering, returns after the input stream is complete.
     #[structopt(short, long)]
@@ -91,6 +95,7 @@ impl Filter {
             winwidth,
             icon_painter,
             self.match_type.clone().unwrap_or(MatchType::Full),
+            self.bonus.clone().unwrap_or_default(),
         )
     }
 

--- a/crates/maple_cli/src/cmd/grep.rs
+++ b/crates/maple_cli/src/cmd/grep.rs
@@ -1,7 +1,11 @@
 use crate::cmd::cache::{cache_exists, send_response_from_cache, SendResponse};
 use crate::light_command::{set_current_dir, LightCommand};
 use anyhow::{Context, Result};
-use filter::{matcher::MatchType, subprocess::Exec, Source};
+use filter::{
+    matcher::{Bonus, MatchType},
+    subprocess::Exec,
+    Source,
+};
 use icon::IconPainter;
 use std::path::PathBuf;
 use std::process::Command;
@@ -149,6 +153,7 @@ impl Grep {
                 winwidth,
                 icon_painter,
                 MatchType::IgnoreFilePath,
+                Bonus::None,
             )
         };
 

--- a/crates/maple_cli/src/cmd/tags.rs
+++ b/crates/maple_cli/src/cmd/tags.rs
@@ -1,6 +1,9 @@
 use crate::cmd::cache::{cache_exists, send_response_from_cache, CacheEntry, SendResponse};
 use anyhow::{anyhow, Result};
-use filter::{matcher::MatchType, subprocess, Source};
+use filter::{
+    matcher::{Bonus, MatchType},
+    subprocess, Source,
+};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, BufReader};
@@ -155,6 +158,7 @@ impl Tags {
                 None,
                 icon_painter,
                 MatchType::TagName,
+                Bonus::None,
             )?;
         }
 

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -36,8 +36,13 @@ pub fn calculate_bonus(bonus: &Bonus, item: &SourceItem, score: Score, indices: 
         Bonus::FileName => {
             if let Some((_, idx)) = pattern::file_name_only(&item.raw) {
                 let hits = indices.iter().filter(|x| **x >= idx).collect::<Vec<_>>();
-                let bonus = score * hits.len() as i64 / (item.raw.len() - idx) as i64;
-                bonus
+                if item.raw.len() > idx {
+                    // bonus = base_score * len(matched elements in filename) / len(filename)
+                    let bonus = score * hits.len() as i64 / (item.raw.len() - idx) as i64;
+                    bonus
+                } else {
+                    0
+                }
             } else {
                 0
             }

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -20,31 +20,95 @@
 mod algo;
 
 use source_item::SourceItem;
+use structopt::clap::arg_enum;
 
 pub use algo::*;
 pub use source_item::MatchType;
 
+pub type Score = i64;
+
 /// A tuple of (score, matched_indices) for the line has a match given the query string.
-pub type MatchResult = Option<(i64, Vec<usize>)>;
+pub type MatchResult = Option<(Score, Vec<usize>)>;
+
+pub fn calculate_bonus(bonus: &Bonus, item: &SourceItem, score: Score, indices: &[usize]) -> Score {
+    match bonus {
+        Bonus::FileName => {
+            if let Some((_, idx)) = pattern::file_name_only(&item.raw) {
+                let hits = indices.iter().filter(|x| **x >= idx).collect::<Vec<_>>();
+                let bonus = score as u64 * hits.len() as u64 / (item.raw.len() - idx) as u64;
+                bonus as Score
+            } else {
+                0
+            }
+        }
+        Bonus::None => 0,
+    }
+}
+
+arg_enum! {
+  #[derive(Debug, Clone)]
+  pub enum Bonus {
+      // Give a bonus if the needle matches in the basename of the haystack.
+      //
+      // Ref https://github.com/liuchengxu/vim-clap/issues/561
+      FileName,
+
+      // No bonus.
+      None,
+  }
+}
+
+impl Default for Bonus {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+impl From<String> for Bonus {
+    fn from(b: String) -> Self {
+        b.as_str().into()
+    }
+}
+
+impl From<&str> for Bonus {
+    fn from(b: &str) -> Self {
+        match b.to_uppercase().as_str() {
+            "NONE" => Self::None,
+            "FILENAME" => Self::FileName,
+            _ => Self::None,
+        }
+    }
+}
 
 /// `Matcher` is composed of two components:
 ///
-///   * `algo`: algorithm used for matching the text.
 ///   * `match_type`: represents the way of extracting the matching piece from the raw line.
+///   * `algo`: algorithm used for matching the text.
+///   * `bouns`: add a bonus to the result of base `algo`.
 pub struct Matcher {
-    algo: Algo,
     match_type: MatchType,
+    algo: Algo,
+    bonus: Bonus,
 }
 
 impl Matcher {
     /// Constructs a `Matcher`.
-    pub fn new(algo: Algo, match_type: MatchType) -> Self {
-        Self { algo, match_type }
+    pub fn new(algo: Algo, match_type: MatchType, bonus: Bonus) -> Self {
+        Self {
+            algo,
+            match_type,
+            bonus,
+        }
     }
 
     /// Actually performs the matching algorithm.
     pub fn do_match(&self, item: &SourceItem, query: &str) -> MatchResult {
-        self.algo.apply_match(query, item, &self.match_type)
+        let base_result = self.algo.apply_match(query, item, &self.match_type);
+
+        base_result.map(|(score, indices)| {
+            let bonus_score = calculate_bonus(&self.bonus, item, score, &indices);
+            (score + bonus_score, indices)
+        })
     }
 }
 
@@ -78,5 +142,28 @@ mod tests {
         let (_, origin_indices) = fzy::fuzzy_indices(line, query).unwrap();
         let (_, indices) = apply_on_file_line_fzy(&line.to_string().into(), query).unwrap();
         assert_eq!(origin_indices, indices);
+    }
+
+    #[test]
+    fn test_bonus_filename() {
+        let lines = vec![
+            "crates/filter/Cargo.toml",
+            "autoload/clap/filter.vim",
+            "crates/filter/src/dynamic.rs",
+            "crates/stdio_server/src/filer.rs",
+            "autoload/clap/provider/files.vim",
+            "autoload/clap/provider/filer.vim",
+            "autoload/clap/filter/sync/lua.vim",
+            "crates/maple_cli/src/cmd/filter.rs",
+            "autoload/clap/filter/sync/python.vim",
+            "autoload/clap/provider/filetypes.vim",
+            "lua/fzy_filter.lua",
+            "autoload/clap/filter/async/external.vim",
+        ];
+        let matcher = Matcher::new(Algo::Fzy, MatchType::Full);
+        for line in lines {
+            println!("{}", line);
+            matcher.do_match(&line.into(), "fil");
+        }
     }
 }

--- a/crates/matcher/src/lib.rs
+++ b/crates/matcher/src/lib.rs
@@ -78,9 +78,9 @@ impl From<String> for Bonus {
 
 impl From<&str> for Bonus {
     fn from(b: &str) -> Self {
-        match b.to_uppercase().as_str() {
-            "NONE" => Self::None,
-            "FILENAME" => Self::FileName,
+        match b.to_lowercase().as_str() {
+            "none" => Self::None,
+            "filename" => Self::FileName,
             _ => Self::None,
         }
     }

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -190,7 +190,10 @@ pub fn print_dyn_filter_results(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use filter::{matcher::Algo, Source};
+    use filter::{
+        matcher::{Algo, Bonus, MatchType, Matcher},
+        Source,
+    };
     use rayon::prelude::*;
 
     fn wrap_matches(line: &str, indices: &[usize]) -> String {
@@ -227,7 +230,8 @@ mod tests {
         skipped: Option<usize>,
         winwidth: usize,
     ) {
-        let mut ranked = source.filter(Algo::Fzy, query).unwrap();
+        let matcher = Matcher::new(Algo::Fzy, MatchType::Full, Bonus::FileName);
+        let mut ranked = source.filter(matcher, query).unwrap();
         ranked.par_sort_unstable_by(|(_, v1, _), (_, v2, _)| v2.partial_cmp(&v1).unwrap());
 
         println!();

--- a/crates/source_item/src/lib.rs
+++ b/crates/source_item/src/lib.rs
@@ -23,11 +23,11 @@ impl From<String> for MatchType {
 
 impl From<&str> for MatchType {
     fn from(match_type: &str) -> Self {
-        match match_type.to_uppercase().as_str() {
-            "FULL" => Self::Full,
-            "TAGNAME" => Self::TagName,
-            "FILENAME" => Self::FileName,
-            "IGNOREFILEPATH" => Self::IgnoreFilePath,
+        match match_type.to_lowercase().as_str() {
+            "full" => Self::Full,
+            "tagname" => Self::TagName,
+            "filename" => Self::FileName,
+            "ignorefilepath" => Self::IgnoreFilePath,
             _ => Self::Full,
         }
     }

--- a/crates/stdio_server/src/session/handler/on_typed.rs
+++ b/crates/stdio_server/src/session/handler/on_typed.rs
@@ -1,5 +1,7 @@
 use log::debug;
 
+use filter::matcher::{Algo, Bonus, MatchType};
+
 use super::*;
 
 pub fn handle_on_typed(msg: Message, context: &SessionContext) {
@@ -19,7 +21,12 @@ pub fn handle_on_typed(msg: Message, context: &SessionContext) {
     if let Some(ref source_list) = *source_list {
         let source = filter::Source::List(source_list.iter().map(|s| s.to_string().into()));
 
-        let lines_info = filter::sync_run(&query, source, filter::matcher::Algo::Fzy).unwrap();
+        let match_type = MatchType::Full;
+        let bonus = match msg.get_provider_id().as_str() {
+            "files" | "git_files" => Bonus::FileName,
+            _ => Bonus::None,
+        };
+        let lines_info = filter::sync_run(&query, source, Algo::Fzy, match_type, bonus).unwrap();
 
         let total = lines_info.len();
 

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -537,6 +537,19 @@ g:clap_force_matchfuzzy                                *g:clap_force_matchfuzzy*
   Force use |matchfuzzypos()| as the sync filter engine, otherwise vim-clap
   will try to use the other sync implementation in the order of Lua>Python>VimL.
 
+
+g:clap_force_python                                        *g:clap_force_python*
+
+  Type: |Bool|
+  Default: `Undefined`
+
+  Force use Python as the sync filter engine. Some matching improvements are
+  only implemented on the Rust end, you also need to compile the Python dynamic
+  module to use that.
+
+  Ref https://github.com/liuchengxu/vim-clap/pull/614
+
+
 -------------------------------------------------------------------------------
 5.1. Highlights                                                *clap-highlights*
 

--- a/pythonx/clap/fuzzymatch-rs/src/lib.rs
+++ b/pythonx/clap/fuzzymatch-rs/src/lib.rs
@@ -115,6 +115,6 @@ fn test_skip_icon() {
     let query = "con";
     println!(
         "ret: {:#?}",
-        fuzzy_match(query, lines, 62, true, "Full".to_string())
+        fuzzy_match(query, lines, 62, true, "Full".into(), "FileName".into())
     );
 }

--- a/pythonx/clap/fuzzymatch-rs/src/lib.rs
+++ b/pythonx/clap/fuzzymatch-rs/src/lib.rs
@@ -81,6 +81,7 @@ fn fuzzymatch_rs(_py: Python, m: &PyModule) -> PyResult<()> {
 
 #[test]
 fn py_and_rs_subscore_should_work() {
+    use filter::matcher::substring::substr_indices as substr_scorer;
     use pyo3::{prelude::*, types::PyModule};
     use std::fs;
 

--- a/pythonx/clap/fuzzymatch-rs/src/lib.rs
+++ b/pythonx/clap/fuzzymatch-rs/src/lib.rs
@@ -1,11 +1,9 @@
-use filter::matcher::{substring::substr_indices as substr_scorer, Algo, Matcher};
+use filter::matcher::{Algo, Matcher};
 use printer::truncate_long_matched_lines;
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 use std::collections::HashMap;
 
-/// Use f64 here as substr_scorer returns f64;
-type MatchResult = Option<(i64, Vec<usize>)>;
 /// Pass a Vector of lines to Vim for setting them in Vim with one single API call.
 type LinesInBatch = Vec<String>;
 /// Each line's matched indices of LinesInBatch.
@@ -23,26 +21,31 @@ fn fuzzy_match(
     winwidth: usize,
     enable_icon: bool,
     match_type: String,
+    bonus: String,
 ) -> PyResult<(MatchedIndicesInBatch, LinesInBatch, TruncatedMapInfo)> {
-    let fzy_matcher = Matcher::new(Algo::Fzy, match_type.into());
-    let matcher: Box<dyn Fn(&str) -> MatchResult> = if query.contains(' ') {
-        Box::new(|line: &str| substr_scorer(line, query))
-    } else {
-        Box::new(|line: &str| {
-            if enable_icon {
-                // " " is 4 bytes, but the offset of highlight is 2.
-                fzy_matcher
-                    .do_match(&line[4..].into(), query)
-                    .map(|(score, indices)| (score, indices.into_iter().map(|x| x + 4).collect()))
-            } else {
-                fzy_matcher.do_match(&line.into(), query)
-            }
-        })
+    let matcher = Matcher::new(
+        if query.contains(' ') {
+            Algo::SubString
+        } else {
+            Algo::Fzy
+        },
+        match_type.into(),
+        bonus.into(),
+    );
+    let do_match = |line: &str| {
+        if enable_icon {
+            // " " is 4 bytes, but the offset of highlight is 2.
+            matcher
+                .do_match(&line[4..].into(), query)
+                .map(|(score, indices)| (score, indices.into_iter().map(|x| x + 4).collect()))
+        } else {
+            matcher.do_match(&line.into(), query)
+        }
     };
 
     let mut ranked = candidates
         .into_iter()
-        .filter_map(|line| matcher(&line).map(|(score, indices)| (line.into(), score, indices)))
+        .filter_map(|line| do_match(&line).map(|(score, indices)| (line.into(), score, indices)))
         .collect::<Vec<_>>();
 
     ranked.sort_unstable_by(|(_, v1, _), (_, v2, _)| v2.partial_cmp(v1).unwrap());

--- a/pythonx/clap/fzy.py
+++ b/pythonx/clap/fzy.py
@@ -62,6 +62,6 @@ try:
         return fuzzy_match_rs(vim.eval("a:query"), vim.eval("a:candidates"),
                               int(vim.eval("a:winwidth")),
                               str2bool(vim.eval("a:enable_icon")),
-                              vim.eval("a:match_type"))
+                              vim.eval("a:match_type"), vim.eval("a:bonus"))
 except Exception:
     pass


### PR DESCRIPTION
Introduce an additional `Bonus` for the result of the base algorithm(fzy, skim, etc), e.g., add a bonus score to the match that hits the elements in the file name when the source item is a path. This PR makes `+name-only` kind of duplicated in some sense. cc @svermeulen

Currently, we just have one Bonus, we can have multiple Bonuses at the same time in the future which will help #542.

Before:

![Screenshot from 2021-01-16 16-02-36](https://user-images.githubusercontent.com/8850248/104807588-079ca600-581b-11eb-95c3-2902f9a0d80e.png)

With this PR:

![Screenshot from 2021-01-16 16-51-40](https://user-images.githubusercontent.com/8850248/104807609-27cc6500-581b-11eb-9d2d-949e921cf235.png)

If the Lua filter is also available(using neovim or vim with `+lua`), you need to add `let g:clap_force_python = v:true` in your vimrc to choose the Python filter for using this, for this improvement is only implemented on the Rust side and you need to compile the Python dynamic module too.


Close #561