### PR TITLE
Remove the vista dep from `tags` provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [unreleased]
 
+## Added
+
+- Support generating the source of `tags` provider using the Rust binary, remove the vista.vim dep from `tags` provider. #795
 
 ## [0.32] 2022-01-21
+
 ## Improved
 
 - Rework the truncation of long lines. #788

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Note the `*` in the spinner, it tells you are using the cache, use `g:clap_forer
 | `Clap quickfix`                        | Entries of the quickfix list                           | _none_                                                                                 |
 | `Clap loclist`                         | Entries of the location list                           | _none_                                                                                 |
 | `Clap registers`                       | Registers                                              | _none_                                                                                 |
-| `Clap tags`                            | Tags in the current buffer                             | **[vista.vim][vista.vim]**                                                             |
+| `Clap tags`                            | Tags in the current buffer                             | **maple[maple]**/**[vista.vim][vista.vim]**                                            |
 | `Clap proj_tags`                       | Tags in the current project                            | **[maple][maple]** and **[universal-ctags][universal-ctags]** with JSON output support |
 | `Clap yanks`                           | Yank stack of the current vim session                  | _none_                                                                                 |
 | `Clap filer`                           | Ivy-like file explorer                                 | **[maple][maple]**                                                                     |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Note the `*` in the spinner, it tells you are using the cache, use `g:clap_forer
 | `Clap quickfix`                        | Entries of the quickfix list                           | _none_                                                                                 |
 | `Clap loclist`                         | Entries of the location list                           | _none_                                                                                 |
 | `Clap registers`                       | Registers                                              | _none_                                                                                 |
-| `Clap tags`                            | Tags in the current buffer                             | **maple[maple]**/**[vista.vim][vista.vim]**                                            |
+| `Clap tags`                            | Tags in the current buffer                             | **[maple][maple]**/**[vista.vim][vista.vim]**                                          |
 | `Clap proj_tags`                       | Tags in the current project                            | **[maple][maple]** and **[universal-ctags][universal-ctags]** with JSON output support |
 | `Clap yanks`                           | Yank stack of the current vim session                  | _none_                                                                                 |
 | `Clap filer`                           | Ivy-like file explorer                                 | **[maple][maple]**                                                                     |

--- a/autoload/clap/api.vim
+++ b/autoload/clap/api.vim
@@ -626,6 +626,9 @@ function! s:init_provider() abort
           endif
         endif
       endif
+      if self.id ==# 'tags'
+        let extra['debounce'] = v:false
+      endif
       call clap#client#notify_on_init('on_init', extra)
     endif
     " Try to fill the preview window.

--- a/autoload/clap/provider/tags.vim
+++ b/autoload/clap/provider/tags.vim
@@ -6,41 +6,65 @@ set cpoptions&vim
 
 let s:tags = {}
 
-function! s:tags.source(...) abort
-  let [bufnr, winnr, fname, fpath] = [
-        \ g:clap.start.bufnr,
-        \ win_id2win(g:clap.start.winid),
-        \ bufname(g:clap.start.bufnr),
-        \ expand('#'.g:clap.start.bufnr.':p')
-        \ ]
+if get(g:, 'clap_provider_tags_force_vista', v:false)
+  function! s:tags.source(...) abort
+    let [bufnr, winnr, fname, fpath] = [
+          \ g:clap.start.bufnr,
+          \ win_id2win(g:clap.start.winid),
+          \ bufname(g:clap.start.bufnr),
+          \ expand('#'.g:clap.start.bufnr.':p')
+          \ ]
 
-  try
-    call vista#source#Update(bufnr, winnr, fname, fpath)
-  catch
-    return [v:exception, 'Ensure you have installed https://github.com/liuchengxu/vista.vim']
-  endtry
+    try
+      call vista#source#Update(bufnr, winnr, fname, fpath)
+    catch
+      return [v:exception, 'Ensure you have installed https://github.com/liuchengxu/vista.vim']
+    endtry
 
-  if len(g:clap.provider.args) == 1 && index(g:vista#executives, g:clap.provider.args[0]) > -1
-    let executive = g:clap.provider.args
-  else
-    let executive = []
-  endif
+    if len(g:clap.provider.args) == 1 && index(g:vista#executives, g:clap.provider.args[0]) > -1
+      let executive = g:clap.provider.args
+    else
+      let executive = []
+    endif
 
-  let [data, cur_executive, using_alternative] = call('vista#finder#GetSymbols', executive)
+    let [data, cur_executive, using_alternative] = call('vista#finder#GetSymbols', executive)
 
-  if empty(data)
-    return ['No symbols found via vista.vim']
-  endif
+    if empty(data)
+      return ['No symbols found via vista.vim']
+    endif
 
-  if using_alternative
-    let self.prompt_format = ' %spinner%%forerunner_status%*'.cur_executive.':'
-  else
-    let self.prompt_format = ' %spinner%%forerunner_status%'.cur_executive.':'
-  endif
-  call clap#spinner#refresh()
+    if using_alternative
+      let self.prompt_format = ' %spinner%%forerunner_status%*'.cur_executive.':'
+    else
+      let self.prompt_format = ' %spinner%%forerunner_status%'.cur_executive.':'
+    endif
+    call clap#spinner#refresh()
 
-  return vista#finder#PrepareSource(data)
-endfunction
+    return vista#finder#PrepareSource(data)
+  endfunction
+
+  function! s:tags.on_enter() abort
+    let s:origin_syntax = getbufvar(g:clap.start.bufnr, '&syntax')
+    call g:clap.display.setbufvar('&syntax', 'clap_tags')
+    let g:__clap_match_type_enum = 'TagName'
+  endfunction
+
+  function! s:tags.on_exit() abort
+    if exists('g:__clap_match_type_enum')
+      unlet g:__clap_match_type_enum
+    endif
+  endfunction
+
+  let s:tags.on_move_async = function('clap#impl#on_move#async')
+else
+  function! s:tags.on_typed() abort
+    call clap#client#call('on_typed', v:null, {'query': g:clap.input.get()})
+  endfunction
+
+  function! s:tags.on_move_async() abort
+    call clap#client#call_with_lnum('on_move', function('clap#impl#on_move#handler'))
+  endfunction
+endif
 
 function! s:tags.on_move() abort
   try
@@ -51,24 +75,11 @@ function! s:tags.on_move() abort
   call clap#preview#buffer(lnum, s:origin_syntax)
 endfunction
 
-function! s:tags.on_enter() abort
-  let s:origin_syntax = getbufvar(g:clap.start.bufnr, '&syntax')
-  call g:clap.display.setbufvar('&syntax', 'clap_tags')
-  let g:__clap_match_type_enum = 'TagName'
-endfunction
-
-function! s:tags.on_exit() abort
-  if exists('g:__clap_match_type_enum')
-    unlet g:__clap_match_type_enum
-  endif
-endfunction
-
 function! s:tags.sink(selected) abort
   call vista#finder#fzf#sink(a:selected, g:clap.start.winid)
 endfunction
 
-let s:tags.on_move_async = function('clap#impl#on_move#async')
-
+let s:tags.syntax = 'clap_tags'
 let g:clap#provider#tags# = s:tags
 
 let &cpoptions = s:save_cpo

--- a/crates/icon/src/lib.rs
+++ b/crates/icon/src/lib.rs
@@ -149,6 +149,12 @@ pub fn filer_icon<P: AsRef<Path>>(path: P) -> IconType {
     }
 }
 
+pub fn tags_kind_icon(kind: &str) -> IconType {
+    bsearch_icon_table(kind, TAGKIND_ICON_TABLE)
+        .map(|idx| TAGKIND_ICON_TABLE[idx].1)
+        .unwrap_or(DEFAULT_ICON)
+}
+
 pub fn prepend_filer_icon<P: AsRef<Path>>(path: P, line: impl Display) -> String {
     format!("{} {}", filer_icon(path), line)
 }

--- a/crates/icon/src/lib.rs
+++ b/crates/icon/src/lib.rs
@@ -45,6 +45,7 @@ impl<T: AsRef<str>> From<T> for Icon {
         match icon.as_ref().to_lowercase().as_str() {
             "file" => Self::Enabled(IconKind::File),
             "grep" => Self::Enabled(IconKind::Grep),
+            "tags" | "buffer_tags" => Self::Enabled(IconKind::BufferTags),
             "projtags" | "proj_tags" => Self::Enabled(IconKind::ProjTags),
             _ => Self::Null,
         }
@@ -57,6 +58,7 @@ pub enum IconKind {
     File,
     Grep,
     ProjTags,
+    BufferTags,
     Unknown,
 }
 
@@ -86,6 +88,7 @@ impl IconKind {
             Self::File => prepend_icon(raw_str.as_ref()),
             Self::Grep => prepend_grep_icon(raw_str.as_ref()),
             Self::ProjTags => fmt(proj_tags_icon(raw_str.as_ref())),
+            Self::BufferTags => fmt(buffer_tags_icon(raw_str.as_ref())),
             Self::Unknown => fmt(DEFAULT_ICON),
         }
     }
@@ -96,6 +99,7 @@ impl IconKind {
             Self::File => file_icon(text),
             Self::Grep => grep_icon(text),
             Self::ProjTags => proj_tags_icon(text),
+            Self::BufferTags => buffer_tags_icon(text),
             Self::Unknown => DEFAULT_ICON,
         }
     }
@@ -152,6 +156,12 @@ pub fn filer_icon<P: AsRef<Path>>(path: P) -> IconType {
 pub fn tags_kind_icon(kind: &str) -> IconType {
     bsearch_icon_table(kind, TAGKIND_ICON_TABLE)
         .map(|idx| TAGKIND_ICON_TABLE[idx].1)
+        .unwrap_or(DEFAULT_ICON)
+}
+
+fn buffer_tags_icon(line: &str) -> IconType {
+    pattern::extract_buffer_tags_kind(line)
+        .map(|kind| tags_kind_icon(kind))
         .unwrap_or(DEFAULT_ICON)
 }
 

--- a/crates/maple_cli/src/command/ctags/mod.rs
+++ b/crates/maple_cli/src/command/ctags/mod.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::Result;
-use filter::subprocess::Exec;
+use filter::subprocess::{Redirection, Exec};
 use itertools::Itertools;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -144,14 +144,18 @@ impl BufferTagInfo {
 }
 
 fn build_cmd_in_json_format(file: impl AsRef<std::ffi::OsStr>) -> Exec {
+    // Redirect stderr otherwise the warning message might occur `ctags: Warning: ignoring null tag...`
     Exec::cmd("ctags")
+        .stderr(Redirection::Merge)
         .arg("--fields=+n")
         .arg("--output-format=json")
         .arg(file)
 }
 
 fn build_cmd_in_raw_format(file: impl AsRef<std::ffi::OsStr>) -> Exec {
+    // Redirect stderr otherwise the warning message might occur `ctags: Warning: ignoring null tag...`
     Exec::cmd("ctags")
+        .stderr(Redirection::Merge)
         .arg("--fields=+Kn")
         .arg("-f")
         .arg("-")
@@ -191,6 +195,7 @@ fn buffer_tags_lines_inner(
         })
         .collect::<Vec<_>>();
 
+    println!("---------- tags: {:?}", tags);
     let max_name_len = max_name_len.into_inner();
 
     Ok(tags

--- a/crates/maple_cli/src/command/ctags/mod.rs
+++ b/crates/maple_cli/src/command/ctags/mod.rs
@@ -98,7 +98,7 @@ impl BufferTagInfo {
             name_group = name_line,
             name_group_width = max_name_len + 6,
             kind = kind,
-            kind_width = 20,
+            kind_width = 10,
             pattern = self.pattern[2..pattern_len - 2].trim()
         )
     }

--- a/crates/maple_cli/src/command/ctags/mod.rs
+++ b/crates/maple_cli/src/command/ctags/mod.rs
@@ -1,19 +1,22 @@
 pub mod recursive;
 pub mod tagsfile;
 
+use std::ops::Deref;
 use std::path::PathBuf;
 
 use anyhow::Result;
+use filter::subprocess::Exec;
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use structopt::StructOpt;
 
 use crate::app::Params;
 use crate::paths::AbsPathBuf;
-use crate::tools::ctags::EXCLUDE;
+use crate::tools::ctags::{CTAGS_HAS_JSON_FEATURE, EXCLUDE};
 
 /// Generate ctags recursively given the directory.
 #[derive(StructOpt, Debug, Clone)]
-pub(self) struct SharedParams {
+pub struct SharedParams {
     /// The directory for executing the ctags command.
     #[structopt(long, parse(from_os_str))]
     dir: Option<PathBuf>,
@@ -61,6 +64,76 @@ impl SharedParams {
 pub enum Ctags {
     RecursiveTags(recursive::RecursiveTags),
     TagsFile(tagsfile::TagsFile),
+    /// Prints the tags of given file.
+    FileTags {
+        #[structopt(long)]
+        file: AbsPathBuf,
+    },
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+struct BufferTagInfo {
+    name: String,
+    pattern: String,
+    line: usize,
+    kind: String,
+}
+
+impl BufferTagInfo {
+    fn display(&self, max_name_len: usize) -> String {
+        let pattern_len = self.pattern.len();
+
+        // let icon_name_line = format!(
+            // "{} {}:{}",
+            // icon::tags_kind_icon(&self.kind),
+            // self.name,
+            // self.line
+        // );
+
+        let name_line = format!("{}:{}", self.name, self.line);
+
+        let kind = format!("[{}]", self.kind);
+        format!(
+            "{name_group:<name_group_width$} {kind:<kind_width$} {pattern}",
+            name_group = name_line,
+            name_group_width = max_name_len + 6,
+            kind = kind,
+            kind_width = 20,
+            pattern = self.pattern[2..pattern_len - 2].trim()
+        )
+    }
+}
+
+pub fn buffer_tags_lines(file: impl AsRef<std::ffi::OsStr>) -> Result<Vec<String>> {
+    use std::io::BufRead;
+
+    let stdout = Exec::cmd("ctags")
+        .arg("--fields=+n")
+        .arg("--output-format=json")
+        .arg(file)
+        .stream_stdout()?;
+
+    let mut max_name_len = 0;
+
+    let tags = std::io::BufReader::with_capacity(8 * 1024 * 1024, stdout)
+        .lines()
+        .flatten()
+        .filter_map(|s| {
+            let maybe_tag_info = serde_json::from_str::<BufferTagInfo>(&s).ok();
+            if let Some(ref tag_info) = maybe_tag_info {
+                let name_len = tag_info.name.len();
+                if name_len > max_name_len {
+                    max_name_len = name_len;
+                }
+            }
+            maybe_tag_info
+        })
+        .collect::<Vec<_>>();
+
+    Ok(tags
+        .into_iter()
+        .map(|s| s.display(max_name_len))
+        .collect::<Vec<_>>())
 }
 
 impl Ctags {
@@ -68,6 +141,32 @@ impl Ctags {
         match self {
             Self::RecursiveTags(recursive_tags) => recursive_tags.run(params),
             Self::TagsFile(tags_file) => tags_file.run(params),
+            Self::FileTags { file } => {
+                use std::io::BufRead;
+
+                if *CTAGS_HAS_JSON_FEATURE.deref() {
+                    let lines = buffer_tags_lines(file.to_string())?;
+                    for line in lines {
+                        println!("{}", line);
+                    }
+                } else {
+                    let stdout = Exec::cmd("ctags")
+                        .arg("-n")
+                        .arg("-f")
+                        .arg("-")
+                        .arg(file.to_string())
+                        .stream_stdout()?;
+
+                    /*
+                    let lines = std::io::BufReader::with_capacity(8 * 1024 * 1024, stdout)
+                        .lines()
+                        .flatten()
+                        .filter_map(|s| TagInfo::from_ctags(&s))
+                        .collect::<Vec<_>>();
+                    */
+                }
+                Ok(())
+            }
         }
     }
 }

--- a/crates/maple_cli/src/command/ctags/mod.rs
+++ b/crates/maple_cli/src/command/ctags/mod.rs
@@ -195,7 +195,6 @@ fn buffer_tags_lines_inner(
         })
         .collect::<Vec<_>>();
 
-    println!("---------- tags: {:?}", tags);
     let max_name_len = max_name_len.into_inner();
 
     Ok(tags

--- a/crates/maple_cli/src/command/ctags/tagsfile.rs
+++ b/crates/maple_cli/src/command/ctags/tagsfile.rs
@@ -59,7 +59,8 @@ impl TagsFile {
         let tags_searcher = CtagsSearcher::new(config);
 
         if let Some(ref query) = self.query {
-            let results = tags_searcher.search(query, SearchType::StartWith, self.force_generate)?;
+            let results =
+                tags_searcher.search(query, SearchType::StartWith, self.force_generate)?;
             for line in results {
                 println!("{:?}", line);
             }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
@@ -78,6 +78,6 @@ impl<'a, P: AsRef<Path> + Hash> CtagsSearcher<'a, P> {
         Ok(std::io::BufReader::with_capacity(8 * 1024 * 1024, stdout)
             .lines()
             .flatten()
-            .filter_map(|s| TagInfo::from_ctags(&s)))
+            .filter_map(|s| TagInfo::from_readtags(&s)))
     }
 }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/mod.rs
@@ -83,7 +83,9 @@ pub struct TagInfo {
 
 impl TagInfo {
     /// Parse from the output of `readtags`.
-    pub fn from_ctags(s: &str) -> Option<Self> {
+    ///
+    /// TODO: add more tests
+    pub fn from_readtags(s: &str) -> Option<Self> {
         let mut items = s.split('\t');
 
         let mut l = Self {

--- a/crates/maple_cli/src/stdio_server/deprecated_runner.rs
+++ b/crates/maple_cli/src/stdio_server/deprecated_runner.rs
@@ -40,7 +40,7 @@ fn loop_handle_rpc_message(rx: &Receiver<String>) {
             match call.clone() {
                 Call::Notification(notification) => match notification.method.as_str() {
                     "exit" => manager.terminate(notification.session_id),
-                    "on_init" => manager.new_session(call, BuiltinHandle),
+                    "on_init" => manager.new_session(call, BuiltinHandle::new()),
                     _ => {
                         tokio::spawn(async move {
                             if let Err(e) = notification.process().await {

--- a/crates/maple_cli/src/stdio_server/session/context.rs
+++ b/crates/maple_cli/src/stdio_server/session/context.rs
@@ -73,6 +73,7 @@ impl Scale {
 #[derive(Clone, Debug)]
 pub struct SyncFilterResults {
     pub total: usize,
+    pub results: Vec<FilteredItem>,
     pub decorated_lines: printer::DecoratedLines,
 }
 
@@ -139,6 +140,7 @@ impl SessionContext {
 
         Ok(SyncFilterResults {
             total,
+            results: ranked,
             decorated_lines,
         })
     }

--- a/crates/maple_cli/src/stdio_server/session/context.rs
+++ b/crates/maple_cli/src/stdio_server/session/context.rs
@@ -181,7 +181,8 @@ impl SessionContext {
 
         let icon = if enable_icon.unwrap_or(false) {
             match provider_id.as_str() {
-                "tags" | "proj_tags" => Icon::Enabled(IconKind::ProjTags),
+                "tags" => Icon::Enabled(IconKind::BufferTags),
+                "proj_tags" => Icon::Enabled(IconKind::ProjTags),
                 "grep" | "grep2" => Icon::Enabled(IconKind::Grep),
                 "files" => Icon::Enabled(IconKind::File),
                 _ => Icon::Null,

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -70,6 +70,7 @@ pub trait EventHandle: Send + Sync + 'static {
     async fn on_create(&mut self, _call: Call, context: Arc<SessionContext>) {
         const TIMEOUT: Duration = Duration::from_millis(300);
 
+        // TODO: blocking on_create for the swift providers like `tags`.
         match tokio::time::timeout(TIMEOUT, on_session_create(context.clone())).await {
             Ok(scale_result) => match scale_result {
                 Ok(scale) => process_source_scale(scale, context),

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -15,7 +15,7 @@ use parking_lot::Mutex;
 use crate::stdio_server::providers::builtin::on_session_create;
 use crate::stdio_server::{rpc::Call, types::ProviderId, MethodCall};
 
-pub use self::context::{Scale, SessionContext, SyncFilterResults};
+pub use self::context::{SourceScale, SessionContext, SyncFilterResults};
 pub use self::manager::SessionManager;
 
 static BACKGROUND_JOBS: Lazy<Arc<Mutex<HashSet<u64>>>> =
@@ -50,19 +50,18 @@ pub fn note_job_is_finished(job_id: u64) {
 
 pub type SessionId = u64;
 
-fn process_source_scale(scale: Scale, context: Arc<SessionContext>) {
-    if let Some(total) = scale.total() {
+fn process_source_scale(source_scale: SourceScale, context: Arc<SessionContext>) {
+    if let Some(total) = source_scale.total() {
         let method = "s:set_total_size";
         utility::println_json_with_length!(total, method);
     }
 
-    if let Some(lines) = scale.initial_lines(100) {
+    if let Some(lines) = source_scale.initial_lines(100) {
         printer::decorate_lines::<i64>(lines, context.display_winwidth as usize, context.icon)
             .print_on_session_create();
     }
 
-    let mut val = context.scale.lock();
-    *val = scale;
+    context.set_source_scale(source_scale);
 }
 
 #[async_trait::async_trait]
@@ -108,7 +107,7 @@ pub struct Session<T> {
     /// Each Session can have its own message processing logic.
     pub event_handler: T,
     pub event_recv: crossbeam_channel::Receiver<SessionEvent>,
-    pub source_scale: Scale,
+    pub source_scale: SourceScale,
 }
 
 #[derive(Debug, Clone)]
@@ -140,7 +139,7 @@ impl<T: EventHandle> Session<T> {
             context: Arc::new(call.into()),
             event_handler,
             event_recv: session_receiver,
-            source_scale: Scale::Indefinite,
+            source_scale: SourceScale::Indefinite,
         };
 
         (session, session_sender)

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -15,7 +15,7 @@ use parking_lot::Mutex;
 use crate::stdio_server::providers::builtin::on_session_create;
 use crate::stdio_server::{rpc::Call, types::ProviderId, MethodCall};
 
-pub use self::context::{SourceScale, SessionContext, SyncFilterResults};
+pub use self::context::{SessionContext, SourceScale, SyncFilterResults};
 pub use self::manager::SessionManager;
 
 static BACKGROUND_JOBS: Lazy<Arc<Mutex<HashSet<u64>>>> =

--- a/crates/maple_cli/src/tools/ctags/mod.rs
+++ b/crates/maple_cli/src/tools/ctags/mod.rs
@@ -161,7 +161,7 @@ impl CtagsCommand {
             .run()?
             .filter_map(|tag| {
                 if let Ok(tag) = serde_json::from_str::<TagInfo>(&tag) {
-                    Some(tag.display_line())
+                    Some(tag.format_proj_tags())
                 } else {
                     None
                 }
@@ -179,7 +179,7 @@ impl CtagsCommand {
             .par_split(|x| x == &b'\n')
             .filter_map(|tag| {
                 if let Ok(tag) = serde_json::from_str::<TagInfo>(&String::from_utf8_lossy(tag)) {
-                    Some(tag.display_line())
+                    Some(tag.format_proj_tags())
                 } else {
                     None
                 }
@@ -198,7 +198,7 @@ impl CtagsCommand {
     pub fn formatted_tags_iter(&self) -> Result<impl Iterator<Item = String>> {
         Ok(self.run()?.filter_map(|tag| {
             if let Ok(tag) = serde_json::from_str::<TagInfo>(&tag) {
-                Some(tag.display_line())
+                Some(tag.format_proj_tags())
             } else {
                 None
             }
@@ -302,7 +302,7 @@ pub struct TagInfo {
 
 impl TagInfo {
     /// Builds the line for displaying the tag info.
-    pub fn display_line(&self) -> String {
+    pub fn format_proj_tags(&self) -> String {
         let pat_len = self.pattern.len();
         let name_lnum = format!("{}:{}", self.name, self.line);
         let kind = format!("[{}@{}]", self.kind, self.path);

--- a/crates/pattern/src/lib.rs
+++ b/crates/pattern/src/lib.rs
@@ -17,7 +17,7 @@ static GREP_STRIP_FPATH: Lazy<Regex> = Lazy::new(|| Regex::new(r"^.*:\d+:\d+:").
 // match the tag_name:lnum of tag line.
 static TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(.*:\d+)").unwrap());
 
-static BUFFER_TAGS: Lazy<Regex> = Lazy::new(|| Regex::new(r"^.*:(\d+)").unwrap());
+static BUFFER_TAGS: Lazy<Regex> = Lazy::new(|| Regex::new(r"^.*:(\d+).*\[(.*)\]").unwrap());
 
 static PROJ_TAGS: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(.*):(\d+).*\[(.*)@(.*?)\]").unwrap());
 
@@ -128,6 +128,12 @@ pub fn extract_proj_tags(line: &str) -> Option<(usize, &str)> {
 pub fn extract_proj_tags_kind(line: &str) -> Option<&str> {
     let cap = PROJ_TAGS.captures(line)?;
     let kind = cap.get(3).map(|x| x.as_str())?;
+    Some(kind)
+}
+
+pub fn extract_buffer_tags_kind(line: &str) -> Option<&str> {
+    let cap = BUFFER_TAGS.captures(line)?;
+    let kind = cap.get(2).map(|x| x.as_str())?;
     Some(kind)
 }
 

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -828,6 +828,15 @@ g:clap_provider_colors_ignore_default     *g:clap_provider_colors_ignore_default
   Ignore the colors under the path `$VIMRUNTIME` .
 
 
+g:clap_provider_tags_force_vista           *g:clap_provider_tags_force_vista*
+
+  Type: |bool|
+  Default: `undefined`
+
+  The latest Rust binary of vim-clap supports generating the source of `tags` on
+  its own, but you can still use this option to use vista.vim before getting
+  the latest Rust binary in case you use the prebuilt binary.
+
 ===============================================================================
 7. Commands                                                     *clap-commands*
 


### PR DESCRIPTION
This PR supports generating the source for `tags` provider using the Rust binary, and remove the `+json` requirement from the ctags executable.

Close #57