### PR TITLE
Improve the window layout of `buffers` provider

### DIFF
--- a/autoload/clap/provider/buffers.vim
+++ b/autoload/clap/provider/buffers.vim
@@ -16,8 +16,8 @@ function! s:padding(origin, target_width) abort
 endfunction
 
 function! s:format_buffer(b) abort
-  let fullpath = bufname(a:b)
-  let fullpath = empty(fullpath) ? '[No Name]' : fnamemodify(fullpath, ':p:~:.')
+  let buffer_name = bufname(a:b)
+  let fullpath = empty(buffer_name) ? '[No Name]' : fnamemodify(buffer_name, ':p:~:.')
   let filename = empty(fullpath) ? '[No Name]' : fnamemodify(fullpath, ':t')
   let flag = a:b == bufnr('')  ? '%' : (a:b == bufnr('#') ? '#' : ' ')
   let modified = getbufvar(a:b, '&modified') ? ' [+]' : ''

--- a/autoload/clap/provider/buffers.vim
+++ b/autoload/clap/provider/buffers.vim
@@ -30,7 +30,7 @@ function! s:format_buffer(b) abort
   let extra = join(filter([modified, readonly], '!empty(v:val)'), '')
   let line = s:padding(get(s:line_info, a:b, ''), 10)
 
-  return trim(printf('%s %s %s %s %s %s %s %s', filename, bp, fsize, icon, line, fullpath, flag, extra))
+  return trim(printf('%s %s %s %s %s %s %s %s', bp, filename, fsize, icon, line, fullpath, flag, extra))
 endfunction
 
 function! s:buffers() abort

--- a/autoload/clap/provider/buffers.vim
+++ b/autoload/clap/provider/buffers.vim
@@ -16,19 +16,21 @@ function! s:padding(origin, target_width) abort
 endfunction
 
 function! s:format_buffer(b) abort
-  let name = bufname(a:b)
-  let name = empty(name) ? '[No Name]' : fnamemodify(name, ':p:~:.')
+  let fullpath = bufname(a:b)
+  let fullpath = empty(fullpath) ? '[No Name]' : fnamemodify(fullpath, ':p:~:.')
+  let filename = empty(fullpath) ? '[No Name]' : fnamemodify(fullpath, ':t')
   let flag = a:b == bufnr('')  ? '%' : (a:b == bufnr('#') ? '#' : ' ')
   let modified = getbufvar(a:b, '&modified') ? ' [+]' : ''
   let readonly = getbufvar(a:b, '&modifiable') ? '' : ' [RO]'
 
+  let filename = s:padding(filename, 25)
   let bp = s:padding('['.a:b.']', 5)
-  let fsize = s:padding(clap#util#getfsize(name), 6)
-  let icon = g:clap_enable_icon ? s:padding(clap#icon#for(name), 3) : ''
+  let fsize = s:padding(clap#util#getfsize(fullpath), 6)
+  let icon = g:clap_enable_icon ? s:padding(clap#icon#for(fullpath), 3) : ''
   let extra = join(filter([modified, readonly], '!empty(v:val)'), '')
   let line = s:padding(get(s:line_info, a:b, ''), 10)
 
-  return trim(printf('%s %s %s %s %s %s %s', bp, fsize, icon, line, name, flag, extra))
+  return trim(printf('%s %s %s %s %s %s %s %s', filename, bp, fsize, icon, line, fullpath, flag, extra))
 endfunction
 
 function! s:buffers() abort


### PR DESCRIPTION
Now the layout is in order from left to right: filename with extension, buffer, file size, icon, current line in buffer, full path, flag and extra.
An example here:
![image](https://user-images.githubusercontent.com/17099856/209087494-1d8aa0df-c691-41ab-8c29-de96f7c4ccef.png)

Close #897
