### PR TITLE
Added onehalf themes

### DIFF
--- a/autoload/clap/themes/onehalfdark.vim
+++ b/autoload/clap/themes/onehalfdark.vim
@@ -23,6 +23,11 @@ let s:palette.current_selection = { 'ctermbg': '236', 'guibg': '#282c34', 'cterm
 let s:palette.selected_sign = { 'ctermfg': '168', 'guifg': '#e06c75' } " red
 let s:palette.current_selection_sign = s:palette.selected_sign
 
+" blue
+let g:clap_fuzzy_match_hl_groups = [
+  \ ['75', '#61afef'],
+\ ]
+
 let g:clap#themes#onehalfdark#palette = s:palette
 
 let &cpoptions = s:save_cpo

--- a/autoload/clap/themes/onehalfdark.vim
+++ b/autoload/clap/themes/onehalfdark.vim
@@ -1,0 +1,29 @@
+" Author: kerunaru <kerunaru@icloud.com>
+" Description: Clap theme based on the onehalfdark theme.
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+let s:palette = {}
+
+let s:palette.display = { 'ctermbg': '237', 'guibg': '#313640' } " cursor_line
+
+" Let ClapInput, ClapSpinner and ClapSearchText use the same background.
+let s:bg0 = { 'ctermbg': '239', 'guibg': '#373C45' } " non_text
+let s:palette.input = s:bg0
+let s:palette.indicator = extend({ 'ctermfg': '247', 'guifg':'#919baa' }, s:bg0) " gutter_fg
+let s:palette.spinner = extend({ 'ctermfg': '180', 'guifg':'#e5c07b', 'cterm': 'bold', 'gui': 'bold'}, s:bg0) " yellow
+let s:palette.search_text = extend({ 'ctermfg': '188', 'guifg': '#dcdfe4', 'cterm': 'bold', 'gui': 'bold' }, s:bg0) " white
+
+let s:palette.preview = { 'ctermbg': '239', 'guibg': '#373C45' } " non_text
+
+let s:palette.selected = { 'ctermfg': '73', 'guifg': '#56b6c2', 'cterm': 'bold,underline', 'gui': 'bold,underline' } " cyan
+let s:palette.current_selection = { 'ctermbg': '236', 'guibg': '#282c34', 'cterm': 'bold', 'gui': 'bold' } " gutter_bg
+
+let s:palette.selected_sign = { 'ctermfg': '168', 'guifg': '#e06c75' } " red
+let s:palette.current_selection_sign = s:palette.selected_sign
+
+let g:clap#themes#onehalfdark#palette = s:palette
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/themes/onehalflight.vim
+++ b/autoload/clap/themes/onehalflight.vim
@@ -1,0 +1,29 @@
+" Author: kerunaru <kerunaru@icloud.com>
+" Description: Clap theme based on the onehalflight theme.
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+let s:palette = {}
+
+let s:palette.display = { 'ctermbg': '255', 'guibg': '#f0f0f0' } " cursor_line
+
+" Let ClapInput, ClapSpinner and ClapSearchText use the same background.
+let s:bg0 = { 'ctermbg': '252', 'guibg': '#e5e5e5' } " non_text
+let s:palette.input = s:bg0
+let s:palette.indicator = extend({ 'ctermfg': '247', 'guifg':'#a0a1a7' }, s:bg0) " comment_fg
+let s:palette.spinner = extend({ 'ctermfg': '166', 'guifg':'#c18401', 'cterm': 'bold', 'gui': 'bold'}, s:bg0) " yellow
+let s:palette.search_text = extend({ 'ctermfg': '237', 'guifg': '#383a42', 'cterm': 'bold', 'gui': 'bold' }, s:bg0) " black
+
+let s:palette.preview = { 'ctermbg': '252', 'guibg': '#e5e5e5' } " non_text
+
+let s:palette.selected = { 'ctermfg': '31', 'guifg': '#0997b3', 'cterm': 'bold,underline', 'gui': 'bold,underline' } " cyan
+let s:palette.current_selection = { 'ctermbg': '231', 'guibg': '#fafafa', 'cterm': 'bold', 'gui': 'bold' } " gutter_bg
+
+let s:palette.selected_sign = { 'ctermfg': '167', 'guifg': '#e45649' } " red
+let s:palette.current_selection_sign = s:palette.selected_sign
+
+let g:clap#themes#onehalflight#palette = s:palette
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/themes/onehalflight.vim
+++ b/autoload/clap/themes/onehalflight.vim
@@ -23,6 +23,11 @@ let s:palette.current_selection = { 'ctermbg': '231', 'guibg': '#fafafa', 'cterm
 let s:palette.selected_sign = { 'ctermfg': '167', 'guifg': '#e45649' } " red
 let s:palette.current_selection_sign = s:palette.selected_sign
 
+" blue
+let g:clap_fuzzy_match_hl_groups = [
+  \ ['75', '#61afef'],
+\ ]
+
 let g:clap#themes#onehalflight#palette = s:palette
 
 let &cpoptions = s:save_cpo


### PR DESCRIPTION
Based on the simple and clean [onehalf themes](https://github.com/sonph/onehalf), I created these for vim-clap. I put some comments specifying which color identifier I used for every Clap element.