### PR TITLE
Truncate the tail of long lines

### DIFF
--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -98,7 +98,6 @@ pub fn truncate_long_matched_lines<T>(
                     let end = line.len();
                     let left_truncated = if let Some(n) = skipped {
                         let icon: String = line.chars().take(n).collect();
-                        // start += n;
                         format!("{}{}{}", icon, DOTS, utf8_str_slice(&line, start, end))
                     } else {
                         format!("{}{}", DOTS, utf8_str_slice(&line, start, end))

--- a/crates/stdio_server/src/lib.rs
+++ b/crates/stdio_server/src/lib.rs
@@ -46,7 +46,7 @@ fn loop_handle_rpc_message(rx: &Receiver<String>) {
     let mut session_manager = Manager::default();
     for msg in rx.iter() {
         if let Ok(msg) = serde_json::from_str::<Message>(&msg.trim()) {
-            debug!("Recv: {:?}", msg);
+            debug!("==> message(in): {:?}", msg);
             match &msg.method[..] {
                 "initialize_global_env" => env::initialize_global(msg), // should be called only once.
                 "filer" => filer::handle_filer_message(msg),

--- a/crates/stdio_server/src/session/handlers/mod.rs
+++ b/crates/stdio_server/src/session/handlers/mod.rs
@@ -17,7 +17,7 @@ impl HandleMessage for MessageHandler {
                 let msg_id = msg.id;
                 if let Err(e) = on_move::OnMoveHandler::try_new(&msg, context).map(|x| x.handle()) {
                     log::error!("Handle RpcMessage::OnMove {:?}, error: {:?}", msg, e);
-                    write_response(json!({"error": format!("{}",e), "id": msg_id }));
+                    write_response(json!({"error": e.to_string(), "id": msg_id }));
                 }
             }
             RpcMessage::OnTyped(msg) => on_typed::handle_on_typed(msg, context),

--- a/crates/stdio_server/src/session/handlers/on_move.rs
+++ b/crates/stdio_server/src/session/handlers/on_move.rs
@@ -225,7 +225,6 @@ impl<'a> OnMoveHandler<'a> {
             | Grep { path, lnum }
             | ProjTags { path, lnum }
             | BufferTags { path, lnum } => {
-                debug!("path:{}, lnum:{}", path.display(), lnum);
                 self.preview_file_at(&path, *lnum);
             }
             HelpTags {
@@ -249,7 +248,6 @@ impl<'a> OnMoveHandler<'a> {
 
     fn send_response(&self, result: serde_json::value::Value) {
         let provider_id: crate::types::ProviderId = self.provider_id.clone();
-        debug!("sending on_move response, result: {:?}", result);
         write_response(json!({
                 "id": self.msg_id,
                 "provider_id": provider_id,
@@ -303,8 +301,8 @@ impl<'a> OnMoveHandler<'a> {
                     .chain(self.truncate_preview_lines(lines_iter))
                     .collect::<Vec<_>>();
                 debug!(
-                    "sending msg_id:{}, provider_id:{}",
-                    self.msg_id, self.provider_id
+                    "<== message(out) sending event: on_move, msg_id:{}, provider_id:{}, lines: {:?}",
+                    self.msg_id, self.provider_id, lines
                 );
                 self.send_response(json!({
                   "event": "on_move",

--- a/crates/stdio_server/src/session/mod.rs
+++ b/crates/stdio_server/src/session/mod.rs
@@ -82,7 +82,7 @@ impl<T: HandleMessage> Session<T> {
             loop {
                 match self.event_recv.recv() {
                     Ok(event) => {
-                        debug!("session recv: {:?}", event);
+                        debug!("event(in) receive a session event: {:?}", event);
                         match event {
                             SessionEvent::Terminate => {
                                 self.handle_terminate();

--- a/crates/stdio_server/src/session/providers/filer.rs
+++ b/crates/stdio_server/src/session/providers/filer.rs
@@ -142,7 +142,7 @@ pub fn handle_filer_message(msg: Message) {
             json!({ "id": msg.id, "provider_id": "filer", "result": result })
         }
         Err(err) => {
-            let error = json!({"message": format!("{}", err), "dir": cwd});
+            let error = json!({"message": err.to_string(), "dir": cwd});
             json!({ "id": msg.id, "provider_id": "filer", "error": error })
         }
     };


### PR DESCRIPTION
This PR can reduce the highlighting job on the vim side, sigificantly for the long query string.

Close #628