### PR TITLE
Redirect command output to file when creating the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [unreleased]
 
+## Improved
+
+- Speed up the cache creation signigicantly. #858
+
 ## Changed
 
 - The spinner will be hidden if it's idle.

--- a/autoload/clap/maple/command.vim
+++ b/autoload/clap/maple/command.vim
@@ -61,12 +61,12 @@ function! clap#maple#command#ripgrep_forerunner() abort
   return [s:maple_bin] + global_opts + subcommand
 endfunction
 
-function! clap#maple#command#exec_forerunner(cmd) abort
+function! clap#maple#command#exec_forerunner(shell_cmd) abort
   " No global --number option.
   let global_opts = s:prepare_global_opts(v:null)
 
   let subcommand = [
-        \ 'exec', a:cmd,
+        \ 'exec', a:shell_cmd,
         \ '--cmd-dir', clap#rooter#working_dir(),
         \ '--output-threshold', s:cache_threshold,
         \ ]

--- a/crates/icon/src/lib.rs
+++ b/crates/icon/src/lib.rs
@@ -93,6 +93,13 @@ impl<T: AsRef<str>> From<T> for IconKind {
 
 impl IconKind {
     /// Returns a `String` of raw str with icon added.
+    pub fn add_icon_to_text<S: AsRef<str>>(&self, text: S) -> String {
+        let text = text.as_ref();
+        let icon = self.icon(text);
+        format!("{icon} {text}")
+    }
+
+    /// Returns a `String` of raw str with icon added.
     pub fn paint<S: AsRef<str>>(&self, raw_str: S) -> String {
         let fmt = |s| format!("{} {}", s, raw_str.as_ref());
         match *self {

--- a/crates/maple_cli/src/cache/mod.rs
+++ b/crates/maple_cli/src/cache/mod.rs
@@ -191,3 +191,16 @@ pub fn find_largest_cache_digest() -> Option<Digest> {
     digests.sort_unstable_by_key(|digest| digest.total);
     digests.last().cloned()
 }
+
+pub fn store_cache_digest(base_cmd: BaseCommand, new_created_cache: PathBuf) -> Result<Digest> {
+    // TODO: mmap should be faster.
+    let total = crate::utils::count_lines(std::fs::File::open(&new_created_cache)?)?;
+
+    let digest = Digest::new(base_cmd, total, new_created_cache);
+
+    let cache_info = crate::datastore::CACHE_INFO_IN_MEMORY.clone();
+    let mut cache_info = cache_info.lock();
+    cache_info.limited_push(digest.clone())?;
+
+    Ok(digest)
+}

--- a/crates/maple_cli/src/command/ctags/buffer_tags.rs
+++ b/crates/maple_cli/src/command/ctags/buffer_tags.rs
@@ -97,19 +97,24 @@ fn subprocess_cmd_in_raw_format(file: impl AsRef<std::ffi::OsStr>) -> Subprocess
 }
 
 fn tokio_cmd_in_json_format(file: &Path) -> TokioCommand {
-    let mut cmd = crate::process::tokio::build_command(format!(
-        "ctags --fields=+n --output-format=json {}",
-        file.display()
-    ));
-    cmd.stderr(Stdio::null());
-    cmd
+    let mut tokio_cmd = TokioCommand::new("ctags");
+    tokio_cmd
+        .stderr(Stdio::null())
+        .arg("--fields=+n")
+        .arg("--output-format=json")
+        .arg(file);
+    tokio_cmd
 }
 
 fn tokio_cmd_in_raw_format(file: &Path) -> TokioCommand {
-    let mut cmd =
-        crate::process::tokio::build_command(format!("ctags --fields=+Kn -f - {}", file.display()));
-    cmd.stderr(Stdio::null());
-    cmd
+    let mut tokio_cmd = TokioCommand::new("ctags");
+    tokio_cmd
+        .stderr(Stdio::null())
+        .arg("--fields=+Kn")
+        .arg("-f")
+        .arg("-")
+        .arg(file);
+    tokio_cmd
 }
 
 fn find_context_tag(superset_tags: Vec<BufferTagInfo>, at: usize) -> Option<BufferTagInfo> {

--- a/crates/maple_cli/src/command/exec.rs
+++ b/crates/maple_cli/src/command/exec.rs
@@ -14,7 +14,7 @@ use crate::process::BaseCommand;
 pub struct Exec {
     /// Specify the system command to run.
     #[clap(index = 1, long)]
-    cmd: String,
+    shell_cmd: String,
 
     /// Specify the working directory of CMD
     #[clap(long, parse(from_os_str))]
@@ -28,7 +28,7 @@ pub struct Exec {
 impl Exec {
     // This can work with the piped command, e.g., git ls-files | uniq.
     fn prepare_exec_cmd(&self) -> Command {
-        let mut cmd = StdCommand::from(self.cmd.as_str());
+        let mut cmd = StdCommand::new(self.shell_cmd.as_str());
 
         if let Some(ref cmd_dir) = self.cmd_dir {
             cmd.current_dir(cmd_dir);
@@ -70,7 +70,7 @@ impl Exec {
             None => std::env::current_dir()?,
         };
 
-        let base_cmd = BaseCommand::new(self.cmd.clone(), cwd);
+        let base_cmd = BaseCommand::new(self.shell_cmd.clone(), cwd);
 
         light_cmd.try_cache_or_execute(base_cmd, no_cache)?.print();
 

--- a/crates/maple_cli/src/process/mod.rs
+++ b/crates/maple_cli/src/process/mod.rs
@@ -83,6 +83,11 @@ impl BaseCommand {
         Ok(stdout_stream)
     }
 
+    pub fn cache_file_path(&self) -> std::io::Result<PathBuf> {
+        let cached_filename = utility::calculate_hash(self);
+        crate::utils::generate_cache_file_path(cached_filename.to_string())
+    }
+
     /// Writes the whole stdout `cmd_stdout` to a cache file.
     fn write_stdout_to_disk(&self, cmd_stdout: &[u8]) -> Result<PathBuf> {
         use std::io::Write;

--- a/crates/maple_cli/src/process/rstd.rs
+++ b/crates/maple_cli/src/process/rstd.rs
@@ -3,18 +3,28 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Collect the output of command, exit directly if any error happened.
-pub fn collect_stdout(cmd: &mut Command) -> std::io::Result<Vec<u8>> {
-    let cmd_output = cmd.output()?;
-
-    if !cmd_output.status.success() && !cmd_output.stderr.is_empty() {
-        return Err(std::io::Error::new(
+/// Executes the command and redirects the output to a file.
+pub fn write_stdout_to_file<P: AsRef<Path>>(
+    cmd: &mut Command,
+    output_file: P,
+) -> std::io::Result<()> {
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(output_file)?;
+    let exit_status = cmd.stdout(file).spawn()?.wait()?;
+    if exit_status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
             std::io::ErrorKind::Other,
-            String::from_utf8_lossy(&cmd_output.stderr),
-        ));
+            format!(
+                "Failed to execute the command: {cmd:?}, exit code: {:?}",
+                exit_status.code()
+            ),
+        ))
     }
-
-    Ok(cmd_output.stdout)
 }
 
 /// Builds [`std::process::Command`] from a cmd string which can use pipe.
@@ -69,9 +79,18 @@ impl StdCommand {
         super::process_output(output)
     }
 
-    /// Returns the stdout of inner command.
+    /// Returns the stdout of command, exit directly if any error happened.
     pub fn stdout(&mut self) -> std::io::Result<Vec<u8>> {
-        collect_stdout(&mut self.0)
+        let cmd_output = self.0.output()?;
+
+        if !cmd_output.status.success() && !cmd_output.stderr.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                String::from_utf8_lossy(&cmd_output.stderr),
+            ));
+        }
+
+        Ok(cmd_output.stdout)
     }
 
     #[allow(unused)]

--- a/crates/maple_cli/src/process/rstd.rs
+++ b/crates/maple_cli/src/process/rstd.rs
@@ -27,10 +27,12 @@ pub fn write_stdout_to_file<P: AsRef<Path>>(
     }
 }
 
+// TODO: make it configurable so that it can support powershell easier?
+// https://github.com/liuchengxu/vim-clap/issues/640
 /// Builds [`std::process::Command`] from a cmd string which can use pipe.
 ///
 /// This can work with the piped command, e.g., `git ls-files | uniq`.
-fn build_command(shell_cmd: &str) -> Command {
+fn shell_command(shell_cmd: &str) -> Command {
     if cfg!(target_os = "windows") {
         let mut cmd = Command::new("cmd");
         cmd.args(&["/C", shell_cmd]);
@@ -46,16 +48,16 @@ fn build_command(shell_cmd: &str) -> Command {
 #[derive(Debug)]
 pub struct StdCommand(Command);
 
-impl<T: AsRef<str>> From<T> for StdCommand {
-    fn from(cmd: T) -> Self {
-        Self(build_command(cmd.as_ref()))
+impl From<Command> for StdCommand {
+    fn from(cmd: Command) -> Self {
+        Self(cmd)
     }
 }
 
 impl StdCommand {
     /// Constructs a new [`StdCommand`].
-    pub fn new(cmd: impl AsRef<str>) -> Self {
-        cmd.as_ref().into()
+    pub fn new(shell_cmd: impl AsRef<str>) -> Self {
+        Self(shell_command(shell_cmd.as_ref()))
     }
 
     /// Sets the working directory for the inner `Command`.

--- a/crates/maple_cli/src/process/tokio.rs
+++ b/crates/maple_cli/src/process/tokio.rs
@@ -7,7 +7,7 @@ use tokio::process::Command;
 /// Builds `Command` from a cmd string which can use pipe.
 ///
 /// This can work with the piped command, e.g., `git ls-files | uniq`.
-pub fn build_command(shell_cmd: impl AsRef<str>) -> Command {
+pub fn shell_command(shell_cmd: impl AsRef<str>) -> Command {
     if cfg!(target_os = "windows") {
         let mut cmd = Command::new("cmd");
         cmd.args(&["/C", shell_cmd.as_ref()]);
@@ -23,16 +23,16 @@ pub fn build_command(shell_cmd: impl AsRef<str>) -> Command {
 #[derive(Debug)]
 pub struct TokioCommand(Command);
 
-impl<T: AsRef<str>> From<T> for TokioCommand {
-    fn from(cmd: T) -> Self {
-        Self(build_command(cmd))
+impl From<Command> for TokioCommand {
+    fn from(cmd: Command) -> Self {
+        Self(cmd)
     }
 }
 
 impl TokioCommand {
     /// Constructs a new instance of [`TokioCommand`].
-    pub fn new(cmd: impl AsRef<str>) -> Self {
-        cmd.into()
+    pub fn new(shell_cmd: impl AsRef<str>) -> Self {
+        Self(shell_command(shell_cmd))
     }
 
     pub async fn lines(&mut self) -> std::io::Result<Vec<String>> {

--- a/crates/maple_cli/src/process/tokio.rs
+++ b/crates/maple_cli/src/process/tokio.rs
@@ -61,15 +61,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_tokio_command() {
-        let mut tokio_cmd: TokioCommand = format!(
+        let shell_cmd = format!(
             "ls {}",
             std::env::current_dir()
                 .unwrap()
                 .into_os_string()
                 .into_string()
                 .unwrap()
-        )
-        .into();
+        );
+        let mut tokio_cmd = TokioCommand::new(shell_cmd);
         assert_eq!(
             vec!["Cargo.toml", "benches", "src"]
                 .into_iter()

--- a/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
+++ b/crates/maple_cli/src/stdio_server/providers/builtin/mod.rs
@@ -9,7 +9,7 @@ use parking_lot::Mutex;
 use serde_json::json;
 
 use crate::command::ctags::recursive_tags::build_recursive_ctags_cmd;
-use crate::command::grep::RgBaseCommand;
+use crate::command::grep::RgTokioCommand;
 use crate::process::tokio::TokioCommand;
 use crate::stdio_server::session::{EventHandle, SessionContext, SourceScale};
 use crate::stdio_server::{write_response, MethodCall};
@@ -179,7 +179,7 @@ pub async fn on_session_create(context: Arc<SessionContext>) -> Result<SourceSca
             return Ok(scale);
         }
         "grep2" => {
-            let rg_cmd = RgBaseCommand::new(context.cwd.to_path_buf());
+            let rg_cmd = RgTokioCommand::new(context.cwd.to_path_buf());
             let (total, path) = if context.no_cache {
                 rg_cmd.create_cache().await?
             } else {

--- a/crates/maple_cli/src/stdio_server/session/mod.rs
+++ b/crates/maple_cli/src/stdio_server/session/mod.rs
@@ -80,7 +80,7 @@ pub trait EventHandle: Send + Sync + 'static {
                 match context.provider_id.as_str() {
                     "grep" | "grep2" => {
                         let rg_cmd =
-                            crate::command::grep::RgBaseCommand::new(context.cwd.to_path_buf());
+                            crate::command::grep::RgTokioCommand::new(context.cwd.to_path_buf());
                         let job_id = utility::calculate_hash(&rg_cmd.inner);
                         spawn_singleton_job(
                             async move {


### PR DESCRIPTION
It's much more efficient to redirect the output to a file when creating the cache.

```Bash
# Before, the number of total items for this cache is 8079019 (`maple cache list` can display the cache info)
~/.../plugged/vim-clap ❯❯❯ time ./target/release/maple grep foo --cmd-dir /Users/xuliucheng/src/github.com/subspace/subspace --refresh-cache
Recreating the grep cache for /Users/xuliucheng/src/github.com/subspace/subspace

real    3m31.732s
user    3m35.523s
sys     0m12.804s

# After
~/.../plugged/vim-clap ❯❯❯ time ./target/release/maple grep foo --cmd-dir /Users/xuliucheng/src/github.com/subspace/subspace --refresh-cache
Recreating the grep cache for /Users/xuliucheng/src/github.com/subspace/subspace

real	0m32.364s
user	0m35.097s
sys	0m2.531s
```

