### PR TITLE
preview: show the current method/function when it's invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 - Support generating the source of `tags` provider using the Rust binary, remove the vista.vim dep from `tags` provider. #795
+- Initial support of preview with context. #798
 
 ## Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,6 +1985,7 @@ dependencies = [
  "directories",
  "memchr",
  "simdutf8",
+ "types",
 ]
 
 [[package]]

--- a/crates/maple_cli/src/command/ctags/buffer_tags.rs
+++ b/crates/maple_cli/src/command/ctags/buffer_tags.rs
@@ -89,7 +89,7 @@ pub fn current_context_tag(file: &Path, at: usize) -> Option<BufferTagInfo> {
         Ok(_l) => None, // Skip if the line is exactly a tag line.
         Err(_l) => {
             let context_tags = superset_tags
-                .par_iter()
+                .into_par_iter()
                 .filter(|tag| CONTEXT_KINDS.contains(&tag.kind.as_ref()))
                 .collect::<Vec<_>>();
 
@@ -97,7 +97,7 @@ pub fn current_context_tag(file: &Path, at: usize) -> Option<BufferTagInfo> {
                 Ok(_) => None,
                 Err(l) => {
                     let maybe_idx = l.checked_sub(1); // use the previous item.
-                    maybe_idx.map(|idx| context_tags[idx].clone())
+                    maybe_idx.and_then(|idx| context_tags.into_iter().nth(idx))
                 }
             }
         }

--- a/crates/maple_cli/src/command/ctags/buffer_tags.rs
+++ b/crates/maple_cli/src/command/ctags/buffer_tags.rs
@@ -70,7 +70,7 @@ pub fn current_context_tag(file: &Path, at: usize) -> Option<BufferTagInfo> {
             const CONTEXT_KINDS: &[&str] = &["function", "method", "module", "macro"];
 
             let context_tags = tags
-                .iter()
+                .par_iter()
                 .filter(|tag| CONTEXT_KINDS.contains(&tag.kind.as_ref()))
                 .collect::<Vec<_>>();
 

--- a/crates/maple_cli/src/command/ctags/buffer_tags.rs
+++ b/crates/maple_cli/src/command/ctags/buffer_tags.rs
@@ -67,7 +67,7 @@ pub fn current_context_tag(file: &Path, at: usize) -> Option<BufferTagInfo> {
     match tags.binary_search_by_key(&at, |tag| tag.line) {
         Ok(_l) => None, // Skip if the line is exactly a tag line.
         Err(_l) => {
-            const CONTEXT_KINDS: &[&str] = &["function", "method", "module"];
+            const CONTEXT_KINDS: &[&str] = &["function", "method", "module", "macro"];
 
             let context_tags = tags
                 .iter()
@@ -225,6 +225,7 @@ fn collect_buffer_tags(
         "module",
         "implementation",
         "struct",
+        "macro",
         "enumerator",
     ];
 

--- a/crates/maple_cli/src/command/grep/mod.rs
+++ b/crates/maple_cli/src/command/grep/mod.rs
@@ -7,9 +7,9 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use anyhow::{Context, Result};
+use clap::Parser;
 use itertools::Itertools;
 use rayon::prelude::*;
-use clap::Parser;
 
 use filter::{
     matcher::{Bonus, MatchType},

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
@@ -66,17 +66,13 @@ impl<'a, P: AsRef<Path> + Hash> CtagsSearcher<'a, P> {
         search_type: SearchType,
         force_generate: bool,
     ) -> Result<impl Iterator<Item = TagInfo>> {
-        use std::io::BufRead;
-
         if force_generate || !self.tags_exists() {
             self.generate_tags()?;
         }
 
-        let stdout = self.build_exec(query, search_type).stream_stdout()?;
+        let cmd = self.build_exec(query, search_type);
 
-        // We usually have a decent amount of RAM nowdays.
-        Ok(std::io::BufReader::with_capacity(8 * 1024 * 1024, stdout)
-            .lines()
+        Ok(crate::utils::lines(cmd)?
             .flatten()
             .filter_map(|s| TagInfo::from_readtags(&s)))
     }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/gtags/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/gtags/mod.rs
@@ -1,4 +1,3 @@
-use std::io::BufRead;
 use std::path::{PathBuf, MAIN_SEPARATOR};
 
 use anyhow::{anyhow, Result};
@@ -121,11 +120,7 @@ impl GtagsSearcher {
 
 // Returns a stream of tag parsed from the gtags output.
 fn execute(cmd: Exec) -> Result<impl Iterator<Item = TagInfo>> {
-    let stdout = cmd.stream_stdout()?;
-
-    // We usually have a decent amount of RAM nowdays.
-    Ok(std::io::BufReader::with_capacity(8 * 1024 * 1024, stdout)
-        .lines()
+    Ok(crate::utils::lines(cmd)?
         .flatten()
         .filter_map(|s| TagInfo::from_gtags(&s)))
 }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/definition.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/definition.rs
@@ -113,11 +113,10 @@ pub fn get_comments_by_ext(ext: &str) -> &[&str] {
     static LANGUAGE_COMMENT_TABLE: OnceCell<HashMap<&str, Vec<&str>>> = OnceCell::new();
 
     let table = LANGUAGE_COMMENT_TABLE.get_or_init(|| {
-        let comments: HashMap<&str, Vec<&str>> = serde_json::from_str(include_str!(
+        serde_json::from_str(include_str!(
             "../../../../../../../scripts/dumb_jump/comments_map.json"
         ))
-        .expect("Wrong path for comments_map.json");
-        comments
+        .expect("Wrong path for comments_map.json")
     });
 
     table

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/definition.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/definition.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Display};
 
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
-use once_cell::sync::{Lazy, OnceCell};
+use once_cell::sync::Lazy;
 use rayon::prelude::*;
 use serde::Deserialize;
 
@@ -104,24 +104,6 @@ pub fn get_language_by_ext(ext: &str) -> Result<&&str> {
     RG_LANGUAGE_EXT_TABLE
         .get(ext)
         .ok_or_else(|| anyhow!("dumb_analyzer is unsupported for {}", ext))
-}
-
-/// Map of file extension to the comment prefix.
-///
-/// Keyed by the extension name.
-pub fn get_comments_by_ext(ext: &str) -> &[&str] {
-    static LANGUAGE_COMMENT_TABLE: OnceCell<HashMap<&str, Vec<&str>>> = OnceCell::new();
-
-    let table = LANGUAGE_COMMENT_TABLE.get_or_init(|| {
-        serde_json::from_str(include_str!(
-            "../../../../../../../scripts/dumb_jump/comments_map.json"
-        ))
-        .expect("Wrong path for comments_map.json")
-    });
-
-    table
-        .get(ext)
-        .unwrap_or_else(|| table.get("*").expect("`*` entry exists; qed"))
 }
 
 /// Type of match result of ripgrep.

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/mod.rs
@@ -19,11 +19,13 @@ use anyhow::Result;
 use rayon::prelude::*;
 
 use self::definition::{
-    definitions_and_references, do_search_usages, get_comments_by_ext, get_language_by_ext,
-    MatchKind,
+    definitions_and_references, do_search_usages, get_language_by_ext, MatchKind,
 };
 use self::worker::find_occurrences_by_ext;
-use crate::dumb_analyzer::find_usages::{Usage, Usages};
+use crate::dumb_analyzer::{
+    find_usages::{Usage, Usages},
+    get_comments_by_ext,
+};
 use crate::tools::ripgrep::{Match, Word};
 use crate::utils::ExactOrInverseTerms;
 

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/worker.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/regex/worker.rs
@@ -4,7 +4,8 @@ use std::path::PathBuf;
 use anyhow::Result;
 use rayon::prelude::*;
 
-use super::definition::{build_full_regexp, get_comments_by_ext, is_comment, DefinitionKind};
+use super::definition::{build_full_regexp, is_comment, DefinitionKind};
+use crate::dumb_analyzer::get_comments_by_ext;
 use crate::process::AsyncCommand;
 use crate::tools::ripgrep::{Match, Word};
 

--- a/crates/maple_cli/src/dumb_analyzer/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/mod.rs
@@ -1,5 +1,5 @@
 mod find_usages;
 
 pub use self::find_usages::{
-    CtagsSearcher, GtagsSearcher, RegexSearcher, SearchType, Usage, Usages,
+    get_comments_by_ext, CtagsSearcher, GtagsSearcher, RegexSearcher, SearchType, Usage, Usages,
 };

--- a/crates/maple_cli/src/previewer/mod.rs
+++ b/crates/maple_cli/src/previewer/mod.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use anyhow::{anyhow, Result};
 
+use types::PreviewInfo;
 use utility::{read_first_lines, read_preview_lines};
 
 #[inline]
@@ -61,10 +62,15 @@ pub fn preview_file_at<P: AsRef<Path>>(
 ) -> Result<(Vec<String>, usize)> {
     tracing::debug!(path = %path.as_ref().display(), lnum, "Previewing file");
 
-    let (lines_iter, hi_lnum) = read_preview_lines(path.as_ref(), lnum, half_size)?;
+    let PreviewInfo {
+        lines,
+        highlight_lnum,
+        ..
+    } = read_preview_lines(path.as_ref(), lnum, half_size)?;
+
     let lines = std::iter::once(format!("{}:{}", path.as_ref().display(), lnum))
-        .chain(truncate_preview_lines(max_width, lines_iter.into_iter()))
+        .chain(truncate_preview_lines(max_width, lines.into_iter()))
         .collect::<Vec<_>>();
 
-    Ok((lines, hi_lnum))
+    Ok((lines, highlight_lnum))
 }

--- a/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
@@ -36,7 +36,7 @@ impl EventHandle for BuiltinHandle {
     async fn on_move(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {
         let msg_id = msg.id;
 
-        let source_scale = context.source_scale.lock();
+        let source_scale = context.state.source_scale.lock();
 
         let curline = match (source_scale.deref(), msg.get_u64("lnum").ok()) {
             (SourceScale::Small { ref lines, .. }, Some(lnum)) => {
@@ -67,7 +67,7 @@ impl EventHandle for BuiltinHandle {
     async fn on_typed(&mut self, msg: MethodCall, context: Arc<SessionContext>) -> Result<()> {
         let query = msg.get_query();
 
-        let source_scale = context.source_scale.lock();
+        let source_scale = context.state.source_scale.lock();
 
         match source_scale.deref() {
             SourceScale::Small { ref lines, .. } => {

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -285,10 +285,11 @@ impl<'a> OnMoveHandler<'a> {
                 start,
                 ..
             }) => {
+                let container_width = self.context.display_winwidth as usize;
+
                 // Truncate the left of absolute path string.
                 let mut fname = path.display().to_string();
-                let max_fname_len =
-                    self.context.display_winwidth as usize - 1 - crate::utils::display_width(*lnum);
+                let max_fname_len = container_width - 1 - crate::utils::display_width(*lnum);
                 if fname.len() > max_fname_len {
                     if let Some((offset, _)) =
                         fname.char_indices().nth(fname.len() - max_fname_len + 2)
@@ -306,7 +307,6 @@ impl<'a> OnMoveHandler<'a> {
 
                 let highlight_lnum = match current_context_tag(path, *lnum) {
                     Some(tag) if tag.line < start => {
-                        let container_width = self.context.display_winwidth as usize;
                         let border_line = "─".repeat(container_width);
                         lines.insert(1, border_line.clone());
 

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -314,7 +314,7 @@ impl<'a> OnMoveHandler<'a> {
                             let pattern = if pattern.len() > max_pattern_len {
                                 // Use the chars instead of indexing the str to avoid the char boundary error.
                                 let mut p: String =
-                                    pattern.chars().take(max_pattern_len - 2).collect();
+                                    pattern.chars().take(max_pattern_len - 4 - 2).collect();
                                 p.push_str("..");
                                 Cow::Owned(p)
                             } else {

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -297,7 +298,18 @@ impl<'a> OnMoveHandler<'a> {
                         Some(tag) if tag.line < start => {
                             let border_line = "─".repeat(self.context.display_winwidth as usize);
                             lines.insert(1, border_line.clone());
-                            lines.insert(1, format!("{}  💡", tag.extract_pattern()));
+                            let pattern = tag.extract_pattern();
+                            // 2 whitespaces + 💡
+                            let max_pattern_len = self.context.display_winwidth as usize - 4;
+                            let pattern = if pattern.len() > max_pattern_len {
+                                let mut p: String =
+                                    pattern.chars().take(max_pattern_len - 2).collect();
+                                p.push_str("..");
+                                Cow::Owned(p)
+                            } else {
+                                Cow::Borrowed(pattern)
+                            };
+                            lines.insert(1, format!("{}  💡", pattern));
                             lines.insert(1, border_line);
                             highlight_lnum + 3
                         }

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -9,7 +9,7 @@ use serde_json::json;
 use pattern::*;
 use types::PreviewInfo;
 
-use crate::command::ctags::buffer_tags::current_context_tag;
+use crate::command::ctags::buffer_tags::{current_context_tag, BufferTagInfo};
 use crate::previewer::{self, vim_help::HelpTagPreview};
 use crate::stdio_server::{
     global, providers::filer, session::SessionContext, write_response, MethodCall,

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -284,7 +284,17 @@ impl<'a> OnMoveHandler<'a> {
                 start,
                 ..
             }) => {
-                let fname = path.display().to_string();
+                // Truncate the absolute path string.
+                let mut fname = path.display().to_string();
+                let max_fname_len =
+                    self.context.display_winwidth as usize - 1 - crate::utils::display_width(*lnum);
+                if fname.len() > max_fname_len {
+                    if let Some((offset, _)) =
+                        fname.char_indices().nth(fname.len() - max_fname_len + 2)
+                    {
+                        fname.replace_range(..offset, "..");
+                    }
+                }
                 let mut lines = std::iter::once(format!("{}:{}", fname, lnum))
                     .chain(self.truncate_preview_lines(lines.into_iter()))
                     .collect::<Vec<_>>();
@@ -302,6 +312,7 @@ impl<'a> OnMoveHandler<'a> {
                             // 2 whitespaces + 💡
                             let max_pattern_len = self.context.display_winwidth as usize - 4;
                             let pattern = if pattern.len() > max_pattern_len {
+                                // Use the chars instead of indexing the str to avoid the char boundary error.
                                 let mut p: String =
                                     pattern.chars().take(max_pattern_len - 2).collect();
                                 p.push_str("..");

--- a/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/on_move.rs
@@ -304,7 +304,7 @@ impl<'a> OnMoveHandler<'a> {
                 }
 
                 let highlight_lnum =
-                    match crate::command::ctags::buffer_tags::current_function_tag(path, *lnum) {
+                    match crate::command::ctags::buffer_tags::current_context_tag(path, *lnum) {
                         Some(tag) if tag.line < start => {
                             let border_line = "─".repeat(self.context.display_winwidth as usize);
                             lines.insert(1, border_line.clone());

--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump/searcher.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump/searcher.rs
@@ -48,6 +48,7 @@ fn search_gtags(dir: &Path, search_info: &SearchInfo) -> Result<Usages> {
     } = search_info;
     let usages = GtagsSearcher::new(dir.to_path_buf())
         .search_references(keyword)?
+        .par_bridge()
         .filter_map(|tag_info| {
             let (line, indices) = tag_info.grep_format_gtags("refs", keyword, false);
             filtering_terms

--- a/crates/maple_cli/src/stdio_server/session/context.rs
+++ b/crates/maple_cli/src/stdio_server/session/context.rs
@@ -83,9 +83,9 @@ pub struct SessionContext {
     pub match_type: MatchType,
     pub match_bonuses: Vec<matcher::Bonus>,
     pub source_scale: Arc<Mutex<SourceScale>>,
+    pub is_running: Arc<AtomicBool>,
     pub source_cmd: Option<String>,
     pub runtimepath: Option<String>,
-    pub is_running: Arc<Mutex<AtomicBool>>,
 }
 
 impl SessionContext {
@@ -183,7 +183,7 @@ impl SessionContext {
             match_bonuses,
             icon,
             source_scale: Arc::new(Mutex::new(SourceScale::Indefinite)),
-            is_running: Arc::new(Mutex::new(true.into())),
+            is_running: Arc::new(true.into()),
         }
     }
 }

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -145,7 +145,7 @@ impl<T: EventHandle> Session<T> {
 
     /// Sets the running signal to false, in case of the forerunner thread is still working.
     pub fn handle_terminate(&mut self) {
-        self.context.is_running.store(false, Ordering::SeqCst);
+        self.context.state.is_running.store(false, Ordering::SeqCst);
         tracing::debug!(
             session_id = self.session_id,
             provider_id = %self.provider_id(),

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -3,7 +3,7 @@ mod manager;
 
 use std::borrow::Cow;
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::sync::{atomic::Ordering, Arc};
 use std::time::Duration;
 
 use anyhow::Result;
@@ -145,8 +145,7 @@ impl<T: EventHandle> Session<T> {
 
     /// Sets the running signal to false, in case of the forerunner thread is still working.
     pub fn handle_terminate(&mut self) {
-        let mut val = self.context.is_running.lock();
-        *val.get_mut() = false;
+        self.context.is_running.store(false, Ordering::SeqCst);
         tracing::debug!(
             session_id = self.session_id,
             provider_id = %self.provider_id(),

--- a/crates/maple_cli/src/tools/ripgrep/mod.rs
+++ b/crates/maple_cli/src/tools/ripgrep/mod.rs
@@ -7,6 +7,8 @@ use std::{borrow::Cow, convert::TryFrom};
 
 use anyhow::Result;
 
+use crate::utils::display_width;
+
 pub use self::jsont::{Match, Message, SubMatch};
 
 /// Word represents the input query around by word boundries.
@@ -128,23 +130,6 @@ impl TryFrom<&str> for Match {
             Err("Not Message::Match type".into())
         }
     }
-}
-
-/// Returns the width of displaying `n` on the screen.
-///
-/// Same with `n.to_string().len()` but without allocation.
-fn display_width(mut n: usize) -> usize {
-    if n == 0 {
-        return 1;
-    }
-
-    let mut len = 0;
-    while n > 0 {
-        len += 1;
-        n /= 10;
-    }
-
-    len
 }
 
 impl Match {

--- a/crates/maple_cli/src/utils.rs
+++ b/crates/maple_cli/src/utils.rs
@@ -221,6 +221,24 @@ pub fn count_lines<R: std::io::Read>(handle: R) -> Result<usize, std::io::Error>
     Ok(count)
 }
 
+/// Returns the width of displaying `n` on the screen.
+///
+/// Same with `n.to_string().len()` but without allocation.
+pub fn display_width(n: usize) -> usize {
+    if n == 0 {
+        return 1;
+    }
+
+    let mut n = n;
+    let mut len = 0;
+    while n > 0 {
+        len += 1;
+        n /= 10;
+    }
+
+    len
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/maple_cli/src/utils.rs
+++ b/crates/maple_cli/src/utils.rs
@@ -1,10 +1,14 @@
-use std::path::{Path, PathBuf};
+use std::{
+    io::{BufRead, Lines},
+    path::{Path, PathBuf},
+};
 
 use anyhow::{anyhow, Result};
 use chrono::prelude::*;
 use directories::ProjectDirs;
 use once_cell::sync::Lazy;
 
+use filter::subprocess::Exec;
 use icon::Icon;
 use types::{ExactTerm, InverseTerm};
 use utility::{println_json, println_json_with_length, read_first_lines};
@@ -18,19 +22,10 @@ pub static PROJECT_DIRS: Lazy<ProjectDirs> = Lazy::new(|| {
 });
 
 /// Yes or no terms.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ExactOrInverseTerms {
     pub exact_terms: Vec<ExactTerm>,
     pub inverse_terms: Vec<InverseTerm>,
-}
-
-impl Default for ExactOrInverseTerms {
-    fn default() -> Self {
-        Self {
-            exact_terms: Vec::new(),
-            inverse_terms: Vec::new(),
-        }
-    }
 }
 
 impl ExactOrInverseTerms {
@@ -202,8 +197,6 @@ pub fn build_abs_path(cwd: impl AsRef<Path>, curline: impl AsRef<Path>) -> PathB
 ///
 /// Credit: https://github.com/eclarke/linecount/blob/master/src/lib.rs
 pub fn count_lines<R: std::io::Read>(handle: R) -> Result<usize, std::io::Error> {
-    use std::io::BufRead;
-
     let mut reader = std::io::BufReader::with_capacity(1024 * 32, handle);
     let mut count = 0;
     loop {
@@ -219,6 +212,12 @@ pub fn count_lines<R: std::io::Read>(handle: R) -> Result<usize, std::io::Error>
     }
 
     Ok(count)
+}
+
+#[inline]
+pub fn lines(cmd: Exec) -> Result<Lines<impl BufRead>> {
+    // We usually have a decent amount of RAM nowdays.
+    Ok(std::io::BufReader::with_capacity(8 * 1024 * 1024, cmd.stream_stdout()?).lines())
 }
 
 /// Returns the width of displaying `n` on the screen.

--- a/crates/printer/src/truncation.rs
+++ b/crates/printer/src/truncation.rs
@@ -54,6 +54,8 @@ fn truncate_line_v1(
     }
 }
 
+const MAX_LINE_LEN: usize = 500;
+
 /// Long matched lines can cause the matched items invisible.
 ///
 /// # Arguments
@@ -68,14 +70,25 @@ pub fn truncate_long_matched_lines<T>(
     let mut truncated_map = HashMap::new();
     let winwidth = winwidth - WINWIDTH_OFFSET;
     items.enumerate().for_each(|(lnum, mut filtered_item)| {
-        let source_item = &filtered_item.source_item;
-        if let Some((truncated, truncated_indices)) = truncate_line_v1(
-            source_item.display_text(),
+        let origin_display_text = filtered_item.source_item.display_text();
+
+        // Truncate the text simply if it's too long.
+        if origin_display_text.len() > MAX_LINE_LEN {
+            let display_text: String = origin_display_text.chars().take(1000).collect();
+            filtered_item.display_text = Some(display_text);
+            filtered_item.match_indices = filtered_item
+                .match_indices
+                .iter()
+                .filter(|x| **x < 1000)
+                .copied()
+                .collect();
+        } else if let Some((truncated, truncated_indices)) = truncate_line_v1(
+            origin_display_text,
             &mut filtered_item.match_indices,
             winwidth,
             skipped,
         ) {
-            truncated_map.insert(lnum + 1, source_item.display_text().to_string());
+            truncated_map.insert(lnum + 1, origin_display_text.to_string());
 
             filtered_item.display_text = Some(truncated);
             filtered_item.match_indices = truncated_indices;

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -8,3 +8,14 @@ pub use self::search_term::{
     TermType,
 };
 pub use self::source_item::{FilteredItem, FuzzyText, MatchType, MatchingText, SourceItem};
+
+/// The preview content is usually part of a file.
+#[derive(Clone, Debug)]
+pub struct PreviewInfo {
+    pub start: usize,
+    pub end: usize,
+    /// Line number of the line that should be highlighed in the preview window.
+    pub highlight_lnum: usize,
+    /// [start, end] of the source file.
+    pub lines: Vec<String>,
+}

--- a/crates/utility/Cargo.toml
+++ b/crates/utility/Cargo.toml
@@ -9,3 +9,5 @@ anyhow = "1.0"
 directories = "3.0"
 memchr = "2.4"
 simdutf8 = "0.1"
+
+types = { path = "../types" }

--- a/crates/utility/src/lib.rs
+++ b/crates/utility/src/lib.rs
@@ -235,7 +235,7 @@ mod tests {
     fn test_multi_byte_reading() {
         let mut current_dir = std::env::current_dir().unwrap();
         current_dir.push("test_673.txt");
-        let (lines, _hl_line) = read_preview_lines_impl(current_dir, 2, 5).unwrap();
+        let PreviewInfo { lines, .. } = read_preview_lines_impl(current_dir, 2, 5).unwrap();
         assert_eq!(
             lines,
             [

--- a/crates/utility/src/lib.rs
+++ b/crates/utility/src/lib.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use anyhow::{anyhow, Result};
+use types::PreviewInfo;
 
 use self::bytelines::ByteLines;
 
@@ -86,7 +87,7 @@ fn read_preview_lines_utf8<P: AsRef<Path>>(
     size: usize,
 ) -> io::Result<(impl Iterator<Item = String>, usize)> {
     let file = File::open(path)?;
-    let (start, end, hl_line) = if target_line > size {
+    let (start, end, highlight_lnum) = if target_line > size {
         (target_line - size, target_line + size, size)
     } else {
         (0, 2 * size, target_line)
@@ -97,7 +98,7 @@ fn read_preview_lines_utf8<P: AsRef<Path>>(
             .skip(start)
             .filter_map(|l| l.ok())
             .take(end - start),
-        hl_line,
+        highlight_lnum,
     ))
 }
 
@@ -106,7 +107,7 @@ pub fn read_preview_lines<P: AsRef<Path>>(
     path: P,
     target_line: usize,
     size: usize,
-) -> io::Result<(Vec<String>, usize)> {
+) -> io::Result<PreviewInfo> {
     read_preview_lines_impl(path, target_line, size)
 }
 
@@ -123,8 +124,8 @@ fn read_preview_lines_impl<P: AsRef<Path>>(
     path: P,
     target_line: usize,
     size: usize,
-) -> io::Result<(Vec<String>, usize)> {
-    let (start, end, hl_line) = if target_line > size {
+) -> io::Result<PreviewInfo> {
+    let (start, end, highlight_lnum) = if target_line > size {
         (target_line - size, target_line + size, size)
     } else {
         (0, 2 * size, target_line)
@@ -149,15 +150,19 @@ fn read_preview_lines_impl<P: AsRef<Path>>(
             file.read_to_end(&mut filebuf)
         })
         .map(|_| {
-            (
-                ByteLines::new(&filebuf)
-                    .into_iter()
-                    .skip(start)
-                    .take(end - start)
-                    .map(|l| l.to_string())
-                    .collect::<Vec<_>>(),
-                hl_line,
-            )
+            let lines = ByteLines::new(&filebuf)
+                .into_iter()
+                .skip(start)
+                .take(end - start)
+                .map(|l| l.to_string())
+                .collect::<Vec<_>>();
+
+            PreviewInfo {
+                start,
+                end,
+                highlight_lnum,
+                lines,
+            }
         })
 }
 

--- a/pythonx/clap/fuzzymatch-rs/Cargo.lock
+++ b/pythonx/clap/fuzzymatch-rs/Cargo.lock
@@ -624,6 +624,7 @@ dependencies = [
  "directories",
  "memchr",
  "simdutf8",
+ "types",
 ]
 
 [[package]]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use maple_cli::{Cmd, Context, Maple, Result, Parser};
+use maple_cli::{Cmd, Context, Maple, Parser, Result};
 
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));


### PR DESCRIPTION
The idea is the same with the nearest function/method symbol provided by vista.vim. The context tag is not guaranteed to be 100% correct.

Close #66

<img width="1492" alt="截屏2022-02-06 上午10 58 02" src="https://user-images.githubusercontent.com/8850248/152666113-c782726c-ce80-44dc-baea-37d4f727d183.png">
