### PR TITLE
Parallel recursive ctags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improved
 
 - Improve the overal performance by using rayon. #754
+- Parallel recursive ctags creation, 30x faster on my machine. #755
 
 ## [0.29] 2021-08-30
 

--- a/crates/filter/src/lib.rs
+++ b/crates/filter/src/lib.rs
@@ -113,38 +113,13 @@ pub fn sync_run<I: Iterator<Item = SourceItem>>(
 }
 
 /// Performs the synchorous filtering on a small scale of source in parallel.
-pub fn par_filter_on_list(
+pub fn par_filter(
     query: impl Into<Query>,
-    source_list: Vec<SourceItem>,
+    source_items: Vec<SourceItem>,
     fuzzy_matcher: &Matcher,
-) -> Result<Vec<FilteredItem>> {
-    let query: Query = query.into();
-    let mut filtered = source::par_filter(source_list, fuzzy_matcher, &query);
-    filtered.par_sort_unstable_by(|item1, item2| item2.score.partial_cmp(&item1.score).unwrap());
-    Ok(filtered.into_par_iter().map(Into::into).collect())
-}
-
-pub fn simple_run<T: Into<SourceItem>>(
-    lines: impl Iterator<Item = T>,
-    query: &str,
-    bonuses: Option<Vec<Bonus>>,
 ) -> Vec<FilteredItem> {
-    let matcher = matcher::Matcher::with_bonuses(
-        FuzzyAlgorithm::Fzy,
-        MatchType::Full,
-        bonuses.unwrap_or_default(),
-    );
-
     let query: Query = query.into();
-    let do_match = |source_item: &SourceItem| matcher.match_query(source_item, &query);
-
-    let filtered = lines
-        .map(|line| line.into())
-        .filter_map(|source_item| {
-            do_match(&source_item).map(|(score, indices)| (source_item, score, indices))
-        })
-        .map(Into::into)
-        .collect::<Vec<_>>();
-
-    sort_initial_filtered(filtered)
+    let mut filtered = source::par_filter_impl(source_items, fuzzy_matcher, &query);
+    filtered.par_sort_unstable_by(|item1, item2| item2.score.partial_cmp(&item1.score).unwrap());
+    filtered
 }

--- a/crates/filter/src/source.rs
+++ b/crates/filter/src/source.rs
@@ -108,10 +108,14 @@ impl<I: Iterator<Item = SourceItem>> Source<I> {
     }
 }
 
-pub fn par_filter(list: Vec<SourceItem>, matcher: &Matcher, query: &Query) -> Vec<FilteredItem> {
+/// Filter the source list in parallel.
+pub(crate) fn par_filter_impl(
+    list: Vec<SourceItem>,
+    matcher: &Matcher,
+    query: &Query,
+) -> Vec<FilteredItem> {
     let scorer = |item: &SourceItem| matcher.match_query(item, query);
     list.into_par_iter()
-        .filter_map(|item| scorer(&item).map(|(score, indices)| (item, score, indices)))
-        .map(Into::into)
+        .filter_map(|item| scorer(&item).map(|(score, indices)| (item, score, indices).into()))
         .collect()
 }

--- a/crates/maple_cli/benches/benchmark.rs
+++ b/crates/maple_cli/benches/benchmark.rs
@@ -3,6 +3,8 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use filter::{FilteredItem, Query, SourceItem};
 use matcher::{FuzzyAlgorithm, MatchType, Matcher};
 
+use maple_cli::command::ctags::recursive::build_recursive_ctags_cmd;
+
 fn prepare_source_items() -> Vec<SourceItem> {
     use std::io::BufRead;
 
@@ -76,6 +78,17 @@ fn bench_filter(c: &mut Criterion) {
 
     c.bench_function("par filter 1m", |b| {
         b.iter(|| par_filter(black_box(source_items_1m.clone()), &matcher, &query))
+    });
+
+    let ctags_cmd =
+        build_recursive_ctags_cmd("/home/xlc/src/github.com/paritytech/substrate".into());
+
+    c.bench_function("parallel recursive ctags", |b| {
+        b.iter(|| ctags_cmd.par_formatted_lines())
+    });
+
+    c.bench_function("recursive ctags", |b| {
+        b.iter(|| ctags_cmd.formatted_lines())
     });
 }
 

--- a/crates/maple_cli/src/command/ctags/recursive.rs
+++ b/crates/maple_cli/src/command/ctags/recursive.rs
@@ -80,11 +80,11 @@ impl RecursiveTags {
 
         if self.forerunner {
             let (total, cache) = if no_cache {
-                ctags_cmd.create_cache()?
+                ctags_cmd.par_create_cache()?
             } else if let Some((total, cache_path)) = ctags_cmd.get_ctags_cache() {
                 (total, cache_path)
             } else {
-                ctags_cmd.create_cache()?
+                ctags_cmd.par_create_cache()?
             };
             send_response_from_cache(&cache, total, SendResponse::Json, icon_painter);
             return Ok(());

--- a/crates/maple_cli/src/command/ctags/recursive.rs
+++ b/crates/maple_cli/src/command/ctags/recursive.rs
@@ -81,7 +81,7 @@ impl RecursiveTags {
         if self.forerunner {
             let (total, cache) = if no_cache {
                 ctags_cmd.par_create_cache()?
-            } else if let Some((total, cache_path)) = ctags_cmd.get_ctags_cache() {
+            } else if let Some((total, cache_path)) = ctags_cmd.ctags_cache() {
                 (total, cache_path)
             } else {
                 ctags_cmd.par_create_cache()?

--- a/crates/maple_cli/src/command/ctags/recursive.rs
+++ b/crates/maple_cli/src/command/ctags/recursive.rs
@@ -95,7 +95,7 @@ impl RecursiveTags {
                 } else {
                     Default::default()
                 },
-                Source::List(ctags_cmd.formatted_tags_stream()?.map(Into::into)),
+                Source::List(ctags_cmd.formatted_tags_iter()?.map(Into::into)),
                 FilterContext::new(None, Some(30), None, icon_painter, MatchType::TagName),
                 vec![Bonus::None],
             )?;

--- a/crates/maple_cli/src/command/exec.rs
+++ b/crates/maple_cli/src/command/exec.rs
@@ -6,7 +6,8 @@ use structopt::StructOpt;
 
 use crate::app::Params;
 use crate::process::{
-    light::{set_current_dir, LightCommand},
+    light::LightCommand,
+    rstd::StdCommand,
     BaseCommand,
 };
 
@@ -29,11 +30,13 @@ pub struct Exec {
 impl Exec {
     // This can work with the piped command, e.g., git ls-files | uniq.
     fn prepare_exec_cmd(&self) -> Command {
-        let mut cmd = crate::process::rstd::build_command(&self.cmd);
+        let mut cmd = StdCommand::from(self.cmd.as_str());
 
-        set_current_dir(&mut cmd, self.cmd_dir.as_ref());
+        if let Some(ref cmd_dir) = self.cmd_dir {
+            cmd.current_dir(cmd_dir);
+        }
 
-        cmd
+        cmd.into_inner()
     }
 
     pub fn run(

--- a/crates/maple_cli/src/command/exec.rs
+++ b/crates/maple_cli/src/command/exec.rs
@@ -5,11 +5,7 @@ use anyhow::Result;
 use structopt::StructOpt;
 
 use crate::app::Params;
-use crate::process::{
-    light::LightCommand,
-    rstd::StdCommand,
-    BaseCommand,
-};
+use crate::process::{light::LightCommand, rstd::StdCommand, BaseCommand};
 
 /// Execute the shell command
 #[derive(StructOpt, Debug, Clone)]

--- a/crates/maple_cli/src/process/light.rs
+++ b/crates/maple_cli/src/process/light.rs
@@ -1,6 +1,6 @@
-//! Wrapper of std `Command` with some optimization about the output.
+//! Wrapper of [`std::process::Command`] with some optimization about the output.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::process::Command;
 
 use anyhow::{anyhow, Result};
@@ -21,19 +21,6 @@ fn trim_trailing(lines: &mut Vec<String>) {
         // " " len is 4.
         if last_line.is_empty() || last_line.len() == 4 {
             lines.remove(lines.len() - 1);
-        }
-    }
-}
-
-pub fn set_current_dir<P: AsRef<Path>>(cmd: &mut Command, cmd_dir: Option<P>) {
-    if let Some(cmd_dir) = cmd_dir {
-        // If cmd_dir is not a directory, use its parent as current dir.
-        if cmd_dir.as_ref().is_dir() {
-            cmd.current_dir(cmd_dir);
-        } else {
-            let mut cmd_dir: PathBuf = cmd_dir.as_ref().into();
-            cmd_dir.pop();
-            cmd.current_dir(cmd_dir);
         }
     }
 }

--- a/crates/maple_cli/src/process/tokio.rs
+++ b/crates/maple_cli/src/process/tokio.rs
@@ -1,4 +1,4 @@
-//! Wrapper of tokio `Command`.
+//! Wrapper of [`tokio::process::Command`].
 
 use std::path::Path;
 
@@ -37,6 +37,7 @@ impl From<String> for TokioCommand {
 }
 
 impl TokioCommand {
+    /// Constructs a new instance of [`TokioCommand`].
     pub fn new(cmd: impl AsRef<str>) -> Self {
         cmd.as_ref().into()
     }
@@ -71,5 +72,8 @@ async fn test_tokio_command() {
             .unwrap()
     )
     .into();
-    assert_eq!(vec!["Cargo.toml", "benches", "src"], tokio_cmd.lines().await.unwrap());
+    assert_eq!(
+        vec!["Cargo.toml", "benches", "src"],
+        tokio_cmd.lines().await.unwrap()
+    );
 }

--- a/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
@@ -99,7 +99,7 @@ pub async fn on_session_create(context: Arc<SessionContext>) -> Result<Scale> {
     if context.provider_id.as_str() == "proj_tags" {
         let ctags_cmd =
             crate::command::ctags::recursive::build_recursive_ctags_cmd(context.cwd.to_path_buf());
-        let lines = ctags_cmd.formatted_tags_stream()?.collect::<Vec<_>>();
+        let lines = ctags_cmd.formatted_tags_iter()?.collect::<Vec<_>>();
         return Ok(to_scale(lines));
     }
 

--- a/crates/maple_cli/src/stdio_server/session/context.rs
+++ b/crates/maple_cli/src/stdio_server/session/context.rs
@@ -108,11 +108,11 @@ impl SessionContext {
         query: &str,
         lines: impl Iterator<Item = &'a str>,
     ) -> Result<SyncFilterResults> {
-        let ranked = filter::par_filter_on_list(
+        let ranked = filter::par_filter(
             query,
             lines.map(Into::into).collect(),
             &self.fuzzy_matcher(),
-        )?;
+        );
 
         let total = ranked.len();
 

--- a/crates/maple_cli/src/tools/ctags/mod.rs
+++ b/crates/maple_cli/src/tools/ctags/mod.rs
@@ -75,7 +75,7 @@ impl CtagsCommand {
         self.inner.cached_info()
     }
 
-    /// Runs the command and writes the cache to the disk.
+    /// Parallel version of [`create_cache`].
     pub fn par_create_cache(&self) -> Result<(usize, PathBuf)> {
         use itertools::Itertools;
 

--- a/crates/maple_cli/src/tools/ctags/mod.rs
+++ b/crates/maple_cli/src/tools/ctags/mod.rs
@@ -31,7 +31,7 @@ impl CtagsCommand {
     pub fn par_formatted_lines(&self) -> Result<Vec<String>> {
         use rayon::prelude::*;
 
-        let stdout = StdCommand::new(self.inner.command.clone()).stdout()?;
+        let stdout = StdCommand::new(&self.inner.command).stdout()?;
 
         Ok(stdout
             .par_split(|x| x == &b'\n')

--- a/crates/maple_cli/src/tools/ctags/mod.rs
+++ b/crates/maple_cli/src/tools/ctags/mod.rs
@@ -60,7 +60,7 @@ impl CtagsCommand {
     }
 
     /// Returns an iterator of tag line in a formatted form.
-    pub fn formatted_tags_stream(&self) -> Result<impl Iterator<Item = String>> {
+    pub fn formatted_tags_iter(&self) -> Result<impl Iterator<Item = String>> {
         Ok(self.run()?.filter_map(|tag| {
             if let Ok(tag) = serde_json::from_str::<TagInfo>(&tag) {
                 Some(tag.display_line())
@@ -80,11 +80,11 @@ impl CtagsCommand {
         use itertools::Itertools;
 
         let mut total = 0usize;
-        let mut formatted_tags_stream = self.formatted_tags_stream()?.map(|x| {
+        let mut formatted_tags_iter = self.formatted_tags_iter()?.map(|x| {
             total += 1;
             x
         });
-        let lines = formatted_tags_stream.join("\n");
+        let lines = formatted_tags_iter.join("\n");
 
         let cache_path = self.inner.clone().create_cache(total, lines.as_bytes())?;
 

--- a/crates/maple_cli/src/tools/ctags/mod.rs
+++ b/crates/maple_cli/src/tools/ctags/mod.rs
@@ -2,7 +2,9 @@ use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
+use itertools::Itertools;
 use once_cell::sync::OnceCell;
+use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::process::rstd::StdCommand;
@@ -20,31 +22,6 @@ impl CtagsCommand {
         Self { inner }
     }
 
-    /// Returns an iterator of raw line of ctags output.
-    fn run(&self) -> Result<impl Iterator<Item = String>> {
-        Ok(BufReader::new(self.inner.stream_stdout()?)
-            .lines()
-            .flatten())
-    }
-
-    /// Parallel version of [`formatted_lines`].
-    pub fn par_formatted_lines(&self) -> Result<Vec<String>> {
-        use rayon::prelude::*;
-
-        let stdout = StdCommand::new(&self.inner.command).stdout()?;
-
-        Ok(stdout
-            .par_split(|x| x == &b'\n')
-            .filter_map(|tag| {
-                if let Ok(tag) = serde_json::from_str::<TagInfo>(&String::from_utf8_lossy(tag)) {
-                    Some(tag.display_line())
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<_>>())
-    }
-
     /// Returns an iterator of tag line in a formatted form.
     pub fn formatted_lines(&self) -> Result<Vec<String>> {
         Ok(self
@@ -59,6 +36,29 @@ impl CtagsCommand {
             .collect())
     }
 
+    /// Parallel version of [`formatted_lines`].
+    pub fn par_formatted_lines(&self) -> Result<Vec<String>> {
+        let stdout = StdCommand::new(&self.inner.command).stdout()?;
+
+        Ok(stdout
+            .par_split(|x| x == &b'\n')
+            .filter_map(|tag| {
+                if let Ok(tag) = serde_json::from_str::<TagInfo>(&String::from_utf8_lossy(tag)) {
+                    Some(tag.display_line())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>())
+    }
+
+    /// Returns an iterator of raw line of ctags output.
+    fn run(&self) -> Result<impl Iterator<Item = String>> {
+        Ok(BufReader::new(self.inner.stream_stdout()?)
+            .lines()
+            .flatten())
+    }
+
     /// Returns an iterator of tag line in a formatted form.
     pub fn formatted_tags_iter(&self) -> Result<impl Iterator<Item = String>> {
         Ok(self.run()?.filter_map(|tag| {
@@ -71,33 +71,29 @@ impl CtagsCommand {
     }
 
     /// Returns a tuple of (total, cache_path) if the cache exists.
-    pub fn get_ctags_cache(&self) -> Option<(usize, PathBuf)> {
+    pub fn ctags_cache(&self) -> Option<(usize, PathBuf)> {
         self.inner.cached_info()
-    }
-
-    /// Parallel version of [`create_cache`].
-    pub fn par_create_cache(&self) -> Result<(usize, PathBuf)> {
-        use itertools::Itertools;
-
-        let lines = self.par_formatted_lines()?;
-        let total = lines.len();
-        let lines = lines.into_iter().join("\n");
-
-        let cache_path = self.inner.clone().create_cache(total, lines.as_bytes())?;
-
-        Ok((total, cache_path))
     }
 
     /// Runs the command and writes the cache to the disk.
     pub fn create_cache(&self) -> Result<(usize, PathBuf)> {
-        use itertools::Itertools;
-
         let mut total = 0usize;
         let mut formatted_tags_iter = self.formatted_tags_iter()?.map(|x| {
             total += 1;
             x
         });
         let lines = formatted_tags_iter.join("\n");
+
+        let cache_path = self.inner.clone().create_cache(total, lines.as_bytes())?;
+
+        Ok((total, cache_path))
+    }
+
+    /// Parallel version of [`create_cache`].
+    pub fn par_create_cache(&self) -> Result<(usize, PathBuf)> {
+        let lines = self.par_formatted_lines()?;
+        let total = lines.len();
+        let lines = lines.into_iter().join("\n");
 
         let cache_path = self.inner.clone().create_cache(total, lines.as_bytes())?;
 

--- a/crates/maple_cli/src/tools/ctags/mod.rs
+++ b/crates/maple_cli/src/tools/ctags/mod.rs
@@ -76,6 +76,19 @@ impl CtagsCommand {
     }
 
     /// Runs the command and writes the cache to the disk.
+    pub fn par_create_cache(&self) -> Result<(usize, PathBuf)> {
+        use itertools::Itertools;
+
+        let lines = self.par_formatted_lines()?;
+        let total = lines.len();
+        let lines = lines.into_iter().join("\n");
+
+        let cache_path = self.inner.clone().create_cache(total, lines.as_bytes())?;
+
+        Ok((total, cache_path))
+    }
+
+    /// Runs the command and writes the cache to the disk.
     pub fn create_cache(&self) -> Result<(usize, PathBuf)> {
         use itertools::Itertools;
 


### PR DESCRIPTION
The result is 30x faster, test repo: https://github.com/paritytech/substrate

```
parallel recursive ctags
                        time:   [13.764 ms 13.967 ms 14.164 ms]
                        change: [-0.4382% +1.6583% +3.7623%] (p = 0.11 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild

Benchmarking recursive ctags: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 38.9s, or reduce sample count to 10.
recursive ctags         time:   [385.76 ms 387.24 ms 388.80 ms]
                        change: [+0.4888% +1.1275% +1.7357%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
```


```bash
$ lscpu
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   48 bits physical, 48 bits virtual
CPU(s):                          24
On-line CPU(s) list:             0-23
Thread(s) per core:              2
Core(s) per socket:              12
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       AuthenticAMD
CPU family:                      25
Model:                           33
Model name:                      AMD Ryzen 9 5900X 12-Core Processor
Stepping:                        0
Frequency boost:                 enabled
CPU MHz:                         2200.000
CPU max MHz:                     4950.1948
CPU min MHz:                     2200.0000
BogoMIPS:                        7386.20
Virtualization:                  AMD-V
L1d cache:                       384 KiB
L1i cache:                       384 KiB
L2 cache:                        6 MiB
L3 cache:                        64 MiB
```