### PR TITLE
Bugfix missing keybindings for neovim

### DIFF
--- a/autoload/clap/provider/maps.vim
+++ b/autoload/clap/provider/maps.vim
@@ -37,15 +37,14 @@ function! s:maps_source() abort
   for line in split(cout, "\n")
     if line =~# "^\t"
       let src = '  '.join(reverse(reverse(split(split(line)[-1], '/'))[0:2]), '/')
-      call add(list, printf('%s %s', curr, src))
+      let list[-1] = printf('%s %s', curr, src)
       let curr = ''
     else
       let curr = line[3:]
+      call add(list, printf('%s', curr))
     endif
   endfor
-  if !empty(curr)
-    call add(list, curr)
-  endif
+
   return sort(s:align_pairs(list))
 endfunction
 


### PR DESCRIPTION
For neovim when running `verbose nmap`
The output maybe either with comments:

e.g.
```
  <C-W>R      * <C-W>R<Cmd>ScrollViewRefresh<CR>                                                                                                                         
        Last set from ~/.local/share/nvim/site/pack/packer/start/nvim-scrollview/plugin/scrollview.vim line 141
```
Or without comments
```
n  <C-K>       *@<Cmd>lua vim.lsp.buf.signature_help()<CR>                                                                                                                
n  <C-]>       *@<Cmd>lua vim.lsp.buf.definition()<CR>
```
The problem with the current code is that it assumes the mapping is always followed by a line of comment start with `\t`.  And will postpone add to list until a well formatted commant is parsed.   This means multiple mappings without comments can not be written to the source list.

Also. I do not know when ` get(g:clap.context, 'mode', 'n') ` will be mode other than n.  e.g. If I start up clap in visual mode, seems clap.context does not updated.



 

