### PR TITLE
Introduce debounce on Rust event_loop handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - `hel`: match the tags that starts with `hel`.
   - `hel*`: match the tags that contain `hel`.
 
+- Introduce debounce for user typed event. #793
+
 ## Fixed
 
 - Fix the regression that `filer` provider is not properly initialized on the Rust backend. #790

--- a/autoload/clap/provider/dumb_jump.vim
+++ b/autoload/clap/provider/dumb_jump.vim
@@ -32,7 +32,7 @@ function! s:dumb_jump.on_typed() abort
     call clap#highlight#clear()
     return
   endif
-  call clap#client#call_with_delay('dumb_jump/on_typed', function('clap#state#handle_response_on_typed'), {
+  call clap#client#call('dumb_jump/on_typed', function('clap#state#handle_response_on_typed'), {
         \ 'provider_id': g:clap.provider.id,
         \ 'query': query,
         \ 'extension': fnamemodify(bufname(g:clap.start.bufnr), ':e'),

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -185,24 +185,70 @@ impl<T: EventHandle> Session<T> {
     }
 
     pub fn start_event_loop(mut self) {
+        use crossbeam_channel::select;
+
+        // https://github.com/denoland/deno/blob/1fb5858009f598ce3f917f9f49c466db81f4d9b0/cli/lsp/diagnostics.rs#L141
+        //
+        // Debounce timer delay. 150ms between keystrokes is about 45 WPM, so we
+        // want something that is longer than that, but not too long to
+        // introduce detectable UI delay; 200ms is a decent compromise.
+        //
+        // Add extra 50ms delay.
+        const DELAY: Duration = Duration::from_millis(200 + 50);
+        // If the debounce timer isn't active, it will be set to expire "never",
+        // which is actually just 1 year in the future.
+        const NEVER: Duration = Duration::from_secs(365 * 24 * 60 * 60);
+
         tokio::spawn(async move {
             tracing::debug!(
                 session_id = self.session_id,
                 provider_id = %self.provider_id(),
                 "Spawning a new session task",
             );
+
+            let mut pending_on_typed = None;
+            let mut debounce_timer = NEVER;
+
             loop {
-                match self.event_recv.recv() {
-                    Ok(event) => {
-                        tracing::debug!(event = ?event.short_display(), "Received an event");
-                        if let Err(err) = self.process_event(event).await {
-                            tracing::debug!(?err, "Error processing SessionEvent");
-                        }
-                    }
-                    Err(err) => {
-                        tracing::debug!(?err, "The channel is possibly broken");
-                        break;
-                    }
+                select! {
+                  recv(self.event_recv) -> maybe_event => {
+                      match maybe_event {
+                          Ok(event) => {
+                              tracing::debug!(event = ?event.short_display(), "Received an event");
+                              match event {
+                                  SessionEvent::Terminate => self.handle_terminate(),
+                                  SessionEvent::Create(call) => {
+                                      self.event_handler
+                                          .on_create(call, self.context.clone())
+                                          .await
+                                  }
+                                  SessionEvent::OnMove(msg) => {
+                                      if let Err(err) =
+                                          self.event_handler.on_move(msg, self.context.clone()).await
+                                      {
+                                          tracing::error!(?err, "Error processing SessionEvent::OnMove");
+                                      }
+                                  }
+                                  SessionEvent::OnTyped(msg) => {
+                                      pending_on_typed.replace(msg);
+                                      debounce_timer = DELAY;
+                                  }
+                              }
+                          }
+                          Err(err) => {
+                              tracing::debug!(?err, "The channel is possibly broken");
+                              return;
+                          }
+                      }
+                  }
+                  default(debounce_timer) => {
+                      debounce_timer = NEVER;
+                      if let Some(msg) = pending_on_typed.take() {
+                          if let Err(err) = self.event_handler.on_typed(msg, self.context.clone()).await {
+                              tracing::error!(?err, "Error processing SessionEvent::OnTyped");
+                          }
+                      }
+                  }
                 }
             }
         });


### PR DESCRIPTION
In case user types too fast.