### PR TITLE
Reuse the last results when it's usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [unreleased]
 
-## [Improved]
+## Improved
 
 - Rework the truncation of long lines. #788
 - Support searching the definition/declaration in the `tags` file using `readtags` for `dumb_jump` provider. #789
@@ -12,6 +12,10 @@
 
   - `hel`: match the tags that starts with `hel`.
   - `hel*`: match the tags that contain `hel`.
+
+## Fixed
+
+- Fix the regression that `filer` provider is not properly initialized on the Rust backend. #790
 
 ## [0.31] 2021-12-12
 

--- a/autoload/clap/provider/filer.vim
+++ b/autoload/clap/provider/filer.vim
@@ -97,7 +97,7 @@ function! s:filter_or_send_message() abort
   if has_key(s:filer_cache, s:current_dir)
     call s:do_filter()
   else
-    call clap#client#call('filer', function('s:handle_response'), {'cwd': s:current_dir})
+    call clap#client#call('filer/on_typed', function('s:handle_response'), {'cwd': s:current_dir})
   endif
 endfunction
 

--- a/crates/icon/src/lib.rs
+++ b/crates/icon/src/lib.rs
@@ -3,7 +3,7 @@
 // pub use constants::*;
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
-use std::path::Path;
+use std::{fmt::Display, path::Path};
 
 pub const DEFAULT_ICON: char = '';
 pub const FOLDER_ICON: char = '';
@@ -149,7 +149,7 @@ pub fn filer_icon<P: AsRef<Path>>(path: P) -> IconType {
     }
 }
 
-pub fn prepend_filer_icon<P: AsRef<Path>>(path: P, line: &str) -> String {
+pub fn prepend_filer_icon<P: AsRef<Path>>(path: P, line: impl Display) -> String {
     format!("{} {}", filer_icon(path), line)
 }
 

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/mod.rs
@@ -64,6 +64,10 @@ impl Usages {
         self.0.iter()
     }
 
+    pub fn par_iter(&self) -> rayon::slice::Iter<'_, Usage> {
+        self.0.par_iter()
+    }
+
     pub fn get_line(&self, index: usize) -> Option<&str> {
         self.0.get(index).map(|usage| usage.line.as_str())
     }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/parser.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/parser.rs
@@ -9,6 +9,7 @@ fn rs_kind_alias() -> HashMap<&'static str, &'static str> {
     vec![
         ("module", "mod"),
         ("function", "fn"),
+        ("interface", "trait"),
         ("enumerator", "enum"),
         ("implementation", "impl"),
     ]

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/definition.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/definition.rs
@@ -11,7 +11,7 @@ use crate::dumb_analyzer::find_usages::{Usage, Usages};
 use crate::tools::ripgrep::{Match, Word};
 use crate::utils::ExactOrInverseTerms;
 
-use super::worker::{find_definitions_with_kind, find_occurrences_by_lang, search_regexp};
+use super::worker::{find_definitions_with_kind, find_occurrences_by_lang, regexp_search};
 
 /// A map of the ripgrep language to a set of regular expressions.
 ///
@@ -322,7 +322,7 @@ pub(super) async fn do_search_usages(
         .collect::<Vec<_>>();
 
     if regex_usages.is_empty() {
-        let lines = search_regexp(word, lang, dir, comments).await?;
+        let lines = regexp_search(word, lang, dir, comments).await?;
         let grep_usages = lines
             .into_par_iter()
             .filter_map(|line| {
@@ -371,7 +371,7 @@ pub(super) async fn definitions_and_references(
         .collect();
 
     if res.is_empty() {
-        search_regexp(word, lang, dir, comments)
+        regexp_search(word, lang, dir, comments)
             .await
             .map(|results| std::iter::once((MatchKind::Occurrence, results)).collect())
     } else {

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/worker.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/worker.rs
@@ -41,7 +41,7 @@ fn find_matches(
     }
 }
 
-pub(super) async fn search_regexp(
+pub(super) async fn regexp_search(
     word: &Word,
     lang_type: &str,
     dir: &Option<PathBuf>,

--- a/crates/maple_cli/src/stdio_server/deprecated_runner.rs
+++ b/crates/maple_cli/src/stdio_server/deprecated_runner.rs
@@ -1,6 +1,5 @@
 use crate::stdio_server::providers::{
-    dumb_jump::DumbJumpHandle, filer::handle_filer_message, filer::FilerHandle,
-    recent_files::RecentFilesHandle, BuiltinHandle,
+    dumb_jump::DumbJumpHandle, filer::FilerHandle, recent_files::RecentFilesHandle, BuiltinHandle,
 };
 
 use super::*;
@@ -88,15 +87,8 @@ fn loop_handle_rpc_message(rx: &Receiver<String>) {
                         "recent_files/on_typed" => manager.send(msg.session_id, OnTyped(msg)),
                         "recent_files/on_move" => manager.send(msg.session_id, OnMove(msg)),
 
-                        "filer" => {
-                            tokio::spawn(async move {
-                                write_response(
-                                    handle_filer_message(msg)
-                                        .expect("Both Success and Error are returned"),
-                                );
-                            });
-                        }
                         "filer/on_init" => manager.new_session(call, FilerHandle),
+                        "filer/on_typed" => manager.send(msg.session_id, OnTyped(msg)),
                         "filer/on_move" => manager.send(msg.session_id, OnMove(msg)),
 
                         "on_typed" => manager.send(msg.session_id, OnTyped(msg)),

--- a/crates/maple_cli/src/stdio_server/deprecated_runner.rs
+++ b/crates/maple_cli/src/stdio_server/deprecated_runner.rs
@@ -1,6 +1,6 @@
 use crate::stdio_server::providers::{
-    dumb_jump::DumbJumpMessageHandler, filer::handle_filer_message, filer::FilerMessageHandler,
-    recent_files::RecentFilesMessageHandler, BuiltinSessionEventHandle,
+    dumb_jump::DumbJumpHandle, filer::handle_filer_message, filer::FilerHandle,
+    recent_files::RecentFilesHandle, BuiltinHandle,
 };
 
 use super::*;
@@ -41,7 +41,7 @@ fn loop_handle_rpc_message(rx: &Receiver<String>) {
             match call.clone() {
                 Call::Notification(notification) => match notification.method.as_str() {
                     "exit" => manager.terminate(notification.session_id),
-                    "on_init" => manager.new_session(call, BuiltinSessionEventHandle),
+                    "on_init" => manager.new_session(call, BuiltinHandle),
                     _ => {
                         tokio::spawn(async move {
                             if let Err(e) = notification.process().await {
@@ -78,14 +78,12 @@ fn loop_handle_rpc_message(rx: &Receiver<String>) {
                             });
                         }
 
-                        "dumb_jump/on_init" => {
-                            manager.new_session(call, DumbJumpMessageHandler::default())
-                        }
+                        "dumb_jump/on_init" => manager.new_session(call, DumbJumpHandle::default()),
                         "dumb_jump/on_typed" => manager.send(msg.session_id, OnTyped(msg)),
                         "dumb_jump/on_move" => manager.send(msg.session_id, OnMove(msg)),
 
                         "recent_files/on_init" => {
-                            manager.new_session(call, RecentFilesMessageHandler::default())
+                            manager.new_session(call, RecentFilesHandle::default())
                         }
                         "recent_files/on_typed" => manager.send(msg.session_id, OnTyped(msg)),
                         "recent_files/on_move" => manager.send(msg.session_id, OnMove(msg)),
@@ -98,7 +96,7 @@ fn loop_handle_rpc_message(rx: &Receiver<String>) {
                                 );
                             });
                         }
-                        "filer/on_init" => manager.new_session(call, FilerMessageHandler),
+                        "filer/on_init" => manager.new_session(call, FilerHandle),
                         "filer/on_move" => manager.send(msg.session_id, OnMove(msg)),
 
                         "on_typed" => manager.send(msg.session_id, OnTyped(msg)),

--- a/crates/maple_cli/src/stdio_server/mod.rs
+++ b/crates/maple_cli/src/stdio_server/mod.rs
@@ -20,11 +20,7 @@ use once_cell::sync::OnceCell;
 use serde::Serialize;
 use serde_json::json;
 
-use self::providers::{
-    dumb_jump,
-    filer::{self, FilerSession},
-    quickfix, recent_files, BuiltinSession,
-};
+use self::providers::{dumb_jump, quickfix, recent_files};
 use self::rpc::{Call, RpcClient};
 use self::session::{SessionEvent, SessionManager};
 use self::session_client::SessionClient;

--- a/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
@@ -13,9 +13,7 @@ use crate::command::grep::RgBaseCommand;
 use crate::process::tokio::TokioCommand;
 use crate::stdio_server::{
     rpc::Call,
-    session::{
-        Scale, Session, SessionContext, SessionEvent, EventHandle, SyncFilterResults,
-    },
+    session::{EventHandle, Scale, Session, SessionContext, SessionEvent, SyncFilterResults},
     write_response, MethodCall,
 };
 

--- a/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
@@ -14,7 +14,7 @@ use crate::process::tokio::TokioCommand;
 use crate::stdio_server::{
     rpc::Call,
     session::{
-        Scale, Session, SessionContext, SessionEvent, SessionEventHandle, SyncFilterResults,
+        Scale, Session, SessionContext, SessionEvent, EventHandle, SyncFilterResults,
     },
     write_response, MethodCall,
 };
@@ -22,10 +22,10 @@ use crate::stdio_server::{
 pub use on_move::{OnMove, OnMoveHandler};
 
 #[derive(Clone)]
-pub struct BuiltinSessionEventHandle;
+pub struct BuiltinHandle;
 
 #[async_trait::async_trait]
-impl SessionEventHandle for BuiltinSessionEventHandle {
+impl EventHandle for BuiltinHandle {
     async fn on_move(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {
         let msg_id = msg.id;
         if let Err(error) = on_move::OnMoveHandler::create(&msg, &context, None).map(|x| x.handle())

--- a/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
@@ -14,22 +14,12 @@ use crate::process::tokio::TokioCommand;
 use crate::stdio_server::{
     rpc::Call,
     session::{
-        SessionEventHandle, NewSession, Scale, Session, SessionContext, SessionEvent, SyncFilterResults,
+        Scale, Session, SessionContext, SessionEvent, SessionEventHandle, SyncFilterResults,
     },
     write_response, MethodCall,
 };
 
 pub use on_move::{OnMove, OnMoveHandler};
-
-pub struct BuiltinSession;
-
-impl NewSession for BuiltinSession {
-    fn spawn(call: Call) -> Result<Sender<SessionEvent>> {
-        let (session, session_sender) = Session::new(call, BuiltinSessionEventHandle);
-        session.start_event_loop();
-        Ok(session_sender)
-    }
-}
 
 #[derive(Clone)]
 pub struct BuiltinSessionEventHandle;

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -262,7 +262,7 @@ impl<'a> OnMoveHandler<'a> {
                     let dir = self.context.cwd.clone();
                     IS_FERESHING_CACHE.store(true, Ordering::Relaxed);
                     // Spawn a future in the background
-                    tokio::spawn(async move {
+                    tokio::task::spawn_blocking(|| {
                         tracing::debug!(?dir, "Attempting to refresh grep2 cache");
                         match crate::command::grep::refresh_cache(dir) {
                             Ok(total) => {

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -8,7 +8,9 @@ use serde_json::json;
 use pattern::*;
 
 use crate::previewer::{self, vim_help::HelpTagPreview};
-use crate::stdio_server::{filer, global, session::SessionContext, write_response, MethodCall};
+use crate::stdio_server::{
+    global, providers::filer, session::SessionContext, write_response, MethodCall,
+};
 use crate::utils::build_abs_path;
 
 static IS_FERESHING_CACHE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));

--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
@@ -351,7 +351,8 @@ impl EventHandler for DumbJumpMessageHandler {
                 .filter_map(|Usage { line, indices }| {
                     search_info
                         .filtering_terms
-                        .check_jump_line((line.clone(), indices.clone()))
+                        .check_usage_line(line, indices.clone())
+                        .map(|indices| (line, indices))
                 })
                 .collect::<Vec<_>>();
             tracing::debug!("============== ending refiltering");

--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
@@ -15,7 +15,7 @@ use crate::dumb_analyzer::{Filtering, RegexSearcher, TagSearcher, Usage, Usages}
 use crate::stdio_server::{
     providers::builtin::OnMoveHandler,
     rpc::Call,
-    session::{Session, SessionContext, SessionEvent, SessionEventHandle},
+    session::{Session, SessionContext, SessionEvent, EventHandle},
     write_response, MethodCall,
 };
 use crate::tools::ctags::{get_language, TagsConfig};
@@ -278,7 +278,7 @@ async fn search_for_usages(
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct DumbJumpMessageHandler {
+pub struct DumbJumpHandle {
     /// Results from last searching.
     /// This might be a superset of searching results for the last query.
     cached_results: SearchResults,
@@ -288,7 +288,7 @@ pub struct DumbJumpMessageHandler {
     tags_regenerated: Arc<AtomicBool>,
 }
 
-impl DumbJumpMessageHandler {
+impl DumbJumpHandle {
     // TODO: smarter strategy to regenerate the tags?
     fn regenerate_tags(&mut self, dir: &str, extension: String) {
         let mut tags_config = TagsConfig::with_dir(dir);
@@ -334,7 +334,7 @@ impl DumbJumpMessageHandler {
 }
 
 #[async_trait::async_trait]
-impl SessionEventHandle for DumbJumpMessageHandler {
+impl EventHandle for DumbJumpHandle {
     async fn on_create(&mut self, call: Call, context: Arc<SessionContext>) {
         let (msg_id, params) = parse_msg(call.unwrap_method_call());
         // Do not have to await.

--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
@@ -15,7 +15,7 @@ use crate::dumb_analyzer::{Filtering, RegexSearcher, TagSearcher, Usage, Usages}
 use crate::stdio_server::{
     providers::builtin::OnMoveHandler,
     rpc::Call,
-    session::{Session, SessionContext, SessionEvent, EventHandle},
+    session::{EventHandle, Session, SessionContext, SessionEvent},
     write_response, MethodCall,
 };
 use crate::tools::ctags::{get_language, TagsConfig};

--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use crossbeam_channel::Sender;
 use itertools::Itertools;
+use rayon::prelude::*;
 use serde::Deserialize;
 use serde_json::json;
 
@@ -19,9 +20,6 @@ use crate::stdio_server::{
 };
 use crate::tools::ctags::{get_language, TagsConfig};
 use crate::utils::ExactOrInverseTerms;
-
-#[derive(Debug, Clone, Default)]
-struct QueryInfo {}
 
 /// Internal reprentation of user input.
 #[derive(Debug, Clone, Default)]
@@ -349,7 +347,7 @@ impl EventHandler for DumbJumpMessageHandler {
             let refiltered = self
                 .results
                 .usages
-                .iter()
+                .par_iter()
                 .filter_map(|Usage { line, indices }| {
                     search_info
                         .filtering_terms

--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump.rs
@@ -15,7 +15,7 @@ use crate::dumb_analyzer::{Filtering, RegexSearcher, TagSearcher, Usage, Usages}
 use crate::stdio_server::{
     providers::builtin::OnMoveHandler,
     rpc::Call,
-    session::{EventHandler, NewSession, Session, SessionContext, SessionEvent},
+    session::{SessionEventHandle, NewSession, Session, SessionContext, SessionEvent},
     write_response, MethodCall,
 };
 use crate::tools::ctags::{get_language, TagsConfig};
@@ -334,12 +334,8 @@ impl DumbJumpMessageHandler {
 }
 
 #[async_trait::async_trait]
-impl EventHandler for DumbJumpMessageHandler {
-    async fn handle_on_move(
-        &mut self,
-        msg: MethodCall,
-        context: Arc<SessionContext>,
-    ) -> Result<()> {
+impl SessionEventHandle for DumbJumpMessageHandler {
+    async fn on_move(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {
         let msg_id = msg.id;
 
         let lnum = msg
@@ -364,11 +360,7 @@ impl EventHandler for DumbJumpMessageHandler {
         Ok(())
     }
 
-    async fn handle_on_typed(
-        &mut self,
-        msg: MethodCall,
-        _context: Arc<SessionContext>,
-    ) -> Result<()> {
+    async fn on_typed(&mut self, msg: MethodCall, _context: Arc<SessionContext>) -> Result<()> {
         let (msg_id, params) = parse_msg(msg);
 
         let search_info = parse_search_info(&params.query);

--- a/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
@@ -83,6 +83,13 @@ pub struct FilerMessageHandler;
 
 #[async_trait::async_trait]
 impl EventHandler for FilerMessageHandler {
+    async fn on_create(&mut self, call: Call, context: Arc<SessionContext>) {
+        write_response(
+            handle_filer_message(call.unwrap_method_call())
+                .expect("Both Success and Error are returned"),
+        );
+    }
+
     async fn handle_on_move(
         &mut self,
         msg: MethodCall,

--- a/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
@@ -12,7 +12,7 @@ use icon::prepend_filer_icon;
 use crate::stdio_server::providers::builtin::{OnMove, OnMoveHandler};
 use crate::stdio_server::{
     rpc::Call,
-    session::{Session, SessionContext, SessionEvent, SessionEventHandle},
+    session::{Session, SessionContext, SessionEvent, EventHandle},
     write_response, MethodCall,
 };
 use crate::utils::build_abs_path;
@@ -79,10 +79,10 @@ pub fn read_dir_entries<P: AsRef<Path>>(
 }
 
 #[derive(Clone)]
-pub struct FilerMessageHandler;
+pub struct FilerHandle;
 
 #[async_trait::async_trait]
-impl SessionEventHandle for FilerMessageHandler {
+impl EventHandle for FilerHandle {
     async fn on_create(&mut self, call: Call, context: Arc<SessionContext>) {
         write_response(
             handle_filer_message(call.unwrap_method_call())

--- a/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
@@ -12,7 +12,7 @@ use icon::prepend_filer_icon;
 use crate::stdio_server::providers::builtin::{OnMove, OnMoveHandler};
 use crate::stdio_server::{
     rpc::Call,
-    session::{EventHandler, NewSession, Session, SessionContext, SessionEvent},
+    session::{SessionEventHandle, NewSession, Session, SessionContext, SessionEvent},
     write_response, MethodCall,
 };
 use crate::utils::build_abs_path;
@@ -82,7 +82,7 @@ pub fn read_dir_entries<P: AsRef<Path>>(
 pub struct FilerMessageHandler;
 
 #[async_trait::async_trait]
-impl EventHandler for FilerMessageHandler {
+impl SessionEventHandle for FilerMessageHandler {
     async fn on_create(&mut self, call: Call, context: Arc<SessionContext>) {
         write_response(
             handle_filer_message(call.unwrap_method_call())
@@ -90,11 +90,7 @@ impl EventHandler for FilerMessageHandler {
         );
     }
 
-    async fn handle_on_move(
-        &mut self,
-        msg: MethodCall,
-        context: Arc<SessionContext>,
-    ) -> Result<()> {
+    async fn on_move(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {
         #[derive(serde::Deserialize)]
         struct Params {
             // curline: String,
@@ -124,11 +120,7 @@ impl EventHandler for FilerMessageHandler {
         Ok(())
     }
 
-    async fn handle_on_typed(
-        &mut self,
-        msg: MethodCall,
-        _context: Arc<SessionContext>,
-    ) -> Result<()> {
+    async fn on_typed(&mut self, msg: MethodCall, _context: Arc<SessionContext>) -> Result<()> {
         handle_filer_message(msg);
         Ok(())
     }

--- a/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/filer.rs
@@ -12,7 +12,7 @@ use icon::prepend_filer_icon;
 use crate::stdio_server::providers::builtin::{OnMove, OnMoveHandler};
 use crate::stdio_server::{
     rpc::Call,
-    session::{SessionEventHandle, NewSession, Session, SessionContext, SessionEvent},
+    session::{Session, SessionContext, SessionEvent, SessionEventHandle},
     write_response, MethodCall,
 };
 use crate::utils::build_abs_path;
@@ -123,20 +123,6 @@ impl SessionEventHandle for FilerMessageHandler {
     async fn on_typed(&mut self, msg: MethodCall, _context: Arc<SessionContext>) -> Result<()> {
         handle_filer_message(msg);
         Ok(())
-    }
-}
-
-pub struct FilerSession;
-
-impl NewSession for FilerSession {
-    fn spawn(call: Call) -> Result<Sender<SessionEvent>> {
-        let (session, session_sender) = Session::new(call.clone(), FilerMessageHandler);
-        session.start_event_loop();
-
-        // Handle the on_init message.
-        handle_filer_message(call.unwrap_method_call());
-
-        Ok(session_sender)
     }
 }
 

--- a/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
@@ -12,7 +12,7 @@ use crate::datastore::RECENT_FILES_IN_MEMORY;
 use crate::stdio_server::{
     providers::builtin::OnMoveHandler,
     rpc::Call,
-    session::{Session, SessionContext, SessionEvent, SessionEventHandle},
+    session::{Session, SessionContext, SessionEvent, EventHandle},
     write_response, MethodCall,
 };
 
@@ -128,12 +128,12 @@ async fn handle_recent_files_message(
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct RecentFilesMessageHandler {
+pub struct RecentFilesHandle {
     lines: Arc<Mutex<Vec<FilteredItem>>>,
 }
 
 #[async_trait::async_trait]
-impl SessionEventHandle for RecentFilesMessageHandler {
+impl EventHandle for RecentFilesHandle {
     async fn on_create(&mut self, call: Call, context: Arc<SessionContext>) {
         let lines_clone = self.lines.clone();
 

--- a/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
@@ -12,7 +12,7 @@ use crate::datastore::RECENT_FILES_IN_MEMORY;
 use crate::stdio_server::{
     providers::builtin::OnMoveHandler,
     rpc::Call,
-    session::{Session, SessionContext, SessionEvent, EventHandle},
+    session::{EventHandle, Session, SessionContext, SessionEvent},
     write_response, MethodCall,
 };
 

--- a/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
@@ -135,17 +135,11 @@ pub struct RecentFilesHandle {
 #[async_trait::async_trait]
 impl EventHandle for RecentFilesHandle {
     async fn on_create(&mut self, call: Call, context: Arc<SessionContext>) {
-        let lines_clone = self.lines.clone();
+        let initial_lines =
+            handle_recent_files_message(call.unwrap_method_call(), context, true).await;
 
-        // await is required.
-        tokio::spawn(async move {
-            let initial_lines =
-                handle_recent_files_message(call.unwrap_method_call(), context, true).await;
-
-            let mut lines = lines_clone.lock();
-            *lines = initial_lines;
-        })
-        .await;
+        let mut lines = self.lines.lock();
+        *lines = initial_lines;
     }
 
     async fn on_move(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {

--- a/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/recent_files.rs
@@ -12,7 +12,7 @@ use crate::datastore::RECENT_FILES_IN_MEMORY;
 use crate::stdio_server::{
     providers::builtin::OnMoveHandler,
     rpc::Call,
-    session::{EventHandler, NewSession, Session, SessionContext, SessionEvent},
+    session::{SessionEventHandle, NewSession, Session, SessionContext, SessionEvent},
     write_response, MethodCall,
 };
 
@@ -136,12 +136,8 @@ pub struct RecentFilesMessageHandler {
 }
 
 #[async_trait::async_trait]
-impl EventHandler for RecentFilesMessageHandler {
-    async fn handle_on_move(
-        &mut self,
-        msg: MethodCall,
-        context: Arc<SessionContext>,
-    ) -> Result<()> {
+impl SessionEventHandle for RecentFilesMessageHandler {
+    async fn on_move(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {
         let msg_id = msg.id;
 
         let lnum = msg.get_u64("lnum").expect("lnum is required");
@@ -162,11 +158,7 @@ impl EventHandler for RecentFilesMessageHandler {
         Ok(())
     }
 
-    async fn handle_on_typed(
-        &mut self,
-        msg: MethodCall,
-        context: Arc<SessionContext>,
-    ) -> Result<()> {
+    async fn on_typed(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {
         let new_lines = tokio::spawn(handle_recent_files_message(msg, context, false))
             .await
             .unwrap_or_else(|e| {

--- a/crates/maple_cli/src/stdio_server/providers/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/mod.rs
@@ -1,5 +1,5 @@
 pub mod builtin;
 pub mod custom;
 
-pub use self::builtin::{BuiltinSessionEventHandle, OnMove, OnMoveHandler};
+pub use self::builtin::{BuiltinHandle, OnMove, OnMoveHandler};
 pub use self::custom::{dumb_jump, filer, quickfix, recent_files};

--- a/crates/maple_cli/src/stdio_server/providers/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/mod.rs
@@ -1,5 +1,5 @@
 pub mod builtin;
 pub mod custom;
 
-pub use self::builtin::{BuiltinSessionEventHandle, BuiltinSession, OnMove, OnMoveHandler};
+pub use self::builtin::{BuiltinSessionEventHandle, OnMove, OnMoveHandler};
 pub use self::custom::{dumb_jump, filer, quickfix, recent_files};

--- a/crates/maple_cli/src/stdio_server/providers/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/mod.rs
@@ -1,5 +1,5 @@
 pub mod builtin;
 pub mod custom;
 
-pub use self::builtin::{BuiltinEventHandler, BuiltinSession, OnMove, OnMoveHandler};
+pub use self::builtin::{BuiltinSessionEventHandle, BuiltinSession, OnMove, OnMoveHandler};
 pub use self::custom::{dumb_jump, filer, quickfix, recent_files};

--- a/crates/maple_cli/src/stdio_server/rpc/messages/method_call.rs
+++ b/crates/maple_cli/src/stdio_server/rpc/messages/method_call.rs
@@ -96,8 +96,6 @@ impl MethodCall {
 
 impl MethodCall {
     pub async fn handle(self) -> anyhow::Result<Value> {
-        use crate::stdio_server::providers::dumb_jump::DumbJumpSession;
-        use crate::stdio_server::providers::recent_files::RecentFilesSession;
         use crate::stdio_server::session::SessionEvent::*;
 
         if self.method != "init_ext_map" {

--- a/crates/maple_cli/src/stdio_server/session/manager.rs
+++ b/crates/maple_cli/src/stdio_server/session/manager.rs
@@ -9,7 +9,7 @@ use crate::stdio_server::{
     MethodCall, SessionEvent,
 };
 
-use super::SessionEventHandle;
+use super::EventHandle;
 
 /// A small wrapper of Sender<SessionEvent> for logging on sending error.
 #[derive(Debug)]
@@ -46,7 +46,7 @@ pub struct SessionManager {
 
 impl SessionManager {
     /// Starts a session in a background task.
-    pub fn new_session(&mut self, call: Call, session_event_handle: impl SessionEventHandle) {
+    pub fn new_session(&mut self, call: Call, session_event_handle: impl EventHandle) {
         let session_id = call.session_id();
         if self.exists(session_id) {
             tracing::error!(session_id, "Skipped as given session already exists");

--- a/crates/maple_cli/src/stdio_server/session/manager.rs
+++ b/crates/maple_cli/src/stdio_server/session/manager.rs
@@ -3,7 +3,13 @@ use std::collections::HashMap;
 use anyhow::Result;
 use crossbeam_channel::Sender;
 
-use crate::stdio_server::{rpc::Call, session::SessionId, MethodCall, SessionEvent};
+use crate::stdio_server::{
+    rpc::Call,
+    session::{Session, SessionId},
+    MethodCall, SessionEvent,
+};
+
+use super::SessionEventHandle;
 
 /// A small wrapper of Sender<SessionEvent> for logging on sending error.
 #[derive(Debug)]
@@ -32,12 +38,6 @@ impl SessionEventSender {
     }
 }
 
-/// Creates a new session with a context built from the message `msg`.
-pub trait NewSession {
-    /// Spawns a new session thread given `msg`.
-    fn spawn(call: Call) -> Result<Sender<SessionEvent>>;
-}
-
 /// This structs manages all the created sessions tracked by the session id.
 #[derive(Debug, Default)]
 pub struct SessionManager {
@@ -46,23 +46,22 @@ pub struct SessionManager {
 
 impl SessionManager {
     /// Starts a session in a background task.
-    pub fn new_session<T: NewSession>(&mut self, call: Call) {
+    pub fn new_session(&mut self, call: Call, session_event_handle: impl SessionEventHandle) {
         let session_id = call.session_id();
         if self.exists(session_id) {
             tracing::error!(session_id, "Skipped as given session already exists");
         } else {
-            match T::spawn(call.clone()) {
-                Ok(sender) => {
-                    sender
-                        .send(SessionEvent::Create(call))
-                        .expect("Failed to send Create Event");
-                    self.sessions
-                        .insert(session_id, SessionEventSender::new(sender, session_id));
-                }
-                Err(error) => {
-                    tracing::error!(?error, "Failed not spawn a new session");
-                }
-            }
+            let (session, session_sender) = Session::new(call.clone(), session_event_handle);
+            session.start_event_loop();
+
+            session_sender
+                .send(SessionEvent::Create(call))
+                .expect("Failed to send Create Event");
+
+            self.sessions.insert(
+                session_id,
+                SessionEventSender::new(session_sender, session_id),
+            );
         }
     }
 

--- a/crates/maple_cli/src/stdio_server/session/manager.rs
+++ b/crates/maple_cli/src/stdio_server/session/manager.rs
@@ -51,10 +51,10 @@ impl SessionManager {
         if self.exists(session_id) {
             tracing::error!(session_id, "Skipped as given session already exists");
         } else {
-            match T::spawn(call) {
+            match T::spawn(call.clone()) {
                 Ok(sender) => {
                     sender
-                        .send(SessionEvent::Create)
+                        .send(SessionEvent::Create(call))
                         .expect("Failed to send Create Event");
                     self.sessions
                         .insert(session_id, SessionEventSender::new(sender, session_id));

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -15,7 +15,7 @@ use crate::stdio_server::providers::builtin::on_session_create;
 use crate::stdio_server::{rpc::Call, types::ProviderId, MethodCall};
 
 pub use self::context::{Scale, SessionContext, SyncFilterResults};
-pub use self::manager::{NewSession, SessionManager};
+pub use self::manager::SessionManager;
 
 static BACKGROUND_JOBS: Lazy<Arc<Mutex<HashSet<u64>>>> =
     Lazy::new(|| Arc::new(Mutex::new(HashSet::default())));

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -38,7 +38,7 @@ fn process_source_scale(scale: Scale, context: Arc<SessionContext>) {
 }
 
 #[async_trait::async_trait]
-pub trait SessionEventHandle: Send + Sync + 'static {
+pub trait EventHandle: Send + Sync + 'static {
     async fn on_create(&mut self, _call: Call, context: Arc<SessionContext>) {
         const TIMEOUT: Duration = Duration::from_millis(300);
 
@@ -114,7 +114,7 @@ impl SessionEvent {
     }
 }
 
-impl<T: SessionEventHandle> Session<T> {
+impl<T: EventHandle> Session<T> {
     pub fn new(call: Call, event_handler: T) -> (Self, Sender<SessionEvent>) {
         let (session_sender, session_receiver) = crossbeam_channel::unbounded();
 

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -4,6 +4,7 @@ mod manager;
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use crossbeam_channel::Sender;
@@ -21,10 +22,66 @@ static BACKGROUND_JOBS: Lazy<Arc<Mutex<HashSet<u64>>>> =
 
 pub type SessionId = u64;
 
+fn process_source_scale(scale: Scale, context: Arc<SessionContext>) {
+    if let Some(total) = scale.total() {
+        let method = "s:set_total_size";
+        utility::println_json_with_length!(total, method);
+    }
+
+    if let Some(lines) = scale.initial_lines(100) {
+        printer::decorate_lines::<i64>(lines, context.display_winwidth as usize, context.icon)
+            .print_on_session_create();
+    }
+
+    let mut val = context.scale.lock();
+    *val = scale;
+}
+
 #[async_trait::async_trait]
 pub trait EventHandler: Send + Sync + 'static {
+    async fn on_create(&mut self, _call: Call, context: Arc<SessionContext>) {
+        const TIMEOUT: Duration = Duration::from_millis(300);
+
+        match tokio::time::timeout(TIMEOUT, on_session_create(context.clone())).await {
+            Ok(scale_result) => match scale_result {
+                Ok(scale) => process_source_scale(scale, context),
+                Err(e) => tracing::error!(?e, "Error occurred on creating session"),
+            },
+            Err(_) => {
+                tracing::debug!(timeout = ?TIMEOUT, "Did not receive value in time");
+                match context.provider_id.as_str() {
+                    "grep" | "grep2" => {
+                        let rg_cmd =
+                            crate::command::grep::RgBaseCommand::new(context.cwd.to_path_buf());
+                        let job_id = utility::calculate_hash(&rg_cmd.inner);
+                        let mut background_jobs = BACKGROUND_JOBS.lock();
+                        if background_jobs.contains(&job_id) {
+                            tracing::debug!(job_id, "An existing job for grep/grep2");
+                        } else {
+                            tracing::debug!(job_id, "Spawning a background job for grep/grep2");
+                            background_jobs.insert(job_id);
+
+                            tokio::spawn(async move {
+                                let res = rg_cmd.create_cache().await;
+                                let mut background_jobs = BACKGROUND_JOBS.lock();
+                                background_jobs.remove(&job_id);
+                                tracing::debug!(
+                                  job_id,
+                                  result = ?res,
+                                  "The background job is done",
+                                );
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     async fn handle_on_move(&mut self, msg: MethodCall, context: Arc<SessionContext>)
         -> Result<()>;
+
     async fn handle_on_typed(
         &mut self,
         msg: MethodCall,
@@ -46,7 +103,7 @@ pub struct Session<T> {
 pub enum SessionEvent {
     OnTyped(MethodCall),
     OnMove(MethodCall),
-    Create,
+    Create(Call),
     Terminate,
 }
 
@@ -56,7 +113,7 @@ impl SessionEvent {
         match self {
             Self::OnTyped(msg) => format!("OnTyped, msg_id: {}", msg.id).into(),
             Self::OnMove(msg) => format!("OnMove, msg_id: {}", msg.id).into(),
-            Self::Create => "Create".into(),
+            Self::Create(_) => "Create".into(),
             Self::Terminate => "Terminate".into(),
         }
     }
@@ -92,77 +149,14 @@ impl<T: EventHandler> Session<T> {
         &self.context.provider_id
     }
 
-    fn process_source_scale(&self, scale: Scale) {
-        if let Some(total) = scale.total() {
-            let method = "s:set_total_size";
-            utility::println_json_with_length!(total, method);
-        }
-
-        if let Some(lines) = scale.initial_lines(100) {
-            printer::decorate_lines::<i64>(
-                lines,
-                self.context.display_winwidth as usize,
-                self.context.icon,
-            )
-            .print_on_session_create();
-        }
-
-        let mut val = self.context.scale.lock();
-        *val = scale;
-    }
-
-    async fn handle_create(&mut self) {
-        let context_clone = self.context.clone();
-
-        const TIMEOUT: u64 = 300;
-
-        match tokio::time::timeout(
-            std::time::Duration::from_millis(TIMEOUT),
-            on_session_create(context_clone),
-        )
-        .await
-        {
-            Ok(scale_result) => match scale_result {
-                Ok(scale) => self.process_source_scale(scale),
-                Err(e) => tracing::error!(?e, "Error occurred on creating session"),
-            },
-            Err(_) => {
-                tracing::debug!(timeout = TIMEOUT, "Did not receive value in time");
-                match self.context.provider_id.as_str() {
-                    "grep" | "grep2" => {
-                        let rg_cmd = crate::command::grep::RgBaseCommand::new(
-                            self.context.cwd.to_path_buf(),
-                        );
-                        let job_id = utility::calculate_hash(&rg_cmd.inner);
-                        let mut background_jobs = BACKGROUND_JOBS.lock();
-                        if background_jobs.contains(&job_id) {
-                            tracing::debug!(job_id, "An existing job for grep/grep2");
-                        } else {
-                            tracing::debug!(job_id, "Spawning a background job for grep/grep2");
-                            background_jobs.insert(job_id);
-
-                            tokio::spawn(async move {
-                                let res = rg_cmd.create_cache().await;
-                                let mut background_jobs = BACKGROUND_JOBS.lock();
-                                background_jobs.remove(&job_id);
-                                tracing::debug!(
-                                  job_id,
-                                  result = ?res,
-                                  "The background job is done",
-                                );
-                            });
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-    }
-
     async fn process_event(&mut self, event: SessionEvent) -> Result<()> {
         match event {
             SessionEvent::Terminate => self.handle_terminate(),
-            SessionEvent::Create => self.handle_create().await,
+            SessionEvent::Create(call) => {
+                self.event_handler
+                    .on_create(call, self.context.clone())
+                    .await
+            }
             SessionEvent::OnMove(msg) => {
                 self.event_handler
                     .handle_on_move(msg, self.context.clone())

--- a/crates/maple_cli/src/stdio_server/session_client.rs
+++ b/crates/maple_cli/src/stdio_server/session_client.rs
@@ -60,8 +60,6 @@ impl SessionClient {
 
     /// Process the method call message from Vim.
     async fn process_method_call(&self, method_call: MethodCall) -> Result<Option<Value>> {
-        use super::dumb_jump::DumbJumpSession;
-        use super::recent_files::RecentFilesSession;
         use super::SessionEvent::*;
 
         let msg = method_call;

--- a/crates/maple_cli/src/utils.rs
+++ b/crates/maple_cli/src/utils.rs
@@ -69,6 +69,17 @@ impl ExactOrInverseTerms {
             None
         }
     }
+
+    pub fn check_usage_line(&self, line: &str, mut indices: Vec<usize>) -> Option<Vec<usize>> {
+        if let Some(exact_indices) = self.check_terms(line) {
+            indices.extend_from_slice(&exact_indices);
+            indices.sort_unstable();
+            indices.dedup();
+            Some(indices)
+        } else {
+            None
+        }
+    }
 }
 
 pub type UtcTime = DateTime<Utc>;

--- a/crates/maple_cli/src/utils.rs
+++ b/crates/maple_cli/src/utils.rs
@@ -184,7 +184,7 @@ pub(crate) fn expand_tilde(path: impl AsRef<str>) -> Result<PathBuf> {
 }
 
 /// Build the absolute path using cwd and relative path.
-pub fn build_abs_path<P: AsRef<Path>>(cwd: P, curline: impl AsRef<Path>) -> PathBuf {
+pub fn build_abs_path(cwd: impl AsRef<Path>, curline: impl AsRef<Path>) -> PathBuf {
     let mut path: PathBuf = cwd.as_ref().into();
     path.push(curline);
     path

--- a/crates/maple_cli/src/utils.rs
+++ b/crates/maple_cli/src/utils.rs
@@ -69,17 +69,6 @@ impl ExactOrInverseTerms {
             None
         }
     }
-
-    pub fn check_usage_line(&self, line: &str, mut indices: Vec<usize>) -> Option<Vec<usize>> {
-        if let Some(exact_indices) = self.check_terms(line) {
-            indices.extend_from_slice(&exact_indices);
-            indices.sort_unstable();
-            indices.dedup();
-            Some(indices)
-        } else {
-            None
-        }
-    }
 }
 
 pub type UtcTime = DateTime<Utc>;

--- a/crates/maple_cli/src/utils.rs
+++ b/crates/maple_cli/src/utils.rs
@@ -43,6 +43,20 @@ impl ExactOrInverseTerms {
         }
     }
 
+    pub fn contains(&self, other: &Self) -> bool {
+        for (local, other) in self.exact_terms.iter().zip(other.exact_terms.iter()) {
+            if !local.contains(other) {
+                return false;
+            }
+        }
+        for (local, other) in self.inverse_terms.iter().zip(other.inverse_terms.iter()) {
+            if !local.contains(other) {
+                return false;
+            }
+        }
+        true
+    }
+
     pub fn check_jump_line(
         &self,
         (jump_line, mut indices): (String, Vec<usize>),

--- a/crates/maple_cli/src/utils.rs
+++ b/crates/maple_cli/src/utils.rs
@@ -43,18 +43,17 @@ impl ExactOrInverseTerms {
         }
     }
 
+    /// The results of applying `other` is a subset of applying `self` on the same source.
     pub fn contains(&self, other: &Self) -> bool {
-        for (local, other) in self.exact_terms.iter().zip(other.exact_terms.iter()) {
-            if !local.contains(other) {
-                return false;
-            }
-        }
-        for (local, other) in self.inverse_terms.iter().zip(other.inverse_terms.iter()) {
-            if !local.contains(other) {
-                return false;
-            }
-        }
-        true
+        self.exact_terms
+            .iter()
+            .zip(other.exact_terms.iter())
+            .all(|(local, other)| local.contains(other))
+            && self
+                .inverse_terms
+                .iter()
+                .zip(other.inverse_terms.iter())
+                .all(|(local, other)| local.contains(other))
     }
 
     pub fn check_jump_line(

--- a/crates/types/src/search_term.rs
+++ b/crates/types/src/search_term.rs
@@ -24,6 +24,19 @@ impl ExactTerm {
     pub fn new(ty: ExactTermType, word: String) -> Self {
         Self { ty, word }
     }
+
+    /// The results of applying `other` is a subset of applying `self` on the same source.
+    pub fn contains(&self, other: &Self) -> bool {
+        use ExactTermType::*;
+
+        match (&self.ty, &other.ty) {
+            (Exact, Exact) | (PrefixExact, PrefixExact) | (SuffixExact, SuffixExact) => {
+                other.word.starts_with(&self.word)
+            }
+            (Exact, PrefixExact) | (Exact, SuffixExact) => true,
+            _ => false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]
@@ -51,6 +64,19 @@ pub struct InverseTerm {
 impl InverseTerm {
     pub fn new(ty: InverseTermType, word: String) -> Self {
         Self { ty, word }
+    }
+
+    /// The results of applying `other` is a subset of applying `self` on the same source.
+    pub fn contains(&self, other: &Self) -> bool {
+        use InverseTermType::*;
+
+        match (&self.ty, &other.ty) {
+            (InverseExact, InverseExact)
+            | (InversePrefixExact, InversePrefixExact)
+            | (InverseSuffixExact, InverseSuffixExact) => self.word.starts_with(&other.word),
+            (InversePrefixExact, InverseExact) | (InverseSuffixExact, InverseExact) => true,
+            _ => false,
+        }
     }
 
     /// Returns true if the full line of given `item` matches the inverse term.

--- a/crates/types/src/search_term.rs
+++ b/crates/types/src/search_term.rs
@@ -31,6 +31,7 @@ impl ExactTerm {
 
         match (&self.ty, &other.ty) {
             (Exact, Exact) | (PrefixExact, PrefixExact) | (SuffixExact, SuffixExact) => {
+                // Comparing with `'hello`, `'he` has more results.
                 other.word.starts_with(&self.word)
             }
             (Exact, PrefixExact) | (Exact, SuffixExact) => true,
@@ -69,6 +70,9 @@ impl InverseTerm {
     /// The results of applying `other` is a subset of applying `self` on the same source.
     pub fn contains(&self, other: &Self) -> bool {
         use InverseTermType::*;
+
+        // Comparing with `!hello`, `!he` has less results.
+        // In order to have a superset results, `self.word` needs to be longer.
 
         match (&self.ty, &other.ty) {
             (InverseExact, InverseExact)

--- a/syntax/clap_grep.vim
+++ b/syntax/clap_grep.vim
@@ -9,7 +9,7 @@ syntax match ClapLinNrColumn /\zs:\d\+:\d\+:\ze/ contains=ClapLinNr,ClapColumn c
 syntax match ClapIconUnknown /^\s*/
 
 execute 'syntax match ClapFpath' '/^.*:\d\+:\d\+:/' 'contains=ClapLinNrColumn,'.join(clap#icon#add_head_hl_groups(), ',')
-execute 'syntax match ClapFpathTruncated' '/^.*\.\./' 'contains='.join(clap#icon#add_head_hl_groups(), ',').',ClapFpathDots'
+execute 'syntax match ClapFpathTruncated' '/^.*\.\..*:\d\+:\d\+:/' 'contains=ClapLinNrColumn,'.join(clap#icon#add_head_hl_groups(), ',').',ClapFpathDots'
 syntax match ClapFpathDots '\.\.' contained
 
 hi default link ClapFpath            Keyword


### PR DESCRIPTION
Sometimes when we type an initial query and get a bunch of results, we
actually don't want them all and want to exclude some of them, then we continue
typing the inverse search term like `!test`, in which case the results from last query
can be reused and refiltered on, making the dumb_jump provider generally faster.