### PR TITLE
Inspect the syntax of preview content on Rust side

### DIFF
--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump/searcher.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump/searcher.rs
@@ -46,7 +46,7 @@ fn search_gtags(dir: &Path, search_info: &SearchInfo) -> Result<Usages> {
         filtering_terms,
         ..
     } = search_info;
-    let usages = GtagsSearcher::new(dir.to_path_buf())
+    let mut usages = GtagsSearcher::new(dir.to_path_buf())
         .search_references(keyword)?
         .par_bridge()
         .filter_map(|tag_info| {
@@ -56,6 +56,9 @@ fn search_gtags(dir: &Path, search_info: &SearchInfo) -> Result<Usages> {
                 .map(|(line, indices)| Usage::new(line, indices))
         })
         .collect::<Vec<_>>();
+    // TODO: the usages are grouped per file, but the usages in a file is not sorted by the line
+    // number.
+    usages.par_sort_unstable_by(|a, b| a.line.cmp(&b.line));
     Ok(usages.into())
 }
 

--- a/crates/maple_cli/src/stdio_server/vim.rs
+++ b/crates/maple_cli/src/stdio_server/vim.rs
@@ -1,10 +1,108 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::Result;
+use once_cell::sync::{Lazy, OnceCell};
+use rayon::prelude::*;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 
 use crate::stdio_server::rpc::RpcClient;
+
+/// Map of file extension to vim syntax mapping.
+static SYNTAX_MAP: OnceCell<HashMap<String, String>> = OnceCell::new();
+
+static FILENAME_SYNTAX_MAP: Lazy<HashMap<&str, &str>> =
+    Lazy::new(|| vec![("vimrc", "vim")].into_iter().collect());
+
+/// Returns the value of `&syntax` for a specific file path.
+///
+/// Used to highlight the preview buffer.
+pub fn syntax_for(path: &Path) -> Option<&str> {
+    match path
+        .file_name()
+        .and_then(|x| x.to_str())
+        .map(|filename| FILENAME_SYNTAX_MAP.deref().get(filename).copied())
+        .flatten()
+    {
+        None => path
+            .extension()
+            .and_then(|x| x.to_str())
+            .map(|ext| {
+                SYNTAX_MAP
+                    .get()
+                    .and_then(|m| m.get(ext).map(|s| s.as_ref()))
+            })
+            .flatten(),
+        Some(s) => Some(s),
+    }
+}
+
+pub fn initialize_syntax_map(output: &str) -> HashMap<&str, &str> {
+    let ext_map: HashMap<&str, &str> = output
+        .par_split(|x| x == '\n')
+        .filter(|s| s.contains("setf"))
+        .filter_map(|s| {
+            // *.mkiv    setf context
+            let items = s.split_whitespace().collect::<Vec<_>>();
+            if items.len() != 3 {
+                None
+            } else {
+                // (mkiv, context)
+                items[0].split('.').last().map(|ext| (ext, items[2]))
+            }
+        })
+        .chain(
+            // Lines as followed can not be parsed correctly, thus the preview highlight of
+            // related file will be broken. Ref #800
+            // *.c       call dist#ft#FTlpc()
+            vec![
+                ("hpp", "cpp"),
+                ("vimrc", "vim"),
+                ("cc", "cpp"),
+                ("cpp", "cpp"),
+                ("c", "c"),
+                ("h", "c"),
+                ("cmd", "dosbatch"),
+                ("CMakeLists.txt", "cmake"),
+                ("Dockerfile", "dockerfile"),
+                ("directory", "desktop"),
+                ("patch", "diff"),
+                ("dircolors", "dircolors"),
+                ("editorconfig", "dosini"),
+                ("COMMIT_EDITMSG", "gitcommit"),
+                ("MERGE_MSG", "gitcommit"),
+                ("TAG_EDITMSG", "gitcommit"),
+                ("NOTES_EDITMSG", "gitcommit"),
+                ("EDIT_DESCRIPTION", "gitcommit"),
+                ("gitconfig", "gitconfig"),
+                ("worktree", "gitconfig"),
+                ("gitmodules", "gitconfig"),
+                ("htm", "html"),
+                ("html", "html"),
+                ("shtml", "html"),
+                ("stm", "html"),
+            ]
+            .into_par_iter(),
+        )
+        .map(|(ext, ft)| (ext, ft))
+        .collect();
+
+    if let Err(e) = SYNTAX_MAP.set(
+        ext_map
+            .par_iter()
+            .map(|(k, v)| (String::from(*k), String::from(*v)))
+            .collect(),
+    ) {
+        tracing::debug!(error = ?e, "Failed to initialized SYNTAX_MAP");
+    } else {
+        tracing::debug!("SYNTAX_MAP initialized successfully");
+    }
+
+    ext_map
+}
 
 #[derive(Clone)]
 pub struct Vim {


### PR DESCRIPTION
Check the syntax by searching the pre-defined map via file name and then file extension. Not an entire solution, but at least easier to add the support accordingly once someone finds no highlight for some kind of file. 

Ref #800