### PR TITLE
Add clap cache threshold configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## [unreleased]
 
+## Added
+
+- Add `g:clap_cache_threshold`. #806
 
 ## [0.33] 2022-02-20
+
 ## Added
 
 - Support generating the source of `tags` provider using the Rust binary, remove the vista.vim dep from `tags` provider. #795

--- a/autoload/clap/maple/command.vim
+++ b/autoload/clap/maple/command.vim
@@ -8,6 +8,8 @@ let s:maple_bin = clap#maple#binary()
 
 let s:can_enable_icon = ['files', 'git_files']
 
+let s:cache_threshold = get(g:, 'clap_cache_threshold', 100000)
+
 function! clap#maple#command#start_grep_sync(cmd, query, enable_icon, glob) abort
   let global_opts = ['--number', g:clap.display.preload_capacity, '--winwidth', winwidth(g:clap.display.winid)]
 
@@ -40,7 +42,7 @@ function! clap#maple#command#ripgrep_forerunner() abort
   let subcommand = [
         \ 'ripgrep-forerunner',
         \ '--cmd-dir', clap#rooter#working_dir(),
-        \ '--output-threshold', clap#filter#capacity(),
+        \ '--output-threshold', s:cache_threshold,
         \ ]
 
   return [s:maple_bin] + global_opts + subcommand
@@ -69,7 +71,7 @@ function! clap#maple#command#exec_forerunner(cmd) abort
   let subcommand = [
         \ 'exec', a:cmd,
         \ '--cmd-dir', clap#rooter#working_dir(),
-        \ '--output-threshold', clap#filter#capacity(),
+        \ '--output-threshold', s:cache_threshold,
         \ ]
 
   return [s:maple_bin] + global_opts + subcommand

--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -223,7 +223,7 @@ function! s:grep_sink(selected) abort
   call s:grep_exit()
   let line = a:selected
 
-  let pattern = '\(.*\):\(\d\+\):\(\d\+\):'
+  let pattern = '\(.\{-}\):\(\d\+\):\(\d\+\):'
   let matched = s:matchlist(line, pattern)
   let [fpath, linenr, column] = [matched[1], str2nr(matched[2]), str2nr(matched[3])]
   call clap#sink#open_file(fpath, linenr, column)

--- a/crates/maple_cli/src/cache/mod.rs
+++ b/crates/maple_cli/src/cache/mod.rs
@@ -73,17 +73,9 @@ impl Digest {
 }
 
 /// List of cache digests.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct CacheInfo {
     digests: Vec<Digest>,
-}
-
-impl Default for CacheInfo {
-    fn default() -> Self {
-        Self {
-            digests: Vec::new(),
-        }
-    }
 }
 
 impl CacheInfo {

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use filter::subprocess::{Exec, Redirection};
 
-use super::{QueryType, TagInfo};
+use super::{QueryType, UnifiedTagInfo};
 use crate::tools::ctags::TagsConfig;
 
 /// `readtags` powered searcher.
@@ -66,7 +66,7 @@ impl<'a, P: AsRef<Path> + Hash> CtagsSearcher<'a, P> {
         query: &str,
         query_type: QueryType,
         force_generate: bool,
-    ) -> Result<impl Iterator<Item = TagInfo>> {
+    ) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
         if force_generate || !self.tags_exists() {
             self.generate_tags()?;
         }
@@ -75,6 +75,6 @@ impl<'a, P: AsRef<Path> + Hash> CtagsSearcher<'a, P> {
 
         Ok(crate::utils::lines(cmd)?
             .flatten()
-            .filter_map(|s| TagInfo::from_readtags(&s)))
+            .filter_map(|s| UnifiedTagInfo::from_readtags(&s)))
     }
 }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/ctags/mod.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Result;
 use filter::subprocess::{Exec, Redirection};
 
-use super::{QueryType, UnifiedTagInfo};
+use super::{QueryType, Symbol};
 use crate::tools::ctags::TagsConfig;
 
 /// `readtags` powered searcher.
@@ -66,7 +66,7 @@ impl<'a, P: AsRef<Path> + Hash> CtagsSearcher<'a, P> {
         query: &str,
         query_type: QueryType,
         force_generate: bool,
-    ) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
+    ) -> Result<impl Iterator<Item = Symbol>> {
         if force_generate || !self.tags_exists() {
             self.generate_tags()?;
         }
@@ -75,6 +75,6 @@ impl<'a, P: AsRef<Path> + Hash> CtagsSearcher<'a, P> {
 
         Ok(crate::utils::lines(cmd)?
             .flatten()
-            .filter_map(|s| UnifiedTagInfo::from_readtags(&s)))
+            .filter_map(|s| Symbol::from_readtags(&s)))
     }
 }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/gtags/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/gtags/mod.rs
@@ -3,7 +3,7 @@ use std::path::{PathBuf, MAIN_SEPARATOR};
 use anyhow::{anyhow, Result};
 use filter::subprocess::Exec;
 
-use super::UnifiedTagInfo;
+use super::Symbol;
 use crate::tools::gtags::GTAGS_DIR;
 
 #[derive(Clone, Debug)]
@@ -99,10 +99,7 @@ impl GtagsSearcher {
     }
 
     /// Search definition tags exactly matching `keyword`.
-    pub fn search_definitions(
-        &self,
-        keyword: &str,
-    ) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
+    pub fn search_definitions(&self, keyword: &str) -> Result<impl Iterator<Item = Symbol>> {
         let cmd = self
             .global()
             .cwd(&self.project_root)
@@ -116,7 +113,7 @@ impl GtagsSearcher {
     /// Search reference tags exactly matching `keyword`.
     ///
     /// Reference means the reference to a symbol which has definitions.
-    pub fn search_references(&self, keyword: &str) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
+    pub fn search_references(&self, keyword: &str) -> Result<impl Iterator<Item = Symbol>> {
         let cmd = self
             .global()
             .cwd(&self.project_root)
@@ -133,8 +130,8 @@ impl GtagsSearcher {
 }
 
 // Returns a stream of tag parsed from the gtags output.
-fn execute(cmd: Exec) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
+fn execute(cmd: Exec) -> Result<impl Iterator<Item = Symbol>> {
     Ok(crate::utils::lines(cmd)?
         .flatten()
-        .filter_map(|s| UnifiedTagInfo::from_gtags(&s)))
+        .filter_map(|s| Symbol::from_gtags(&s)))
 }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/gtags/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/gtags/mod.rs
@@ -3,7 +3,7 @@ use std::path::{PathBuf, MAIN_SEPARATOR};
 use anyhow::{anyhow, Result};
 use filter::subprocess::Exec;
 
-use super::TagInfo;
+use super::UnifiedTagInfo;
 use crate::tools::gtags::GTAGS_DIR;
 
 #[derive(Clone, Debug)]
@@ -99,7 +99,10 @@ impl GtagsSearcher {
     }
 
     /// Search definition tags exactly matching `keyword`.
-    pub fn search_definitions(&self, keyword: &str) -> Result<impl Iterator<Item = TagInfo>> {
+    pub fn search_definitions(
+        &self,
+        keyword: &str,
+    ) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
         let cmd = self
             .global()
             .cwd(&self.project_root)
@@ -113,7 +116,7 @@ impl GtagsSearcher {
     /// Search reference tags exactly matching `keyword`.
     ///
     /// Reference means the reference to a symbol which has definitions.
-    pub fn search_references(&self, keyword: &str) -> Result<impl Iterator<Item = TagInfo>> {
+    pub fn search_references(&self, keyword: &str) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
         let cmd = self
             .global()
             .cwd(&self.project_root)
@@ -130,8 +133,8 @@ impl GtagsSearcher {
 }
 
 // Returns a stream of tag parsed from the gtags output.
-fn execute(cmd: Exec) -> Result<impl Iterator<Item = TagInfo>> {
+fn execute(cmd: Exec) -> Result<impl Iterator<Item = UnifiedTagInfo>> {
     Ok(crate::utils::lines(cmd)?
         .flatten()
-        .filter_map(|s| TagInfo::from_gtags(&s)))
+        .filter_map(|s| UnifiedTagInfo::from_gtags(&s)))
 }

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/mod.rs
@@ -40,6 +40,7 @@ impl Default for QueryType {
 fn rs_kind_alias() -> HashMap<&'static str, &'static str> {
     vec![
         ("module", "mod"),
+        ("typedef", "type"),
         ("function", "fn"),
         ("interface", "trait"),
         ("enumerator", "enum"),
@@ -71,7 +72,7 @@ fn compact_kind(maybe_extension: Option<&str>, kind: &str) -> String {
 
 /// Parsed from `ctags` and `gtags` output.
 #[derive(Default, Debug)]
-pub struct TagInfo {
+pub struct UnifiedTagInfo {
     /// None for `gtags`.
     pub name: Option<String>,
     pub path: String,
@@ -83,7 +84,7 @@ pub struct TagInfo {
     pub scope: Option<String>,
 }
 
-impl TagInfo {
+impl UnifiedTagInfo {
     /// Parse from the output of `readtags`.
     ///
     /// TODO: add more tests

--- a/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/mod.rs
+++ b/crates/maple_cli/src/dumb_analyzer/find_usages/search_engine/mod.rs
@@ -70,21 +70,23 @@ fn compact_kind(maybe_extension: Option<&str>, kind: &str) -> String {
         .to_string()
 }
 
+/// Unified tag info.
+///
 /// Parsed from `ctags` and `gtags` output.
 #[derive(Default, Debug)]
-pub struct UnifiedTagInfo {
+pub struct Symbol {
     /// None for `gtags`.
     pub name: Option<String>,
     pub path: String,
     pub pattern: String,
-    pub line: usize,
+    pub line_number: usize,
     /// ctags only.
     pub kind: Option<String>,
     /// ctags only.
     pub scope: Option<String>,
 }
 
-impl UnifiedTagInfo {
+impl Symbol {
     /// Parse from the output of `readtags`.
     ///
     /// TODO: add more tests
@@ -137,7 +139,7 @@ impl UnifiedTagInfo {
                 match k {
                     "kind" => l.kind = Some(compact_kind(maybe_extension, v)),
                     "scope" => l.scope = Some(v.into()),
-                    "line" => l.line = v.parse().expect("line is an integer"),
+                    "line" => l.line_number = v.parse().expect("line is an integer"),
                     // Unused for now.
                     "language" | "roles" | "access" | "signature" => {}
                     unknown => {
@@ -154,7 +156,7 @@ impl UnifiedTagInfo {
         pattern::parse_gtags(s).map(|(line, path, pattern)| Self {
             path: path.into(),
             pattern: pattern.into(),
-            line,
+            line_number: line,
             ..Default::default()
         })
     }
@@ -166,7 +168,7 @@ impl UnifiedTagInfo {
         query: &str,
         ignorecase: bool,
     ) -> (String, Option<Vec<usize>>) {
-        let mut formatted = format!("[{}]{}:{}:1:", kind, self.path, self.line);
+        let mut formatted = format!("[{}]{}:{}:1:", kind, self.path, self.line_number);
 
         let found = if ignorecase {
             self.pattern.to_lowercase().find(&query.to_lowercase())
@@ -206,7 +208,7 @@ impl UnifiedTagInfo {
             line,
             indices,
             path: self.path,
-            line_number: self.line,
+            line_number: self.line_number,
         }
     }
 }

--- a/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump/searcher.rs
+++ b/crates/maple_cli/src/stdio_server/providers/custom/dumb_jump/searcher.rs
@@ -35,6 +35,7 @@ impl SearchingWorker {
             filtering_terms,
         } = self.query_info;
 
+        // TODO: reorder the ctags results similar to gtags.
         let usages = CtagsSearcher::new(tags_config)
             .search(&keyword, query_type, true)?
             .sorted_by_key(|t| t.line) // Ensure the tags are sorted as the definition goes first and then the implementations.

--- a/crates/maple_cli/src/tools/ripgrep/mod.rs
+++ b/crates/maple_cli/src/tools/ripgrep/mod.rs
@@ -108,7 +108,7 @@ impl Match {
 }
 
 impl TryFrom<&[u8]> for Match {
-    type Error = String;
+    type Error = Cow<'static, str>;
     fn try_from(byte_line: &[u8]) -> Result<Self, Self::Error> {
         let msg = serde_json::from_slice::<Message>(byte_line)
             .map_err(|e| format!("deserialize error: {:?}", e))?;
@@ -121,7 +121,7 @@ impl TryFrom<&[u8]> for Match {
 }
 
 impl TryFrom<&str> for Match {
-    type Error = String;
+    type Error = Cow<'static, str>;
     fn try_from(line: &str) -> Result<Self, Self::Error> {
         let msg = serde_json::from_str::<Message>(line)
             .map_err(|e| format!("deserialize error: {:?}", e))?;

--- a/crates/pattern/src/lib.rs
+++ b/crates/pattern/src/lib.rs
@@ -12,7 +12,7 @@ static DUMB_JUMP_LINE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^\[(.*)\](.*?):(\d+):(\d+):").unwrap());
 
 // match the file path and line number of grep line.
-static GREP_STRIP_FPATH: Lazy<Regex> = Lazy::new(|| Regex::new(r"^.*:\d+:\d+:").unwrap());
+static GREP_STRIP_FPATH: Lazy<Regex> = Lazy::new(|| Regex::new(r"^.*?:\d+:\d+:").unwrap());
 
 // match the tag_name:lnum of tag line.
 static TAG_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(.*:\d+)").unwrap());
@@ -52,7 +52,7 @@ pub fn tag_name_only(line: &str) -> Option<&str> {
 /// //                                |
 /// //                             offset
 #[inline]
-pub fn strip_grep_filepath(line: &str) -> Option<(&str, usize)> {
+pub fn extract_grep_pattern(line: &str) -> Option<(&str, usize)> {
     GREP_STRIP_FPATH
         .find(line)
         .map(|mat| (&line[mat.end()..], mat.end()))
@@ -252,5 +252,17 @@ mod tests {
                 "pub async fn run(self) -> Result<()> {"
             ))
         )
+    }
+
+    #[test]
+    fn test_strip_grep_filepath() {
+        let line = r#"crates/pattern/src/lib.rs:51:1:/// // crates/printer/src/lib.rs:199:26:        let query = "srlisrlisrsr";"#;
+        assert_eq!(
+            extract_grep_pattern(line).unwrap(),
+            (
+                "/// // crates/printer/src/lib.rs:199:26:        let query = \"srlisrlisrsr\";",
+                31
+            )
+        );
     }
 }

--- a/crates/types/src/search_term.rs
+++ b/crates/types/src/search_term.rs
@@ -117,6 +117,10 @@ impl FuzzyTerm {
     pub fn len(&self) -> usize {
         self.word.len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.word.is_empty()
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/crates/types/src/source_item.rs
+++ b/crates/types/src/source_item.rs
@@ -1,4 +1,4 @@
-use pattern::{find_file_name, strip_grep_filepath, tag_name_only};
+use pattern::{find_file_name, extract_grep_pattern, tag_name_only};
 
 /// A tuple of match text piece (matching_text, offset_of_matching_text).
 pub type FuzzyText<'a> = (&'a str, usize);
@@ -134,7 +134,7 @@ impl SourceItem {
             MatchingTextKind::Full => Some((&self.raw, 0)),
             MatchingTextKind::TagName => tag_name_only(self.raw.as_str()).map(|s| (s, 0)),
             MatchingTextKind::FileName => find_file_name(self.raw.as_str()),
-            MatchingTextKind::IgnoreFilePath => strip_grep_filepath(self.raw.as_str()),
+            MatchingTextKind::IgnoreFilePath => extract_grep_pattern(self.raw.as_str()),
         }
     }
 }

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -538,6 +538,20 @@ g:clap_builtin_fuzzy_filter_threshold     *g:clap_builtin_fuzzy_filter_threshold
   let g:clap_builtin_fuzzy_filter_threshold = 0
 <
 
+g:clap_cache_threshold                                   *g:clap_cache_threshold*
+
+  Type: |Number|
+  Default: `100000`
+
+  When the number of execution results of some command exceeds this variable,
+  the output will be wrote to a cache file, which will be reused next time
+  when you invoke the same command against the same directory.
+
+  If you want to run the command without using the cache or want to rebuild
+  the cache, append `!` to the provider argument in `:Clap` command, e.g.,
+  `:Clap files!` .
+
+
 g:clap_preview_size                                         *g:clap_preview_size*
 
   Type: |Number| or |Dict|

--- a/syntax/clap_grep.vim
+++ b/syntax/clap_grep.vim
@@ -8,12 +8,13 @@ syntax match ClapLinNrColumn /\zs:\d\+:\d\+:\ze/ contains=ClapLinNr,ClapColumn c
 " Not sure why this icon somehow are unable to be highlighted in clap#icon#add_head_hl_groups()
 syntax match ClapIconUnknown /^\s*/
 
-execute 'syntax match ClapFpath' '/^.*:\d\+:\d\+:/' 'contains=ClapLinNrColumn,'.join(clap#icon#add_head_hl_groups(), ',')
-execute 'syntax match ClapFpathTruncated' '/^.*\.\..*:\d\+:\d\+:/' 'contains=ClapLinNrColumn,'.join(clap#icon#add_head_hl_groups(), ',').',ClapFpathDots'
+execute 'syntax match ClapFpath' '/^.\{-}:\d\+:\d\+:/' 'contains=ClapLinNrColumn,'.join(clap#icon#add_head_hl_groups(), ',')
+execute 'syntax match ClapFpathTruncated' '/^.\.\..\{-}:\d\+:\d\+:/' 'contains=ClapLinNrColumn,'.join(clap#icon#add_head_hl_groups(), ',').',ClapFpathDots'
 syntax match ClapFpathDots '\.\.' contained
 
 hi default link ClapFpath            Keyword
 hi default link ClapFpathTruncated   Keyword
+hi default link ClapFpathTruncatedFull   Keyword
 hi default link ClapLinNr            LineNr
 hi default link ClapColumn           Comment
 hi default link ClapLinNrColumn      Type

--- a/syntax/clap_grep.vim
+++ b/syntax/clap_grep.vim
@@ -14,7 +14,6 @@ syntax match ClapFpathDots '\.\.' contained
 
 hi default link ClapFpath            Keyword
 hi default link ClapFpathTruncated   Keyword
-hi default link ClapFpathTruncatedFull   Keyword
 hi default link ClapLinNr            LineNr
 hi default link ClapColumn           Comment
 hi default link ClapLinNrColumn      Type


### PR DESCRIPTION
Use a dedicated variable `g:clap_cache_threshold` for the command execution cache threshold instead of binding it to `g:clap_builtin_fuzzy_filter_threshold`.