### PR TITLE
Add preview/file interface for easier external async preview integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [neovim] Add zindex option to fix the tricky floating_win overlapping, and add border for the preview window, use `let g:clap_popup_border = 'nil'` to disable the order. #693
 - Impl preview for `quickfix` provider. #691
+- Impl `preview/file` for easier external async preview integration. #706
 
 ### Changed
 
@@ -17,6 +18,7 @@
 - [neovim] Fix the action dialog creation using floating_win. #688
 - Fix the indicator winwidth is not flexible. #687
 - Fix the icon offset when restoring the full display line for grep provider. #701
+- Fix the Pyo3 compilation on M1. #707
 
 ### Perf
 

--- a/autoload/clap/client.vim
+++ b/autoload/clap/client.vim
@@ -12,8 +12,8 @@ function! clap#client#handle(msg) abort
   let decoded = json_decode(a:msg)
 
   if has_key(decoded, 'force_execute') && has_key(s:handlers, decoded.id)
-    call s:handlers[decoded.id](get(decoded, 'result', v:null), get(decoded, 'error', v:null))
-    call remove(s:handlers, decoded.id)
+    let Handler = remove(s:handlers, decoded.id)
+    call Handler(get(decoded, 'result', v:null), get(decoded, 'error', v:null))
     return
   endif
 
@@ -23,8 +23,8 @@ function! clap#client#handle(msg) abort
   endif
 
   if has_key(s:handlers, decoded.id)
-    call s:handlers[decoded.id](get(decoded, 'result', v:null), get(decoded, 'error', v:null))
-    call remove(s:handlers, decoded.id)
+    let Handler = remove(s:handlers, decoded.id)
+    call Handler(get(decoded, 'result', v:null), get(decoded, 'error', v:null))
     return
   endif
 endfunction

--- a/autoload/clap/client.vim
+++ b/autoload/clap/client.vim
@@ -71,6 +71,10 @@ function! clap#client#call_on_move(method, callback, ...) abort
   call clap#client#call(a:method, a:callback, params)
 endfunction
 
+function! clap#client#call_preview_file(extra) abort
+  call clap#client#call("preview/file", function("clap#impl#on_move#handler"), clap#preview#maple_opts(a:extra))
+endfunction
+
 function! clap#client#notify(method, params) abort
   let s:req_id += 1
   call clap#job#daemon#send_message(json_encode({

--- a/autoload/clap/client.vim
+++ b/autoload/clap/client.vim
@@ -72,7 +72,7 @@ function! clap#client#call_on_move(method, callback, ...) abort
 endfunction
 
 function! clap#client#call_preview_file(extra) abort
-  call clap#client#call("preview/file", function("clap#impl#on_move#handler"), clap#preview#maple_opts(a:extra))
+  call clap#client#call('preview/file', function('clap#impl#on_move#handler'), clap#preview#maple_opts(a:extra))
 endfunction
 
 function! clap#client#notify(method, params) abort

--- a/autoload/clap/preview.vim
+++ b/autoload/clap/preview.vim
@@ -148,6 +148,15 @@ function! clap#preview#async_open_with_delay() abort
   let s:preview_timer = timer_start(s:preview_delay, { -> clap#impl#on_move#invoke_async()})
 endfunction
 
+function! clap#preview#maple_opts(extra) abort
+  let opts = {
+        \ 'fpath': fnamemodify(fnameescape(g:clap.display.getcurline()), ':p'),
+        \ 'preview_width': winwidth(g:clap.preview.winid),
+        \ 'preview_height': winheight(g:clap.preview.winid),
+        \ }
+  return type(a:extra) == v:t_dict ? extend(opts, a:extra) : opts
+endfunction
+
 if has('nvim')
   let s:header_ns_id = nvim_create_namespace('clap_preview_header')
   " Sometimes the first line of preview window is used for the header.

--- a/crates/maple_cli/src/stdio_server/mod.rs
+++ b/crates/maple_cli/src/stdio_server/mod.rs
@@ -94,6 +94,7 @@ fn loop_handle_rpc_message(rx: &Receiver<String>) {
             match &msg.method[..] {
                 "initialize_global_env" => initialize_global(msg), // should be called only once.
                 "init_ext_map" => message_handlers::parse_filetypedetect(msg),
+                "preview/file" => message_handlers::preview_file(msg),
                 "filer" => filer::handle_filer_message(msg),
                 "quickfix" => quickfix::preview_quickfix_entry(msg),
                 "dumb_jump" => dumb_jump::handle_dumb_jump_message(msg),

--- a/crates/maple_cli/src/stdio_server/session/message_handlers/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/message_handlers/mod.rs
@@ -2,9 +2,10 @@
 
 use std::collections::HashMap;
 
+use anyhow::Result;
 use serde_json::json;
 
-use crate::stdio_server::{types::Message, write_response};
+use crate::stdio_server::{previewer, types::Message, write_response};
 
 pub fn parse_filetypedetect(msg: Message) {
     let output = msg.get_string_unsafe("autocmd_filetypedetect");
@@ -29,4 +30,26 @@ pub fn parse_filetypedetect(msg: Message) {
         json!({ "id": msg.id, "force_execute": true, "result": json!({"ext_map": ext_map}) });
 
     write_response(result);
+}
+
+async fn preview_file_impl(msg: Message) -> Result<()> {
+    let fpath = msg.get_string_unsafe("fpath");
+    let size = 20;
+    let max_width = 80;
+
+    let (lines, fname) = previewer::preview_file(fpath, 2 * size, max_width)?;
+
+    let result = json!({"id": msg.id, "result": json!({"lines": lines, "fname": fname})});
+
+    write_response(result);
+
+    Ok(())
+}
+
+pub fn preview_file(msg: Message) {
+    tokio::spawn(async move {
+        if let Err(e) = preview_file_impl(msg).await {
+            log::error!("Error when previewing the file: {}", e);
+        }
+    });
 }

--- a/crates/maple_cli/src/stdio_server/session/message_handlers/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/message_handlers/mod.rs
@@ -33,11 +33,11 @@ pub fn parse_filetypedetect(msg: Message) {
 }
 
 async fn preview_file_impl(msg: Message) -> Result<()> {
-    let fpath = msg.get_string_unsafe("fpath");
-    let size = 20;
-    let max_width = 80;
+    let fpath = msg.get_string("fpath")?;
+    let winwidth = msg.get_u64("preview_width")?;
+    let winheight = msg.get_u64("preview_height")?;
 
-    let (lines, fname) = previewer::preview_file(fpath, 2 * size, max_width)?;
+    let (lines, fname) = previewer::preview_file(fpath, winheight as usize, winwidth as usize)?;
 
     let result = json!({"id": msg.id, "result": json!({"lines": lines, "fname": fname})});
 

--- a/crates/matcher/src/bonus/recent_files.rs
+++ b/crates/matcher/src/bonus/recent_files.rs
@@ -7,15 +7,8 @@ pub struct RecentFiles(Vec<String>);
 
 impl RecentFiles {
     pub fn calc_bonus(&self, item: &SourceItem, base_score: Score) -> Score {
-        if let Err(bonus) = self.0.iter().try_for_each(|s| {
-            if s.contains(&item.raw) {
-                let bonus = base_score / 3;
-                Err(bonus)
-            } else {
-                Ok(())
-            }
-        }) {
-            bonus
+        if self.0.iter().any(|s| s.contains(&item.raw)) {
+            base_score / 3
         } else {
             0
         }


### PR DESCRIPTION
Now users can have an `on_move_async` impl easily for their own providers if the entry is a file path.

```vim 
      let g:clap_provider_quick_open = {
            \ 'source': ['~/.vimrc', '~/.spacevim', '~/.bashrc', '~/.tmux.conf'],
            \ 'sink': 'e',
            \ 'on_move_async': { -> clap#client#call_preview_file(v:null) },
            \ }
```