### PR TITLE
accept complex query like command line program

### DIFF
--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -311,6 +311,7 @@ function! s:parse_opts(args) abort
   for arg in a:args
     if arg ==# '--'
       let g:clap.context.query = join(a:args[idx+1 :], ' ')
+      let idx = len(a:args)
       break
     endif
     if arg =~? '^++\w*=\w*'

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -312,7 +312,6 @@ function! s:parse_opts(args) abort
   for arg in a:args
     if arg ==# '--'
       let g:clap.context.query = join(a:args[idx+1 :], ' ')
-      let idx = len(a:args)
       break
     endif
     if arg =~? '^++\w*=\w*'

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -308,6 +308,7 @@ endif
 
 function! s:parse_opts(args) abort
   let idx = 0
+  let g:clap.provider.args = []
   for arg in a:args
     if arg ==# '--'
       let g:clap.context.query = join(a:args[idx+1 :], ' ')
@@ -326,7 +327,7 @@ function! s:parse_opts(args) abort
       let opt = arg[1:]
       let g:clap.context[opt] = v:true
     else
-      break
+      call add(g:clap.provider.args, arg)
     endif
     let idx += 1
   endfor
@@ -337,7 +338,6 @@ function! s:parse_opts(args) abort
       let g:clap.context.query = clap#util#expand(g:clap.context.query)
     endif
   endif
-  let g:clap.provider.args = a:args[idx :]
 endfunction
 
 function! clap#(bang, ...) abort

--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -309,6 +309,10 @@ endif
 function! s:parse_opts(args) abort
   let idx = 0
   for arg in a:args
+    if arg ==# '--'
+      let g:clap.context.query = join(a:args[idx+1 :], ' ')
+      break
+    endif
     if arg =~? '^++\w*=\w*'
       let matched = matchlist(arg, '^++\(\w*\)=\(\S*\)')
       let [k, v] = [matched[1], matched[2]]

--- a/doc/clap-support.txt
+++ b/doc/clap-support.txt
@@ -97,6 +97,11 @@ Supported Providers & Tools                                    *clap-support*
                          the git base directory or `getcwd()` . For example,
                          use `Clap grep ..` to grep from the parent directory.
 
+                         Use `Clap grep -- word1 word2..` to grep a complex
+			 query, all text after -- would be the query text. You
+			 have to pass `++opt=[OPTION]` and `[DIR]` befor `--`
+			 if there is any of them.
+
 
                                                      *:Clap-help_tags*
 :Clap help_tags          List the help tags.

--- a/doc/clap-support.txt
+++ b/doc/clap-support.txt
@@ -98,9 +98,9 @@ Supported Providers & Tools                                    *clap-support*
                          use `Clap grep ..` to grep from the parent directory.
 
                          Use `Clap grep -- word1 word2..` to grep a complex
-			 query, all text after -- would be the query text. You
-			 have to pass `++opt=[OPTION]` and `[DIR]` befor `--`
-			 if there is any of them.
+			                   query, all text after -- would be treated as the query
+			                   text. You have to pass `++opt=[OPTION]` and `[DIR]`
+			                   before `--` if there is any of them.
 
 
                                                      *:Clap-help_tags*


### PR DESCRIPTION
it's not easy to send query like contain space, '+' etc. Let's use
a command line standard args syntax, all text after '--' is treated
as query instead of opts.