### PR TITLE
Update document after renaming a function

### DIFF
--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -924,8 +924,8 @@ Change default keybindings                      *change-clap-default-keybindings
   `clap_input`, e.g,
   >
   " For example, use <C-n>/<C-p> instead of <C-j>/<C-k> to navigate the result.
-  autocmd FileType clap_input inoremap <silent> <buffer> <C-n> <C-R>=clap#navigation#linewise('down')<CR>
-  autocmd FileType clap_input inoremap <silent> <buffer> <C-p> <C-R>=clap#navigation#linewise('up')<CR>
+  autocmd FileType clap_input inoremap <silent> <buffer> <C-n> <C-R>=clap#navigation#linewise_scroll('down')<CR>
+  autocmd FileType clap_input inoremap <silent> <buffer> <C-p> <C-R>=clap#navigation#linewise_scroll('up')<CR>
 <
   For Vim, please use |g:clap_popup_move_manager|.
   >


### PR DESCRIPTION
Since https://github.com/liuchengxu/vim-clap/commit/0d630e4aa23315c086e858c1a41ff40e082d0fe7, `clap#navigation#linewise` is unavailable anymore