### PR TITLE
Refactor the language keyword weight

### DIFF
--- a/autoload/clap/provider/grep.vim
+++ b/autoload/clap/provider/grep.vim
@@ -243,7 +243,7 @@ endfunction
 
 function! s:grep_sink_star(lines) abort
   call s:grep_exit()
-  let pattern = '\(.*\):\(\d\+\):\(\d\+\):\(.*\)'
+  let pattern = '\(.\{-}\):\(\d\+\):\(\d\+\):\(.*\)'
   call clap#util#open_quickfix(map(a:lines, 's:into_qf_item(v:val, pattern)'))
 endfunction
 

--- a/crates/dumb_analyzer/src/keywords/erlang.rs
+++ b/crates/dumb_analyzer/src/keywords/erlang.rs
@@ -1,9 +1,11 @@
-const DEFINITION: &[&str] = &["function", "functioin!", "command", "command!", "cmd"];
+const DEFINITION: &[&str] = &["fun"];
 
-const REFERENCE: &[&str] = &["let"];
+const REFERENCE: &[&str] = &[];
 
 const STATEMENT: &[&str] = &[
-    "for", "endfor", "while", "endwhile", "if", "elseif", "else", "endif", "call", "in",
+    "after", "and", "andalso", "band", "begin", "bnot", "bor", "bsl", "bsr", "bxor", "case",
+    "catch", "cond", "div", "end", "if", "let", "not", "of", "or", "orelse", "receive", "rem",
+    "try", "when", "xor",
 ];
 
 pub fn token_weight(token: &str) -> Option<usize> {

--- a/crates/dumb_analyzer/src/keywords/go.rs
+++ b/crates/dumb_analyzer/src/keywords/go.rs
@@ -1,0 +1,44 @@
+const DEFINITION: &[&str] = &[
+    "enum",
+    "interface",
+    "struct",
+    "func",
+    "const",
+    "type",
+    "package",
+];
+
+const REFERENCE: &[&str] = &["import"];
+
+const STATEMENT: &[&str] = &[
+    "break",
+    "case",
+    "chan",
+    "continue",
+    "default",
+    "defer",
+    "else",
+    "fallthrough",
+    "for",
+    "go",
+    "goto",
+    "if",
+    "map",
+    "range",
+    "return",
+    "select",
+    "switch",
+    "var",
+];
+
+pub fn token_weight(token: &str) -> Option<usize> {
+    if DEFINITION.contains(&token) {
+        Some(4)
+    } else if REFERENCE.contains(&token) {
+        Some(6)
+    } else if STATEMENT.contains(&token) {
+        Some(8)
+    } else {
+        None
+    }
+}

--- a/crates/dumb_analyzer/src/keywords/mod.rs
+++ b/crates/dumb_analyzer/src/keywords/mod.rs
@@ -1,2 +1,4 @@
+pub mod erlang;
+pub mod go;
 pub mod rust;
 pub mod viml;

--- a/crates/dumb_analyzer/src/keywords/mod.rs
+++ b/crates/dumb_analyzer/src/keywords/mod.rs
@@ -1,0 +1,2 @@
+pub mod rust;
+pub mod viml;

--- a/crates/dumb_analyzer/src/keywords/rust.rs
+++ b/crates/dumb_analyzer/src/keywords/rust.rs
@@ -1,0 +1,21 @@
+const TYPE: &[&str] = &["type", "mod", "impl"];
+const FUNCTION: &[&str] = &["fn", "macro_rules"];
+const VARIABLE: &[&str] = &["let", "const", "static", "enum", "struct", "trait"];
+
+pub fn pattern_weight(item: Option<&str>) -> Option<usize> {
+    item.and_then(|s| {
+        if FUNCTION.contains(&s) {
+            Some(4)
+        } else if s.starts_with("pub") {
+            Some(6)
+        } else if TYPE.contains(&s) {
+            Some(7)
+        } else if VARIABLE.contains(&s) {
+            Some(8)
+        } else if s.starts_with("[cfg(feature") {
+            Some(10)
+        } else {
+            None
+        }
+    })
+}

--- a/crates/dumb_analyzer/src/keywords/rust.rs
+++ b/crates/dumb_analyzer/src/keywords/rust.rs
@@ -10,7 +10,7 @@ const STATEMENT: &[&str] = &[
     "type", "unsafe", "where", "while",
 ];
 
-pub fn pattern_weighttoken(token: &str) -> Option<usize> {
+pub fn token_weight(token: &str) -> Option<usize> {
     if DEFINITION.contains(&token) {
         Some(4)
     } else if REFERENCE.contains(&token) {

--- a/crates/dumb_analyzer/src/keywords/rust.rs
+++ b/crates/dumb_analyzer/src/keywords/rust.rs
@@ -2,20 +2,18 @@ const TYPE: &[&str] = &["type", "mod", "impl"];
 const FUNCTION: &[&str] = &["fn", "macro_rules"];
 const VARIABLE: &[&str] = &["let", "const", "static", "enum", "struct", "trait"];
 
-pub fn pattern_weight(item: Option<&str>) -> Option<usize> {
-    item.and_then(|s| {
-        if FUNCTION.contains(&s) {
-            Some(4)
-        } else if s.starts_with("pub") {
-            Some(6)
-        } else if TYPE.contains(&s) {
-            Some(7)
-        } else if VARIABLE.contains(&s) {
-            Some(8)
-        } else if s.starts_with("[cfg(feature") {
-            Some(10)
-        } else {
-            None
-        }
-    })
+pub fn pattern_weight(token: &str) -> Option<usize> {
+    if FUNCTION.contains(&token) {
+        Some(4)
+    } else if token.starts_with("pub") {
+        Some(6)
+    } else if TYPE.contains(&token) {
+        Some(7)
+    } else if VARIABLE.contains(&token) {
+        Some(8)
+    } else if token.starts_with("[cfg(feature") {
+        Some(10)
+    } else {
+        None
+    }
 }

--- a/crates/dumb_analyzer/src/keywords/rust.rs
+++ b/crates/dumb_analyzer/src/keywords/rust.rs
@@ -1,17 +1,25 @@
-const TYPE: &[&str] = &["type", "mod", "impl"];
-const FUNCTION: &[&str] = &["fn", "macro_rules"];
-const VARIABLE: &[&str] = &["let", "const", "static", "enum", "struct", "trait"];
+const DEFINITION: &[&str] = &[
+    "enum", "trait", "struct", "fn", "const", "static", "crate", "mod",
+];
 
-pub fn pattern_weight(token: &str) -> Option<usize> {
-    if FUNCTION.contains(&token) {
+const REFERENCE: &[&str] = &["use", "impl", "let"];
+
+const STATEMENT: &[&str] = &[
+    "as", "break", "continue", "else", "extern", "false", "for", "if", "impl", "in", "let", "loop",
+    "match", "move", "mut", "pub", "ref", "return", "self", "Self", "static", "super", "true",
+    "type", "unsafe", "where", "while",
+];
+
+pub fn pattern_weighttoken(token: &str) -> Option<usize> {
+    if DEFINITION.contains(&token) {
         Some(4)
-    } else if token.starts_with("pub") {
+    } else if REFERENCE.contains(&token) {
         Some(6)
-    } else if TYPE.contains(&token) {
+    } else if token.starts_with("pub") {
         Some(7)
-    } else if VARIABLE.contains(&token) {
+    } else if STATEMENT.contains(&token) {
         Some(8)
-    } else if token.starts_with("[cfg(feature") {
+    } else if token.starts_with("[cfg") {
         Some(10)
     } else {
         None

--- a/crates/dumb_analyzer/src/keywords/viml.rs
+++ b/crates/dumb_analyzer/src/keywords/viml.rs
@@ -1,4 +1,4 @@
-pub fn pattern_weight(token: &str) -> Option<usize> {
+pub fn token_weight(token: &str) -> Option<usize> {
     // function[!]
     if token.starts_with("function") {
         Some(3)

--- a/crates/dumb_analyzer/src/keywords/viml.rs
+++ b/crates/dumb_analyzer/src/keywords/viml.rs
@@ -1,12 +1,10 @@
-pub fn pattern_weight(item: Option<&str>) -> Option<usize> {
-    item.and_then(|s| {
-        // function[!]
-        if s.starts_with("function") {
-            Some(3)
-        } else if s == "let" {
-            Some(6)
-        } else {
-            None
-        }
-    })
+pub fn pattern_weight(token: &str) -> Option<usize> {
+    // function[!]
+    if token.starts_with("function") {
+        Some(3)
+    } else if token == "let" {
+        Some(6)
+    } else {
+        None
+    }
 }

--- a/crates/dumb_analyzer/src/keywords/viml.rs
+++ b/crates/dumb_analyzer/src/keywords/viml.rs
@@ -1,0 +1,12 @@
+pub fn pattern_weight(item: Option<&str>) -> Option<usize> {
+    item.and_then(|s| {
+        // function[!]
+        if s.starts_with("function") {
+            Some(3)
+        } else if s == "let" {
+            Some(6)
+        } else {
+            None
+        }
+    })
+}

--- a/crates/dumb_analyzer/src/lib.rs
+++ b/crates/dumb_analyzer/src/lib.rs
@@ -4,6 +4,8 @@ use std::collections::HashMap;
 
 use once_cell::sync::OnceCell;
 
+mod keywords;
+
 /// General weight for fine-grained resolved result.
 ///
 /// Lower is better, the better results will be displayed first.
@@ -112,51 +114,9 @@ fn calculate_weight(
 pub fn calculate_pattern_weight(pattern: impl AsRef<str>, file_ext: &str) -> Option<Weight> {
     let trimmed = pattern.as_ref().trim_start();
 
-    // TODO: take care of the comment line universally.
     match file_ext {
-        "vim" => {
-            let weight_fn = |item: Option<&str>| {
-                item.and_then(|s| {
-                    // function[!]
-                    if s.starts_with("function") {
-                        Some(3)
-                    } else if s == "let" {
-                        Some(6)
-                    } else {
-                        None
-                    }
-                })
-            };
-
-            calculate_weight(trimmed, weight_fn)
-        }
-
-        "rs" => {
-            const TYPE: &[&str] = &["type", "mod", "impl"];
-            const FUNCTION: &[&str] = &["fn", "macro_rules"];
-            const VARIABLE: &[&str] = &["let", "const", "static", "enum", "struct", "trait"];
-
-            let weight_fn = |item: Option<&str>| {
-                item.and_then(|s| {
-                    if FUNCTION.contains(&s) {
-                        Some(4)
-                    } else if s.starts_with("pub") {
-                        Some(6)
-                    } else if TYPE.contains(&s) {
-                        Some(7)
-                    } else if VARIABLE.contains(&s) {
-                        Some(8)
-                    } else if s.starts_with("[cfg(feature") {
-                        Some(10)
-                    } else {
-                        None
-                    }
-                })
-            };
-
-            calculate_weight(trimmed, weight_fn)
-        }
-
+        "vim" => calculate_weight(trimmed, keywords::viml::pattern_weight),
+        "rs" => calculate_weight(trimmed, keywords::rust::pattern_weight),
         _ => None,
     }
 }

--- a/crates/dumb_analyzer/src/lib.rs
+++ b/crates/dumb_analyzer/src/lib.rs
@@ -95,6 +95,8 @@ pub fn calculate_pattern_weight(pattern: impl AsRef<str>, file_ext: &str) -> Opt
     let weight_fn = match file_ext {
         "vim" => keywords::viml::token_weight,
         "rs" => keywords::rust::token_weight,
+        "go" => keywords::go::token_weight,
+        "erl" => keywords::erlang::token_weight,
         _ => return None,
     };
 

--- a/crates/dumb_analyzer/src/lib.rs
+++ b/crates/dumb_analyzer/src/lib.rs
@@ -93,8 +93,8 @@ pub fn resolve_reference_kind(pattern: impl AsRef<str>, file_ext: &str) -> (&'st
 /// Calculates the weight of a specific pattern.
 pub fn calculate_pattern_weight(pattern: impl AsRef<str>, file_ext: &str) -> Option<Weight> {
     let weight_fn = match file_ext {
-        "vim" => keywords::viml::pattern_weight,
-        "rs" => keywords::rust::pattern_weight,
+        "vim" => keywords::viml::token_weight,
+        "rs" => keywords::rust::token_weight,
         _ => return None,
     };
 


### PR DESCRIPTION
A heuristic method using the language keyword matching to tweak the basic matching score of line, e.g., the lines that are probably function definition are preferred than the other plain ones.