### PR TITLE
Add tagfiles provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             components: rustfmt
             override: true
       - uses: actions-rs/cargo@v1
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: stable
             components: clippy
             override: true
       - uses: actions-rs/cargo@v1

--- a/autoload/clap/provider/tagfiles.vim
+++ b/autoload/clap/provider/tagfiles.vim
@@ -40,17 +40,17 @@ function! s:extract(tag_row) abort
   " let line = parts[0]
   let file    = parts[1]
   let address = parts[2]
-  if address[0] == '/'
+  if address[0] ==# '/'
     " Format: `/^function example()$/`
     " inside the `/^` and `$/` is like nomagic, but some ctags program
     " put the ^ and $ anyway.
     let address = address[1:-2]
-    if address[0] == '^'
+    if address[0] ==# '^'
       let address = '\v^\V' . address[1:]
     else
       let address = '\V' . address
     end
-    if address[-1:] == '$'
+    if address[-1:] ==# '$'
       let address = address[:-2] . '\v$'
     end
   else
@@ -59,7 +59,7 @@ function! s:extract(tag_row) abort
   return [file, address]
 endfunction
 
-function! s:jump_to(position)
+function! s:jump_to(position) abort
   let [file, address] = a:position
 
   execute 'edit' file

--- a/autoload/clap/provider/tagfiles.vim
+++ b/autoload/clap/provider/tagfiles.vim
@@ -1,0 +1,79 @@
+" Author: romgrk <romgrk.cc@gmail.com>
+" Description: Project-wide tags
+
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+let s:provider = {}
+
+function! s:provider.on_typed() abort
+  call clap#client#notify_provider('on_typed')
+endfunction
+
+function! s:provider.init() abort
+  call clap#client#notify_on_init()
+endfunction
+
+function! s:provider.sink(selected) abort
+  call s:jump_to(s:extract(a:selected))
+  try
+    silent! call vista#util#Blink(2, 200)
+  catch '*' | endtry
+endfunction
+
+function! s:provider.on_move() abort
+  let [path, address] = s:extract(g:clap.display.getcurline())
+  call clap#preview#file_at(path, address)
+endfunction
+
+let s:provider.on_move_async = function('clap#impl#on_move#async')
+let s:provider.enable_rooter = v:true
+let s:provider.support_open_action = v:true
+let s:provider.syntax = 'clap_tagfiles'
+
+let g:clap#provider#tagfiles# = s:provider
+
+" Helpers
+
+function! s:extract(tag_row) abort
+  let parts = split(a:tag_row, '::::')
+  " let line = parts[0]
+  let file    = parts[1]
+  let address = parts[2]
+  if address[0] == '/'
+    " Format: `/^function example()$/`
+    " inside the `/^` and `$/` is like nomagic, but some ctags program
+    " put the ^ and $ anyway.
+    let address = address[1:-2]
+    if address[0] == '^'
+      let address = '\v^\V' . address[1:]
+    else
+      let address = '\V' . address
+    end
+    if address[-1:] == '$'
+      let address = address[:-2] . '\v$'
+    end
+  else
+    let address = str2nr(matchstr(address, '\v\d+'))
+  end
+  return [file, address]
+endfunction
+
+function! s:jump_to(position)
+  let [file, address] = a:position
+
+  execute 'edit' file
+
+  if type(address) == v:t_number
+    let lnum = address
+    execute 'normal! ' lnum 'gg'
+  else
+    let g:cp = address
+    let lnum = search(address)
+  end
+
+  execute 'normal! ^zvzz'
+endfunc
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/clap/provider/tagfiles.vim
+++ b/autoload/clap/provider/tagfiles.vim
@@ -7,7 +7,7 @@ set cpoptions&vim
 let s:provider = {}
 
 function! s:provider.on_typed() abort
-  call clap#client#notify_provider('on_typed')
+  call clap#client#notify('on_typed')
 endfunction
 
 function! s:provider.init() abort

--- a/crates/filter/src/parallel_worker.rs
+++ b/crates/filter/src/parallel_worker.rs
@@ -105,11 +105,12 @@ impl<P: ProgressUpdate<DisplayLines>> BestItems<P> {
         self.items.sort_unstable_by(|a, b| b.cmp(a));
     }
 
-    pub fn on_new_match(
+    pub fn on_new_match_full(
         &mut self,
         matched_item: MatchedItem,
         total_matched: usize,
         total_processed: usize,
+        truncate_text: bool,
     ) {
         if self.items.len() < self.max_capacity {
             self.items.push(matched_item);
@@ -117,8 +118,12 @@ impl<P: ProgressUpdate<DisplayLines>> BestItems<P> {
 
             let now = Instant::now();
             if now > self.past + self.update_interval {
-                let display_lines =
-                    printer::to_display_lines(self.items.clone(), self.winwidth, self.icon);
+                let display_lines = printer::to_display_lines_full(
+                    self.items.clone(),
+                    self.winwidth,
+                    self.icon,
+                    truncate_text,
+                );
                 self.progressor
                     .update_all(&display_lines, total_matched, total_processed);
                 self.last_lines = display_lines.lines;
@@ -139,8 +144,12 @@ impl<P: ProgressUpdate<DisplayLines>> BestItems<P> {
             if total_matched % 16 == 0 || total_processed % 16 == 0 {
                 let now = Instant::now();
                 if now > self.past + self.update_interval {
-                    let display_lines =
-                        printer::to_display_lines(self.items.clone(), self.winwidth, self.icon);
+                    let display_lines = printer::to_display_lines_full(
+                        self.items.clone(),
+                        self.winwidth,
+                        self.icon,
+                        truncate_text,
+                    );
 
                     let visible_highlights = display_lines
                         .indices
@@ -169,6 +178,15 @@ impl<P: ProgressUpdate<DisplayLines>> BestItems<P> {
                 }
             }
         }
+    }
+
+    pub fn on_new_match(
+        &mut self,
+        matched_item: MatchedItem,
+        total_matched: usize,
+        total_processed: usize,
+    ) {
+        self.on_new_match_full(matched_item, total_matched, total_processed, true)
     }
 }
 

--- a/crates/filter/src/parallel_worker.rs
+++ b/crates/filter/src/parallel_worker.rs
@@ -267,11 +267,7 @@ where
     let matched_count = AtomicUsize::new(0);
     let processed_count = AtomicUsize::new(0);
 
-    let printer = Printer {
-        line_width: winwidth,
-        icon,
-        truncate_text: true,
-    };
+    let printer = Printer::new(winwidth, icon);
     let best_items = Mutex::new(BestItems::new(
         printer,
         number,
@@ -315,12 +311,15 @@ where
     let total_processed = processed_count.into_inner();
 
     let BestItems {
-        items, progressor, ..
+        items,
+        progressor,
+        printer,
+        ..
     } = best_items.into_inner();
 
     let matched_items = items;
 
-    let display_lines = printer::to_display_lines(matched_items, winwidth, icon);
+    let display_lines = printer.to_display_lines(matched_items);
     progressor.on_finished(display_lines, total_matched, total_processed);
 
     Ok(())
@@ -355,11 +354,7 @@ where
     let matched_count = AtomicUsize::new(0);
     let processed_count = AtomicUsize::new(0);
 
-    let printer = Printer {
-        line_width: winwidth,
-        icon,
-        truncate_text: true,
-    };
+    let printer = Printer::new(winwidth, icon);
     let best_items = Mutex::new(BestItems::new(
         printer,
         number,
@@ -417,12 +412,15 @@ where
     }
 
     let BestItems {
-        items, progressor, ..
+        items,
+        progressor,
+        printer,
+        ..
     } = best_items.into_inner();
 
     let matched_items = items;
 
-    let display_lines = printer::to_display_lines(matched_items, winwidth, icon);
+    let display_lines = printer.to_display_lines(matched_items);
     progressor.on_finished(display_lines, total_matched, total_processed);
 
     Ok(())

--- a/crates/filter/src/sequential_worker.rs
+++ b/crates/filter/src/sequential_worker.rs
@@ -3,7 +3,7 @@
 use crate::{to_clap_item, FilterContext, MatchedItems, SequentialSource};
 use anyhow::Result;
 use icon::Icon;
-use printer::{println_json, println_json_with_length, DisplayLines};
+use printer::{println_json, println_json_with_length, DisplayLines, Printer};
 use rayon::slice::ParallelSliceMut;
 use std::io::BufRead;
 use std::sync::Arc;
@@ -371,7 +371,8 @@ pub fn dyn_run<I: Iterator<Item = Arc<dyn ClapItem>>>(
         let mut matched_items = MatchedItems::from(matched_items).par_sort().inner();
         matched_items.truncate(number);
 
-        let display_lines = printer::to_display_lines(matched_items, winwidth.unwrap_or(100), icon);
+        let printer = Printer::new(winwidth.unwrap_or(100), icon);
+        let display_lines = printer.to_display_lines(matched_items);
         print_on_dyn_run_finished(display_lines, total_matched);
     } else {
         let matched_items = dyn_collect_all(matched_item_stream, icon);

--- a/crates/maple_core/src/dirs.rs
+++ b/crates/maple_core/src/dirs.rs
@@ -13,6 +13,8 @@ pub static PROJECT_DIRS: Lazy<ProjectDirs> = Lazy::new(|| {
 pub static BASE_DIRS: Lazy<BaseDirs> =
     Lazy::new(|| BaseDirs::new().expect("Failed to construct BaseDirs"));
 
+pub static HOME: Lazy<PathBuf> = Lazy::new(|| BASE_DIRS.home_dir().to_path_buf());
+
 pub fn clap_cache_dir() -> std::io::Result<PathBuf> {
     let cache_dir = PROJECT_DIRS.cache_dir();
     std::fs::create_dir_all(cache_dir)?;

--- a/crates/maple_core/src/paths.rs
+++ b/crates/maple_core/src/paths.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fs::canonicalize;
-use std::path::{Display, Path, PathBuf, MAIN_SEPARATOR};
+use std::path::{Display, Path, PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR};
 
 /// Unit type wrapper of [`PathBuf`] that is absolute path.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize)]
@@ -152,10 +152,7 @@ pub fn truncate_absolute_path(abs_path: &str, max_len: usize) -> Cow<'_, str> {
                             if to_hide > gap + 2 {
                                 let mut tail = tail.to_string();
                                 tail.replace_range(..to_hide - 1, "...");
-                                let head = top
-                                    .iter()
-                                    .take(top.len() - 1)
-                                    .join(&MAIN_SEPARATOR.to_string());
+                                let head = top.iter().take(top.len() - 1).join(MAIN_SEPARATOR_STR);
                                 return format!("{head}{MAIN_SEPARATOR}{tail}").into();
                             } else {
                                 to_hide += component.len() + 1;

--- a/crates/maple_core/src/paths.rs
+++ b/crates/maple_core/src/paths.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::borrow::Cow;
 use std::convert::TryFrom;
 use std::fs::canonicalize;
-use std::path::{Display, Path, PathBuf, MAIN_SEPARATOR, MAIN_SEPARATOR_STR};
+use std::path::{Display, Path, PathBuf, MAIN_SEPARATOR};
 
 /// Unit type wrapper of [`PathBuf`] that is absolute path.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Serialize)]
@@ -152,7 +152,10 @@ pub fn truncate_absolute_path(abs_path: &str, max_len: usize) -> Cow<'_, str> {
                             if to_hide > gap + 2 {
                                 let mut tail = tail.to_string();
                                 tail.replace_range(..to_hide - 1, "...");
-                                let head = top.iter().take(top.len() - 1).join(MAIN_SEPARATOR_STR);
+                                let head = top
+                                    .iter()
+                                    .take(top.len() - 1)
+                                    .join(MAIN_SEPARATOR.to_string().as_str());
                                 return format!("{head}{MAIN_SEPARATOR}{tail}").into();
                             } else {
                                 to_hide += component.len() + 1;

--- a/crates/maple_core/src/searcher/blines.rs
+++ b/crates/maple_core/src/searcher/blines.rs
@@ -105,11 +105,7 @@ pub async fn search(
         item_pool_size,
     } = search_context;
 
-    let printer = Printer {
-        line_width: winwidth,
-        icon,
-        truncate_text: true,
-    };
+    let printer = Printer::new(winwidth, icon);
     let number = item_pool_size;
     let progressor = VimProgressor::new(vim, stop_signal.clone());
 

--- a/crates/maple_core/src/searcher/files.rs
+++ b/crates/maple_core/src/searcher/files.rs
@@ -4,6 +4,7 @@ use crate::stdio_server::VimProgressor;
 use filter::{BestItems, MatchedItem};
 use ignore::{DirEntry, WalkState};
 use matcher::Matcher;
+use printer::Printer;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -91,13 +92,12 @@ pub async fn search(query: String, hidden: bool, matcher: Matcher, search_contex
     let mut total_matched = 0usize;
     let mut total_processed = 0usize;
 
-    let mut best_items = BestItems::new(
+    let printer = Printer {
+        line_width: winwidth,
         icon,
-        winwidth,
-        number,
-        progressor,
-        Duration::from_millis(200),
-    );
+        truncate_text: true,
+    };
+    let mut best_items = BestItems::new(printer, number, progressor, Duration::from_millis(200));
 
     let now = std::time::Instant::now();
 
@@ -124,11 +124,11 @@ pub async fn search(query: String, hidden: bool, matcher: Matcher, search_contex
     let BestItems {
         items,
         progressor,
-        winwidth,
+        printer,
         ..
     } = best_items;
 
-    let display_lines = printer::to_display_lines(items, winwidth, icon);
+    let display_lines = printer.to_display_lines(items);
 
     progressor.on_finished(display_lines, total_matched, total_processed);
 

--- a/crates/maple_core/src/searcher/files.rs
+++ b/crates/maple_core/src/searcher/files.rs
@@ -92,11 +92,7 @@ pub async fn search(query: String, hidden: bool, matcher: Matcher, search_contex
     let mut total_matched = 0usize;
     let mut total_processed = 0usize;
 
-    let printer = Printer {
-        line_width: winwidth,
-        icon,
-        truncate_text: true,
-    };
+    let printer = Printer::new(winwidth, icon);
     let mut best_items = BestItems::new(printer, number, progressor, Duration::from_millis(200));
 
     let now = std::time::Instant::now();

--- a/crates/maple_core/src/searcher/mod.rs
+++ b/crates/maple_core/src/searcher/mod.rs
@@ -1,6 +1,7 @@
 pub mod blines;
 pub mod files;
 pub mod grep;
+pub mod tagfiles;
 
 use crate::stdio_server::Vim;
 use icon::Icon;

--- a/crates/maple_core/src/searcher/tagfiles.rs
+++ b/crates/maple_core/src/searcher/tagfiles.rs
@@ -19,7 +19,8 @@ struct TagItem {
     name: String,
     path: String,
     address: String,
-    kind: String,
+    // TODO: display kind?
+    _kind: String,
     display: Option<String>,
 }
 
@@ -246,6 +247,7 @@ fn read_tag_file<'a>(
                 if input.starts_with("!_TAG") {
                     None
                 } else if let Ok(mut tag) = TagItem::parse(parent_dir, &input) {
+                    // TODO: dispaly text can be lazy evalulated.
                     tag.display.replace(tag.format(cwd, winwidth));
                     Some(tag)
                 } else {

--- a/crates/maple_core/src/searcher/tagfiles.rs
+++ b/crates/maple_core/src/searcher/tagfiles.rs
@@ -1,0 +1,442 @@
+use crate::searcher::SearchContext;
+use crate::stdio_server::VimProgressor;
+use filter::BestItems;
+use matcher::Matcher;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::fs::File;
+use std::io::{BufRead, BufReader, Result};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
+use types::ProgressUpdate;
+use types::{ClapItem, MatchedItem};
+
+#[derive(Serialize, Deserialize, Debug)]
+struct TagItem {
+    name: String,
+    path: String,
+    address: String,
+    kind: String,
+    display: Option<String>,
+}
+
+impl TagItem {
+    pub fn format(&self, cwd: &Path, winwidth: usize) -> String {
+        static HOME: OnceCell<PathBuf> = OnceCell::new();
+
+        let name = format!("{} ", self.name);
+        let taken_width = name.len() + 1;
+        let path_len = self.path.len() + 2;
+        let mut adjustment = 0;
+
+        let mut home_path = PathBuf::new();
+        let path = Path::new(&self.path);
+        let path = path.strip_prefix(cwd).unwrap_or({
+            let home = HOME.get_or_init(|| crate::dirs::BASE_DIRS.home_dir().to_path_buf());
+
+            path.strip_prefix(home)
+                .map(|path| {
+                    home_path.push("~");
+                    home_path = home_path.join(path);
+                    home_path.as_path()
+                })
+                .unwrap_or(path)
+        });
+        let path = path.display();
+
+        let path_label = if taken_width > winwidth {
+            format!("[{}]", path)
+        } else {
+            let available_width = winwidth - taken_width;
+            if path_len > available_width && available_width > 3 {
+                let diff = path_len - available_width;
+                adjustment = 2;
+                let path = path.to_string();
+                let start = path
+                    .char_indices()
+                    .nth(diff + 2)
+                    .map(|x| x.0)
+                    .unwrap_or(path.len());
+                let path = path[start..].to_string();
+                format!("[…{}]", &path)
+            } else {
+                format!("[{}]", path)
+            }
+        };
+
+        let path_len = path_label.len();
+        let text_width = if path_len < winwidth {
+            winwidth - path_len
+        } else {
+            winwidth
+        } + adjustment;
+
+        format!(
+            "{text:<text_width$}{path_label}::::{path}::::{address}",
+            text = name,
+            text_width = text_width,
+            path_label = path_label,
+            path = self.path,
+            address = self.address,
+        )
+    }
+
+    pub fn parse(base: &Path, input: &str) -> anyhow::Result<Self> {
+        let mut field = 0;
+        let mut index_last = 0;
+
+        let mut name = String::new();
+        let mut path = String::new();
+        let mut address = String::new();
+        let mut kind = String::new();
+
+        let mut is_parsing_address = false;
+
+        let mut i = 0;
+        let mut iter = input.chars();
+        'outer: while let Some(mut c) = iter.next() {
+            /* Address parse */
+            if is_parsing_address {
+                /* Parse a pattern-address */
+                if c == '/' {
+                    address.push(c);
+                    let mut escape = false;
+                    loop {
+                        i += c.len_utf8();
+                        c = iter.next().unwrap();
+                        address.push(c);
+                        if c == '\\' && escape == false {
+                            escape = true;
+                            continue;
+                        }
+                        if c == '\\' && escape == true {
+                            escape = false;
+                            continue;
+                        }
+                        if c == '/' && escape == true {
+                            escape = false;
+                            continue;
+                        }
+                        if c == '/' && escape == false {
+                            /* Unescaped slash is end-of-pattern */
+                            break;
+                        }
+                        /* case: escaped non-special character */
+                        if escape {
+                            // Let's just let it pass
+                            escape = false;
+                        }
+                    }
+                }
+                /* Parse a line-number-address */
+                else if c.is_digit(10) {
+                    address.push(c);
+                    loop {
+                        i += c.len_utf8();
+                        if let Some(c_) = iter.next() {
+                            c = c_;
+                            if !c.is_digit(10) {
+                                break;
+                            }
+                            address.push(c);
+                        } else {
+                            /* case: end of string */
+                            break 'outer;
+                        }
+                    }
+                }
+                /* Nothing else is accepted */
+                else {
+                    return Err(anyhow::anyhow!("Invalid tag line: invalid address"));
+                }
+
+                /* Cleanup end-of-tagaddress chars: `;` and `"` usually */
+                loop {
+                    i += c.len_utf8();
+                    if let Some(c_) = iter.next() {
+                        c = c_;
+                        if c == '\t' {
+                            field += 1;
+                            index_last = i + c.len_utf8();
+                            break;
+                        }
+                    } else {
+                        /* case: end of string */
+                        break 'outer;
+                    }
+                }
+                is_parsing_address = false;
+                i += c.len_utf8();
+                continue 'outer;
+            }
+
+            /* Fields other than address are parsed here, because they are easier to match */
+            if c == '\t' {
+                match field {
+                    0 => name.push_str(&input[index_last..i]),
+                    1 => {
+                        let path_buf = base.join(String::from(&input[index_last..i]));
+                        path.push_str(&path_buf.to_string_lossy());
+                        is_parsing_address = true;
+                    }
+                    2 => { /* skip: already parsed above */ }
+                    3 => kind.push_str(&input[index_last..i]),
+                    _ => {}
+                }
+                field += 1;
+                index_last = i + c.len_utf8();
+            }
+
+            i += c.len_utf8();
+        }
+        match field {
+            0 => name.push_str(&input[index_last..]),
+            1 => {
+                let path_buf = base.join(String::from(&input[index_last..]));
+                path.push_str(&path_buf.to_string_lossy());
+            }
+            2 => { /* skip: already parsed above */ }
+            3 => kind.push_str(&input[index_last..]),
+            _ => {}
+        }
+
+        /* Not enough fields for us */
+        if field <= 1 {
+            Err(anyhow::anyhow!("Invalid tag line: not enough fields"))
+        } else {
+            Ok(TagItem {
+                name,
+                path,
+                address,
+                kind,
+                display: None,
+            })
+        }
+    }
+}
+
+impl ClapItem for TagItem {
+    fn raw_text(&self) -> &str {
+        self.name.as_str()
+    }
+
+    fn output_text(&self) -> Cow<'_, str> {
+        Cow::Borrowed(
+            self.display
+                .as_ref()
+                .expect("must be initialized when parsing"),
+        )
+    }
+}
+
+#[derive(Debug)]
+enum SearcherMessage {
+    Match(MatchedItem),
+    ProcessedOne,
+}
+
+fn read_tag_file<'a>(
+    tagfile: &'a Path,
+    cwd: &'a Path,
+    winwidth: usize,
+) -> std::io::Result<impl Iterator<Item = TagItem> + 'a> {
+    let parent_dir = tagfile.parent().unwrap_or(tagfile);
+
+    Ok(BufReader::new(File::open(tagfile)?)
+        .lines()
+        .filter_map(move |line| {
+            line.ok().and_then(|input| {
+                if input.starts_with("!_TAG") {
+                    None
+                } else if let Ok(mut tag) = TagItem::parse(parent_dir, &input) {
+                    tag.display.replace(tag.format(cwd, winwidth));
+                    Some(tag)
+                } else {
+                    None
+                }
+            })
+        }))
+}
+
+fn search_tagfiles(
+    tagfiles: Vec<PathBuf>,
+    cwd: PathBuf,
+    winwidth: usize,
+    matcher: Matcher,
+    stop_signal: Arc<AtomicBool>,
+    item_sender: UnboundedSender<SearcherMessage>,
+) -> Result<()> {
+    let _ = tagfiles
+        .iter()
+        .filter_map(|tagfile| read_tag_file(tagfile, &cwd, winwidth).ok())
+        .flatten()
+        .try_for_each(|tag_item| {
+            if stop_signal.load(Ordering::SeqCst) {
+                return Err(());
+            }
+
+            let msg = if let Some(matched_item) = matcher.match_item(Arc::new(tag_item)) {
+                SearcherMessage::Match(matched_item)
+            } else {
+                SearcherMessage::ProcessedOne
+            };
+
+            item_sender.send(msg).map_err(|_| ())?;
+
+            Ok(())
+        });
+
+    Ok(())
+}
+
+pub async fn search(query: String, cwd: PathBuf, matcher: Matcher, search_context: SearchContext) {
+    let SearchContext {
+        icon,
+        line_width,
+        paths,
+        vim,
+        stop_signal,
+        item_pool_size,
+    } = search_context;
+
+    let number = item_pool_size;
+    let progressor = VimProgressor::new(vim, stop_signal.clone());
+
+    let mut best_items = BestItems::new(
+        icon,
+        line_width,
+        number,
+        progressor,
+        Duration::from_millis(200),
+    );
+
+    let (sender, mut receiver) = unbounded_channel();
+
+    std::thread::Builder::new()
+        .name("tagfiles-worker".into())
+        .spawn({
+            let stop_signal = stop_signal.clone();
+            let tagfiles = paths.into_iter().map(|p| p.join("tags")).collect();
+            move || search_tagfiles(tagfiles, cwd, line_width, matcher, stop_signal, sender)
+        })
+        .expect("Failed to spawn tagfiles worker thread");
+
+    let mut total_matched = 0usize;
+    let mut total_processed = 0usize;
+
+    let now = std::time::Instant::now();
+
+    while let Some(searcher_message) = receiver.recv().await {
+        if stop_signal.load(Ordering::SeqCst) {
+            return;
+        }
+
+        match searcher_message {
+            SearcherMessage::Match(matched_item) => {
+                total_matched += 1;
+                total_processed += 1;
+
+                best_items.on_new_match(matched_item, total_matched, total_processed);
+            }
+            SearcherMessage::ProcessedOne => {
+                total_processed += 1;
+            }
+        }
+    }
+
+    let elapsed = now.elapsed().as_millis();
+
+    let BestItems {
+        items,
+        progressor,
+        winwidth,
+        ..
+    } = best_items;
+
+    let display_lines = printer::to_display_lines(items, winwidth, icon);
+
+    progressor.on_finished(display_lines, total_matched, total_processed);
+
+    tracing::debug!(
+        ?query,
+        total_matched,
+        total_processed,
+        "Searching is completed in {elapsed:?}ms"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_tag_from_tagfile() {
+        let empty_path = PathBuf::new();
+
+        // With escaped characters
+        let data = r#"run	crates/maple_cli/src/app.rs	/^	pub \/* \\\/ *\/ fn	run(self) -> Result<()> {$/;"	P	implementation:Maple"#;
+        let tag = TagItem::parse(&empty_path, data).unwrap();
+        assert_eq!(tag.name, "run");
+        assert_eq!(tag.path, "crates/maple_cli/src/app.rs");
+        assert_eq!(
+            tag.address,
+            r#"/^	pub \/* \\\/ *\/ fn	run(self) -> Result<()> {$/"#
+        );
+        assert_eq!(tag.kind, "P");
+
+        // With invalid escaped characters
+        let data = r#"tag_name	filepath_here.py	/def ta\g_name/	f	"#;
+        let tag = TagItem::parse(&empty_path, data).unwrap();
+        assert_eq!(tag.name, "tag_name");
+        assert_eq!(tag.path, "filepath_here.py");
+        assert_eq!(tag.address, r#"/def ta\g_name/"#);
+        assert_eq!(tag.kind, "f");
+
+        // with different characters after pattern
+        let data = r#"tagname	filename	/pattern/[;"	f	"#;
+        let tag = TagItem::parse(&empty_path, data).unwrap();
+        assert_eq!(tag.address, "/pattern/");
+
+        // Without kind
+        let data = r#"tag_with_no_kind	filepath_here.py	/tag_with_no_kind/"#;
+        let tag = TagItem::parse(&empty_path, data).unwrap();
+        assert_eq!(tag.name, "tag_with_no_kind");
+        assert_eq!(tag.path, "filepath_here.py");
+        assert_eq!(tag.address, r#"/tag_with_no_kind/"#);
+        assert_eq!(tag.kind, "");
+
+        // Invalid: pattern
+        let data = r#"tag_name	filename.py	invalid/pattern/;""	f	"#;
+        assert_eq!(TagItem::parse(&empty_path, data).is_err(), true);
+
+        // With line-number address
+        let data = r#".Button.--icon .Button__icon	client/src/styles/Button.scss	86;"	r"#;
+        let tag = TagItem::parse(&empty_path, data).unwrap();
+        assert_eq!(tag.name, ".Button.--icon .Button__icon");
+        assert_eq!(tag.path, "client/src/styles/Button.scss");
+        assert_eq!(tag.address, r#"86"#);
+        assert_eq!(tag.kind, "r");
+
+        // With line-number address (hasktags style)
+        let data = r#"EndlessList	example.hs	3"#;
+        let tag = TagItem::parse(&empty_path, data).unwrap();
+        assert_eq!(tag.name, "EndlessList");
+        assert_eq!(tag.path, "example.hs");
+        assert_eq!(tag.address, r#"3"#);
+    }
+
+    #[test]
+    fn test_read_tags() {
+        let cur_dir = std::env::current_dir().unwrap();
+        let cwd = cur_dir.parent().unwrap().parent().unwrap();
+        let tags_file = cwd.join("tags");
+        let tagitems = read_tag_file(&tags_file, cwd, 60)
+            .unwrap()
+            .collect::<Vec<_>>();
+        println!("{tagitems:#?}");
+    }
+}

--- a/crates/maple_core/src/stdio_server/handler/on_initialize.rs
+++ b/crates/maple_core/src/stdio_server/handler/on_initialize.rs
@@ -6,7 +6,7 @@ use crate::tools::ctags::ProjectCtagsCommand;
 use crate::tools::rg::{RgTokioCommand, RG_EXEC_CMD};
 use anyhow::Result;
 use filter::SourceItem;
-use printer::DisplayLines;
+use printer::{DisplayLines, Printer};
 use serde_json::{json, Value};
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
@@ -167,12 +167,13 @@ pub async fn initialize_provider(ctx: &Context) -> Result<()> {
             }
 
             if let Some(items) = provider_source.try_skim(ctx.provider_id(), 100) {
+                let printer = Printer::new(ctx.env.display_winwidth, ctx.env.icon);
                 let DisplayLines {
                     lines,
                     icon_added,
                     truncated_map,
                     ..
-                } = printer::to_display_lines(items, ctx.env.display_winwidth, ctx.env.icon);
+                } = printer.to_display_lines(items);
 
                 let using_cache = provider_source.using_cache();
 

--- a/crates/maple_core/src/stdio_server/provider/filer.rs
+++ b/crates/maple_core/src/stdio_server/provider/filer.rs
@@ -4,6 +4,7 @@ use crate::stdio_server::provider::{ClapProvider, Context, Direction};
 use crate::stdio_server::vim::preview_syntax;
 use anyhow::Result;
 use icon::{icon_or_default, FOLDER_ICON};
+use printer::Printer;
 use serde_json::json;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -170,21 +171,21 @@ impl FilerProvider {
 
         let processed = current_items.len();
 
+        // icon is handled inside the provider impl.
+        let printer = Printer::new(ctx.env.display_winwidth, icon::Icon::Null);
         if query.is_empty() {
             let printer::DisplayLines {
                 lines,
                 mut indices,
                 truncated_map: _,
                 icon_added,
-            } = printer::to_display_lines(
+            } = printer.to_display_lines(
                 current_items
                     .iter()
                     .take(200)
                     .cloned()
                     .map(Into::into)
                     .collect(),
-                ctx.env.display_winwidth,
-                icon::Icon::Null, // icon is handled inside the provider impl.
             );
 
             if ctx.env.icon.enabled() {
@@ -211,16 +212,14 @@ impl FilerProvider {
 
         matched_items.truncate(200);
 
+        // icon is handled inside the provider impl.
+        let printer = Printer::new(ctx.env.display_winwidth, icon::Icon::Null);
         let printer::DisplayLines {
             lines,
             mut indices,
             truncated_map,
             icon_added,
-        } = printer::to_display_lines(
-            matched_items,
-            ctx.env.display_winwidth,
-            icon::Icon::Null, // icon is handled inside the provider impl.
-        );
+        } = printer.to_display_lines(matched_items);
 
         if ctx.env.icon.enabled() {
             indices.iter_mut().for_each(|v| {

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -4,6 +4,7 @@ mod filer;
 mod files;
 mod generic_provider;
 mod grep;
+mod tagfiles;
 // mod interactive_grep;
 mod recent_files;
 

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -43,6 +43,7 @@ pub async fn create_provider(provider_id: &str, ctx: &Context) -> Result<Box<dyn
         // ctx.cwd.to_path_buf(),
         // )),
         "recent_files" => Box::new(recent_files::RecentFilesProvider::new()),
+        "tagfiles" => Box::new(tagfiles::TagfilesProvider::new()),
         _ => Box::new(generic_provider::GenericProvider::new()),
     };
     Ok(provider)
@@ -266,7 +267,11 @@ impl Context {
             .collect();
         let matcher_builder = provider_id.matcher_builder().rank_criteria(rank_criteria);
         // Sign column occupies 2 spaces.
-        let display_winwidth = vim.winwidth(display.winid).await? - 2;
+        let display_line_width = match provider_id.as_str() {
+            "grep" => display_winwidth - 4,
+            "tagfiles" => display_winwidth,
+            _ => display_winwidth - 2,
+        };
         let display_winheight = vim.winheight(display.winid).await?;
         let is_nvim: usize = vim.call("has", ["nvim"]).await?;
         let has_nvim_09: usize = vim.call("has", ["nvim-0.9"]).await?;

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -22,6 +22,7 @@ use filter::Query;
 use icon::{Icon, IconKind};
 use matcher::{Bonus, MatchScope, Matcher, MatcherBuilder};
 use parking_lot::RwLock;
+use printer::Printer;
 use rpc::Params;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -472,12 +473,13 @@ impl Context {
             .read()
             .try_skim(self.provider_id(), 100)
         {
+            let printer = Printer::new(self.env.display_winwidth, self.env.icon);
             let printer::DisplayLines {
                 lines,
                 icon_added,
                 truncated_map,
                 ..
-            } = printer::to_display_lines(items, self.env.display_winwidth, self.env.icon);
+            } = printer.to_display_lines(items);
 
             self.vim.exec(
                 "clap#state#update_on_empty_query",

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -37,13 +37,13 @@ pub async fn create_provider(provider_id: &str, ctx: &Context) -> Result<Box<dyn
     let provider: Box<dyn ClapProvider> = match provider_id {
         "blines" => Box::new(blines::BlinesProvider::new()),
         "dumb_jump" => Box::new(dumb_jump::DumbJumpProvider::new()),
-        "filer" => Box::new(filer::FilerProvider::new(ctx.cwd.to_path_buf())),
+        "filer" => Box::new(filer::FilerProvider::new(ctx)),
         "files" => Box::new(files::FilesProvider::new(ctx).await?),
         "grep" => Box::new(grep::GrepProvider::new()),
         // "interactive_grep" => Box::new(interactive_grep::InteractiveGrepProvider::new(
         // ctx.cwd.to_path_buf(),
         // )),
-        "recent_files" => Box::new(recent_files::RecentFilesProvider::new()),
+        "recent_files" => Box::new(recent_files::RecentFilesProvider::new(ctx)),
         "tagfiles" => Box::new(tagfiles::TagfilesProvider::new()),
         _ => Box::new(generic_provider::GenericProvider::new()),
     };

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -267,10 +267,10 @@ impl Context {
             .collect();
         let matcher_builder = provider_id.matcher_builder().rank_criteria(rank_criteria);
         // Sign column occupies 2 spaces.
-        let display_line_width = match provider_id.as_str() {
-            "grep" => display_winwidth - 4,
-            "tagfiles" => display_winwidth,
-            _ => display_winwidth - 2,
+        let display_winwidth = vim.winwidth(display.winid).await? - 2;
+        let display_winwidth = match provider_id.as_str() {
+            "grep" => display_winwidth - 2,
+            _ => display_winwidth,
         };
         let display_winheight = vim.winheight(display.winid).await?;
         let is_nvim: usize = vim.call("has", ["nvim"]).await?;

--- a/crates/maple_core/src/stdio_server/provider/recent_files.rs
+++ b/crates/maple_core/src/stdio_server/provider/recent_files.rs
@@ -17,7 +17,6 @@ pub struct RecentFilesProvider {
 
 impl RecentFilesProvider {
     pub fn new(ctx: &Context) -> Self {
-        let winwidth = ctx.env.display_winwidth;
         let icon = if ctx.env.icon.enabled() {
             icon::Icon::Enabled(icon::IconKind::File)
         } else {
@@ -190,12 +189,6 @@ impl ClapProvider for RecentFilesProvider {
                 None
             };
             let lnum = ctx.vim.display_getcurlnum().await?;
-            let winwidth = ctx.env.display_winwidth;
-            let icon = if ctx.env.icon.enabled() {
-                icon::Icon::Enabled(icon::IconKind::File)
-            } else {
-                icon::Icon::Null
-            };
 
             move || recent_files.process_query(cwd, query, preview_size, lnum)
         })

--- a/crates/maple_core/src/stdio_server/provider/recent_files.rs
+++ b/crates/maple_core/src/stdio_server/provider/recent_files.rs
@@ -4,6 +4,7 @@ use crate::stdio_server::handler::CachedPreviewImpl;
 use crate::stdio_server::provider::{ClapProvider, Context};
 use anyhow::Result;
 use parking_lot::Mutex;
+use printer::Printer;
 use serde_json::{json, Value};
 use std::sync::Arc;
 use types::{ClapItem, MatchedItem, RankCalculator, Score};
@@ -80,12 +81,13 @@ impl RecentFilesProvider {
             _ => None,
         };
 
+        let printer = Printer::new(winwidth, icon);
         let printer::DisplayLines {
             lines,
             indices,
             truncated_map,
             icon_added,
-        } = printer::to_display_lines(ranked.iter().take(200).cloned().collect(), winwidth, icon);
+        } = printer.to_display_lines(ranked.iter().take(200).cloned().collect());
 
         let mut cwd = cwd;
         cwd.push(std::path::MAIN_SEPARATOR);

--- a/crates/maple_core/src/stdio_server/provider/tagfiles.rs
+++ b/crates/maple_core/src/stdio_server/provider/tagfiles.rs
@@ -1,0 +1,369 @@
+use anyhow::anyhow;
+use anyhow::Result;
+use filter::{matcher::LineSplitter, Source};
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use std::fmt::Write;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use structopt::StructOpt;
+use types::SourceItem;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct TagInfo {
+    name: String,
+    path: String,
+    address: String,
+    kind: String,
+}
+
+impl TagInfo {
+    pub fn format(&self, cwd: &PathBuf, winwidth: usize) -> String {
+        static HOME: OnceCell<Option<PathBuf>> = OnceCell::new();
+
+        let name = format!("{} ", self.name);
+        let taken_width = name.len() + 1;
+        let path_len = self.path.len() + 2;
+        let mut adjustment = 0;
+
+        let mut home_path = PathBuf::new();
+        let path = Path::new(&self.path);
+        let path = path.strip_prefix(cwd).unwrap_or(
+            HOME.get_or_init(|| dirs::home_dir())
+                .as_deref()
+                .map(|home| {
+                    path.strip_prefix(home)
+                        .map(|path| {
+                            home_path.push("~");
+                            home_path = home_path.join(path);
+                            home_path.as_path()
+                        })
+                        .unwrap_or(path)
+                })
+                .unwrap_or(path),
+        );
+        let path = path.display();
+
+        let path_label = if taken_width > winwidth {
+            format!("[{}]", path)
+        } else {
+            let available_width = winwidth - taken_width;
+            if path_len > available_width && available_width > 3 {
+                let diff = path_len - available_width;
+                adjustment = 2;
+                let path = path.to_string();
+                let start = path
+                    .char_indices()
+                    .nth(diff + 2)
+                    .map(|x| x.0)
+                    .unwrap_or(path.len());
+                let path = path[start..].to_string();
+                format!("[…{}]", &path)
+            } else {
+                format!("[{}]", path)
+            }
+        };
+
+        let path_len = path_label.len();
+        let text_width = if path_len < winwidth {
+            winwidth - path_len
+        } else {
+            winwidth
+        } + adjustment;
+
+        format!(
+            "{text:<text_width$}{path_label}::::{path}::::{address}",
+            text = name,
+            text_width = text_width,
+            path_label = path_label,
+            path = self.path,
+            address = self.address,
+        )
+    }
+
+    pub fn parse(base: &PathBuf, input: &str) -> anyhow::Result<Self> {
+        let mut field = 0;
+        let mut index_last = 0;
+
+        let mut name = String::new();
+        let mut path = String::new();
+        let mut address = String::new();
+        let mut kind = String::new();
+
+        let mut is_parsing_address = false;
+
+        let mut i = 0;
+        let mut iter = input.chars();
+        'outer: while let Some(mut c) = iter.next() {
+            /* Address parse */
+            if is_parsing_address {
+                /* Parse a pattern-address */
+                if c == '/' {
+                    address.push(c);
+                    let mut escape = false;
+                    loop {
+                        i += c.len_utf8();
+                        c = iter.next().unwrap();
+                        address.push(c);
+                        if c == '\\' && escape == false {
+                            escape = true;
+                            continue;
+                        }
+                        if c == '\\' && escape == true {
+                            escape = false;
+                            continue;
+                        }
+                        if c == '/' && escape == true {
+                            escape = false;
+                            continue;
+                        }
+                        if c == '/' && escape == false {
+                            /* Unescaped slash is end-of-pattern */
+                            break;
+                        }
+                        /* case: escaped non-special character */
+                        if escape {
+                            // Let's just let it pass
+                            escape = false;
+                        }
+                    }
+                }
+                /* Parse a line-number-address */
+                else if c.is_digit(10) {
+                    address.push(c);
+                    loop {
+                        i += c.len_utf8();
+                        if let Some(c_) = iter.next() {
+                            c = c_;
+                            if !c.is_digit(10) {
+                                break;
+                            }
+                            address.push(c);
+                        } else {
+                            /* case: end of string */
+                            break 'outer;
+                        }
+                    }
+                }
+                /* Nothing else is accepted */
+                else {
+                    return Err(anyhow::anyhow!("Invalid tag line: invalid address"));
+                }
+
+                /* Cleanup end-of-tagaddress chars: `;` and `"` usually */
+                loop {
+                    i += c.len_utf8();
+                    if let Some(c_) = iter.next() {
+                        c = c_;
+                        if c == '\t' {
+                            field += 1;
+                            index_last = i + c.len_utf8();
+                            break;
+                        }
+                    } else {
+                        /* case: end of string */
+                        break 'outer;
+                    }
+                }
+                is_parsing_address = false;
+                i += c.len_utf8();
+                continue 'outer;
+            }
+
+            /* Fields other than address are parsed here, because they are easier to match */
+            if c == '\t' {
+                match field {
+                    0 => name.push_str(&input[index_last..i]),
+                    1 => {
+                        let path_buf = base.join(String::from(&input[index_last..i]));
+                        write!(&mut path, "{}", path_buf.display()).unwrap();
+                        is_parsing_address = true;
+                    }
+                    2 => { /* skip: already parsed above */ }
+                    3 => kind.push_str(&input[index_last..i]),
+                    _ => {}
+                }
+                field += 1;
+                index_last = i + c.len_utf8();
+            }
+
+            i += c.len_utf8();
+        }
+        match field {
+            0 => name.push_str(&input[index_last..]),
+            1 => {
+                let path_buf = base.join(String::from(&input[index_last..]));
+                write!(&mut path, "{}", path_buf.display()).unwrap();
+            }
+            2 => { /* skip: already parsed above */ }
+            3 => kind.push_str(&input[index_last..]),
+            _ => {}
+        }
+
+        /* Not enough fields for us */
+        if field <= 1 {
+            Err(anyhow::anyhow! {"Invalid tag line: not enough fields"})
+        } else {
+            Ok(TagInfo {
+                name,
+                path,
+                address,
+                kind,
+            })
+        }
+    }
+}
+
+/// Generate ctags recursively given the directory.
+#[derive(StructOpt, Debug, Clone)]
+pub struct TagFiles {
+    /// Initial query string
+    #[structopt(index = 1, short, long)]
+    query: String,
+
+    /// The directory to generate recursive ctags.
+    #[structopt(long, parse(from_os_str))]
+    files: Vec<PathBuf>,
+
+    /// Specify the language.
+    #[structopt(long = "languages")]
+    languages: Option<String>,
+
+    /// Read input from a cached grep tempfile, only absolute file path is supported.
+    #[structopt(long = "input", parse(from_os_str))]
+    input: Option<PathBuf>,
+}
+
+fn read_tag_files<'a>(
+    cwd: &'a PathBuf,
+    winwidth: usize,
+    files: &'a [[PathBuf; 2]],
+) -> Result<impl Iterator<Item = SourceItem> + 'a> {
+    Ok(files
+        .iter()
+        .filter_map(move |path| read_tag_file(path, &cwd, winwidth).ok())
+        .flatten())
+}
+
+fn read_tag_file<'a>(
+    paths: &'a [PathBuf; 2],
+    cwd: &'a PathBuf,
+    winwidth: usize,
+) -> Result<impl Iterator<Item = SourceItem> + 'a> {
+    let file = File::open(&paths[0]);
+    let file = if let Ok(file) = file {
+        file
+    } else {
+        return Err(anyhow! {"File does not exists"});
+    };
+
+    Ok(BufReader::new(file).lines().filter_map(move |line| {
+        line.ok().and_then(|input| {
+            if input.starts_with("!_TAG") {
+                None
+            } else if let Ok(tag) = TagInfo::parse(&paths[1], &input) {
+                Some(SourceItem {
+                    display: tag.format(&cwd, winwidth),
+                    filter: Some(tag.name),
+                })
+            } else {
+                None
+            }
+        })
+    }))
+}
+
+fn get_paths_from_files<'a>(files: &'a Vec<PathBuf>) -> Vec<[PathBuf; 2]> {
+    files
+        .iter()
+        .map(|path| {
+            let mut dirname = path.clone();
+            dirname.pop();
+            [path.to_owned(), dirname]
+        })
+        .collect::<Vec<_>>()
+}
+
+impl TagFiles {
+    pub fn run(&self, options: &crate::Maple) -> Result<()> {
+        /* let icon_painter = options
+         *     .icon_painter
+         *     .clone()
+         *     .map(|_| icon::IconPainter::ProjTags); */
+
+        let cwd = options.cwd.clone().unwrap();
+        let winwidth = options.winwidth.unwrap_or(120);
+
+        let files = &self.files.clone();
+        let tag_paths = get_paths_from_files(files);
+
+        filter::dyn_run(
+            &self.query,
+            Source::List(read_tag_files(&cwd, winwidth, &tag_paths)?),
+            None,
+            Some(30),
+            None,
+            None,
+            LineSplitter::TagNameOnly,
+        )?;
+
+        Ok(())
+    }
+}
+
+#[test]
+fn test_parse_ctags_line() {
+    let empty_path = PathBuf::new();
+
+    // With escaped characters
+    let data = r#"run	crates/maple_cli/src/app.rs	/^	pub \/* \\\/ *\/ fn	run(self) -> Result<()> {$/;"	P	implementation:Maple"#;
+    let tag = TagInfo::parse(&empty_path, data).unwrap();
+    assert_eq!(tag.name, "run");
+    assert_eq!(tag.path, "crates/maple_cli/src/app.rs");
+    assert_eq!(
+        tag.address,
+        r#"/^	pub \/* \\\/ *\/ fn	run(self) -> Result<()> {$/"#
+    );
+    assert_eq!(tag.kind, "P");
+
+    // With invalid escaped characters
+    let data = r#"tag_name	filepath_here.py	/def ta\g_name/	f	"#;
+    let tag = TagInfo::parse(&empty_path, data).unwrap();
+    assert_eq!(tag.name, "tag_name");
+    assert_eq!(tag.path, "filepath_here.py");
+    assert_eq!(tag.address, r#"/def ta\g_name/"#);
+    assert_eq!(tag.kind, "f");
+
+    // with different characters after pattern
+    let data = r#"tagname	filename	/pattern/[;"	f	"#;
+    let tag = TagInfo::parse(&empty_path, data).unwrap();
+    assert_eq!(tag.address, "/pattern/");
+
+    // Without kind
+    let data = r#"tag_with_no_kind	filepath_here.py	/tag_with_no_kind/"#;
+    let tag = TagInfo::parse(&empty_path, data).unwrap();
+    assert_eq!(tag.name, "tag_with_no_kind");
+    assert_eq!(tag.path, "filepath_here.py");
+    assert_eq!(tag.address, r#"/tag_with_no_kind/"#);
+    assert_eq!(tag.kind, "");
+
+    // Invalid: pattern
+    let data = r#"tag_name	filename.py	invalid/pattern/;""	f	"#;
+    assert_eq!(TagInfo::parse(&empty_path, data).is_err(), true);
+
+    // With line-number address
+    let data = r#".Button.--icon .Button__icon	client/src/styles/Button.scss	86;"	r"#;
+    let tag = TagInfo::parse(&empty_path, data).unwrap();
+    assert_eq!(tag.name, ".Button.--icon .Button__icon");
+    assert_eq!(tag.path, "client/src/styles/Button.scss");
+    assert_eq!(tag.address, r#"86"#);
+    assert_eq!(tag.kind, "r");
+
+    // With line-number address (hasktags style)
+    let data = r#"EndlessList	example.hs	3"#;
+    let tag = TagInfo::parse(&empty_path, data).unwrap();
+    assert_eq!(tag.name, "EndlessList");
+    assert_eq!(tag.path, "example.hs");
+    assert_eq!(tag.address, r#"3"#);
+}

--- a/crates/maple_core/src/stdio_server/provider/tagfiles.rs
+++ b/crates/maple_core/src/stdio_server/provider/tagfiles.rs
@@ -1,309 +1,85 @@
+use crate::stdio_server::handler::initialize_provider;
+use crate::stdio_server::provider::{ClapProvider, Context, SearcherControl};
 use anyhow::Result;
-use once_cell::sync::OnceCell;
-use serde::{Deserialize, Serialize};
-use std::fmt::Write;
-use std::fs::File;
-use std::io::{BufRead, BufReader};
-use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use types::Query;
 
-#[derive(Serialize, Deserialize, Debug)]
-struct TagItem {
-    name: String,
-    path: String,
-    address: String,
-    kind: String,
+#[derive(Debug)]
+pub struct TagfilesProvider {
+    searcher_control: Option<SearcherControl>,
 }
 
-impl TagItem {
-    pub fn format(&self, cwd: &PathBuf, winwidth: usize) -> String {
-        static HOME: OnceCell<PathBuf> = OnceCell::new();
+impl TagfilesProvider {
+    pub fn new() -> Self {
+        Self {
+            searcher_control: None,
+        }
+    }
 
-        let name = format!("{} ", self.name);
-        let taken_width = name.len() + 1;
-        let path_len = self.path.len() + 2;
-        let mut adjustment = 0;
+    fn process_query(&mut self, query: String, ctx: &Context) {
+        if let Some(control) = self.searcher_control.take() {
+            tokio::task::spawn_blocking(move || {
+                control.kill();
+            });
+        }
 
-        let mut home_path = PathBuf::new();
-        let path = Path::new(&self.path);
-        let path = path.strip_prefix(cwd).unwrap_or({
-            let home = HOME.get_or_init(|| crate::dirs::BASE_DIRS.home_dir().to_path_buf());
+        let matcher = ctx.matcher_builder().build(Query::from(&query));
 
-            path.strip_prefix(home)
-                .map(|path| {
-                    home_path.push("~");
-                    home_path = home_path.join(path);
-                    home_path.as_path()
+        let new_control = {
+            let stop_signal = Arc::new(AtomicBool::new(false));
+
+            let join_handle = {
+                let search_context = ctx.search_context(stop_signal.clone());
+                let cwd = ctx.cwd.to_path_buf();
+
+                tokio::spawn(async move {
+                    crate::searcher::tagfiles::search(query, cwd, matcher, search_context).await;
                 })
-                .unwrap_or(path)
-        });
-        let path = path.display();
+            };
 
-        let path_label = if taken_width > winwidth {
-            format!("[{}]", path)
-        } else {
-            let available_width = winwidth - taken_width;
-            if path_len > available_width && available_width > 3 {
-                let diff = path_len - available_width;
-                adjustment = 2;
-                let path = path.to_string();
-                let start = path
-                    .char_indices()
-                    .nth(diff + 2)
-                    .map(|x| x.0)
-                    .unwrap_or(path.len());
-                let path = path[start..].to_string();
-                format!("[…{}]", &path)
-            } else {
-                format!("[{}]", path)
+            SearcherControl {
+                stop_signal,
+                join_handle,
             }
         };
 
-        let path_len = path_label.len();
-        let text_width = if path_len < winwidth {
-            winwidth - path_len
-        } else {
-            winwidth
-        } + adjustment;
-
-        format!(
-            "{text:<text_width$}{path_label}::::{path}::::{address}",
-            text = name,
-            text_width = text_width,
-            path_label = path_label,
-            path = self.path,
-            address = self.address,
-        )
-    }
-
-    pub fn parse(base: &Path, input: &str) -> anyhow::Result<Self> {
-        let mut field = 0;
-        let mut index_last = 0;
-
-        let mut name = String::new();
-        let mut path = String::new();
-        let mut address = String::new();
-        let mut kind = String::new();
-
-        let mut is_parsing_address = false;
-
-        let mut i = 0;
-        let mut iter = input.chars();
-        'outer: while let Some(mut c) = iter.next() {
-            /* Address parse */
-            if is_parsing_address {
-                /* Parse a pattern-address */
-                if c == '/' {
-                    address.push(c);
-                    let mut escape = false;
-                    loop {
-                        i += c.len_utf8();
-                        c = iter.next().unwrap();
-                        address.push(c);
-                        if c == '\\' && escape == false {
-                            escape = true;
-                            continue;
-                        }
-                        if c == '\\' && escape == true {
-                            escape = false;
-                            continue;
-                        }
-                        if c == '/' && escape == true {
-                            escape = false;
-                            continue;
-                        }
-                        if c == '/' && escape == false {
-                            /* Unescaped slash is end-of-pattern */
-                            break;
-                        }
-                        /* case: escaped non-special character */
-                        if escape {
-                            // Let's just let it pass
-                            escape = false;
-                        }
-                    }
-                }
-                /* Parse a line-number-address */
-                else if c.is_digit(10) {
-                    address.push(c);
-                    loop {
-                        i += c.len_utf8();
-                        if let Some(c_) = iter.next() {
-                            c = c_;
-                            if !c.is_digit(10) {
-                                break;
-                            }
-                            address.push(c);
-                        } else {
-                            /* case: end of string */
-                            break 'outer;
-                        }
-                    }
-                }
-                /* Nothing else is accepted */
-                else {
-                    return Err(anyhow::anyhow!("Invalid tag line: invalid address"));
-                }
-
-                /* Cleanup end-of-tagaddress chars: `;` and `"` usually */
-                loop {
-                    i += c.len_utf8();
-                    if let Some(c_) = iter.next() {
-                        c = c_;
-                        if c == '\t' {
-                            field += 1;
-                            index_last = i + c.len_utf8();
-                            break;
-                        }
-                    } else {
-                        /* case: end of string */
-                        break 'outer;
-                    }
-                }
-                is_parsing_address = false;
-                i += c.len_utf8();
-                continue 'outer;
-            }
-
-            /* Fields other than address are parsed here, because they are easier to match */
-            if c == '\t' {
-                match field {
-                    0 => name.push_str(&input[index_last..i]),
-                    1 => {
-                        let path_buf = base.join(String::from(&input[index_last..i]));
-                        path.push_str(&path_buf.to_string_lossy());
-                        is_parsing_address = true;
-                    }
-                    2 => { /* skip: already parsed above */ }
-                    3 => kind.push_str(&input[index_last..i]),
-                    _ => {}
-                }
-                field += 1;
-                index_last = i + c.len_utf8();
-            }
-
-            i += c.len_utf8();
-        }
-        match field {
-            0 => name.push_str(&input[index_last..]),
-            1 => {
-                let path_buf = base.join(String::from(&input[index_last..]));
-                path.push_str(&path_buf.to_string_lossy());
-            }
-            2 => { /* skip: already parsed above */ }
-            3 => kind.push_str(&input[index_last..]),
-            _ => {}
-        }
-
-        /* Not enough fields for us */
-        if field <= 1 {
-            Err(anyhow::anyhow!("Invalid tag line: not enough fields"))
-        } else {
-            Ok(TagItem {
-                name,
-                path,
-                address,
-                kind,
-            })
-        }
+        self.searcher_control.replace(new_control);
     }
 }
 
-/// Generate ctags recursively given the directory.
-#[derive(Debug, Clone)]
-pub struct TagFiles {
-    /// The directory to find tagfiles.
-    tagfiles: Vec<PathBuf>,
-}
-
-impl TagFiles {
-    pub fn run(&self) -> Result<()> {
-        let _tag_item_stream = self
-            .tagfiles
-            .iter()
-            .filter_map(|tagfile| read_tag_file(tagfile).ok())
-            .flatten();
-
-        // TODO: tagfiles searcher
-
+#[async_trait::async_trait]
+impl ClapProvider for TagfilesProvider {
+    async fn on_initialize(&mut self, ctx: &mut Context) -> Result<()> {
+        let query = ctx.vim.context_query_or_input().await?;
+        if !query.is_empty() {
+            self.process_query(query, ctx);
+        } else {
+            initialize_provider(ctx).await?;
+        }
         Ok(())
     }
-}
 
-fn read_tag_file(tagfile: &Path) -> std::io::Result<impl Iterator<Item = TagItem> + '_> {
-    let parent_dir = tagfile.parent().unwrap_or(tagfile);
+    async fn on_typed(&mut self, ctx: &mut Context) -> Result<()> {
+        let query = ctx.vim.input_get().await?;
+        if query.is_empty() {
+            ctx.update_on_empty_query().await?;
+        } else {
+            self.process_query(query, ctx);
+        }
+        Ok(())
+    }
 
-    Ok(BufReader::new(File::open(tagfile)?)
-        .lines()
-        .filter_map(move |line| {
-            line.ok().and_then(|input| {
-                if input.starts_with("!_TAG") {
-                    None
-                } else if let Ok(tag) = TagItem::parse(parent_dir, &input) {
-                    Some(tag)
-                } else {
-                    None
-                }
-            })
-        }))
-}
+    async fn on_move(&mut self, _ctx: &mut Context) -> Result<()> {
+        // TODO: Possible to include the line number in tagfiles?
+        Ok(())
+    }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_parse_tag_from_tagfile() {
-        let empty_path = PathBuf::new();
-
-        // With escaped characters
-        let data = r#"run	crates/maple_cli/src/app.rs	/^	pub \/* \\\/ *\/ fn	run(self) -> Result<()> {$/;"	P	implementation:Maple"#;
-        let tag = TagItem::parse(&empty_path, data).unwrap();
-        assert_eq!(tag.name, "run");
-        assert_eq!(tag.path, "crates/maple_cli/src/app.rs");
-        assert_eq!(
-            tag.address,
-            r#"/^	pub \/* \\\/ *\/ fn	run(self) -> Result<()> {$/"#
-        );
-        assert_eq!(tag.kind, "P");
-
-        // With invalid escaped characters
-        let data = r#"tag_name	filepath_here.py	/def ta\g_name/	f	"#;
-        let tag = TagItem::parse(&empty_path, data).unwrap();
-        assert_eq!(tag.name, "tag_name");
-        assert_eq!(tag.path, "filepath_here.py");
-        assert_eq!(tag.address, r#"/def ta\g_name/"#);
-        assert_eq!(tag.kind, "f");
-
-        // with different characters after pattern
-        let data = r#"tagname	filename	/pattern/[;"	f	"#;
-        let tag = TagItem::parse(&empty_path, data).unwrap();
-        assert_eq!(tag.address, "/pattern/");
-
-        // Without kind
-        let data = r#"tag_with_no_kind	filepath_here.py	/tag_with_no_kind/"#;
-        let tag = TagItem::parse(&empty_path, data).unwrap();
-        assert_eq!(tag.name, "tag_with_no_kind");
-        assert_eq!(tag.path, "filepath_here.py");
-        assert_eq!(tag.address, r#"/tag_with_no_kind/"#);
-        assert_eq!(tag.kind, "");
-
-        // Invalid: pattern
-        let data = r#"tag_name	filename.py	invalid/pattern/;""	f	"#;
-        assert_eq!(TagItem::parse(&empty_path, data).is_err(), true);
-
-        // With line-number address
-        let data = r#".Button.--icon .Button__icon	client/src/styles/Button.scss	86;"	r"#;
-        let tag = TagItem::parse(&empty_path, data).unwrap();
-        assert_eq!(tag.name, ".Button.--icon .Button__icon");
-        assert_eq!(tag.path, "client/src/styles/Button.scss");
-        assert_eq!(tag.address, r#"86"#);
-        assert_eq!(tag.kind, "r");
-
-        // With line-number address (hasktags style)
-        let data = r#"EndlessList	example.hs	3"#;
-        let tag = TagItem::parse(&empty_path, data).unwrap();
-        assert_eq!(tag.name, "EndlessList");
-        assert_eq!(tag.path, "example.hs");
-        assert_eq!(tag.address, r#"3"#);
+    fn on_terminate(&mut self, ctx: &mut Context, session_id: u64) {
+        if let Some(control) = self.searcher_control.take() {
+            // NOTE: The kill operation can not block current task.
+            tokio::task::spawn_blocking(move || control.kill());
+        }
+        ctx.signify_terminated(session_id);
     }
 }

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -157,6 +157,20 @@ pub fn to_display_lines(
     convert_truncated_matched_items_to_display_lines(matched_items, icon, truncated_map)
 }
 
+pub fn to_display_lines_full(
+    mut matched_items: Vec<MatchedItem>,
+    line_width: usize,
+    icon: Icon,
+    truncate_text: bool,
+) -> DisplayLines {
+    let truncated_map = if truncate_text {
+        truncate_item_output_text(matched_items.iter_mut(), line_width, None)
+    } else {
+        Default::default()
+    };
+    convert_truncated_matched_items_to_display_lines(matched_items, icon, truncated_map)
+}
+
 #[derive(Debug)]
 pub struct GrepResult {
     pub matched_item: MatchedItem,

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -147,16 +147,6 @@ fn convert_truncated_matched_items_to_display_lines(
     }
 }
 
-/// Returns the info of the truncated top items ranked by the filtering score.
-pub fn to_display_lines(
-    mut matched_items: Vec<MatchedItem>,
-    winwidth: usize,
-    icon: Icon,
-) -> DisplayLines {
-    let truncated_map = truncate_item_output_text(matched_items.iter_mut(), winwidth, None);
-    convert_truncated_matched_items_to_display_lines(matched_items, icon, truncated_map)
-}
-
 #[derive(Debug)]
 pub struct Printer {
     pub line_width: usize,
@@ -165,6 +155,15 @@ pub struct Printer {
 }
 
 impl Printer {
+    /// Constructs a new instance of `[Printer]` with text truncation enabled.
+    pub fn new(line_width: usize, icon: Icon) -> Self {
+        Self {
+            line_width,
+            icon,
+            truncate_text: true,
+        }
+    }
+
     pub fn to_display_lines(&self, mut matched_items: Vec<MatchedItem>) -> DisplayLines {
         let Self {
             line_width,

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -157,18 +157,29 @@ pub fn to_display_lines(
     convert_truncated_matched_items_to_display_lines(matched_items, icon, truncated_map)
 }
 
-pub fn to_display_lines_full(
-    mut matched_items: Vec<MatchedItem>,
-    line_width: usize,
-    icon: Icon,
-    truncate_text: bool,
-) -> DisplayLines {
-    let truncated_map = if truncate_text {
-        truncate_item_output_text(matched_items.iter_mut(), line_width, None)
-    } else {
-        Default::default()
-    };
-    convert_truncated_matched_items_to_display_lines(matched_items, icon, truncated_map)
+#[derive(Debug)]
+pub struct Printer {
+    pub line_width: usize,
+    pub icon: Icon,
+    pub truncate_text: bool,
+}
+
+impl Printer {
+    pub fn to_display_lines(&self, mut matched_items: Vec<MatchedItem>) -> DisplayLines {
+        let Self {
+            line_width,
+            icon,
+            truncate_text,
+        } = self;
+
+        let truncated_map = if *truncate_text {
+            truncate_item_output_text(matched_items.iter_mut(), *line_width, None)
+        } else {
+            Default::default()
+        };
+
+        convert_truncated_matched_items_to_display_lines(matched_items, *icon, truncated_map)
+    }
 }
 
 #[derive(Debug)]

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -147,7 +147,7 @@ fn convert_truncated_matched_items_to_display_lines(
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Printer {
     pub line_width: usize,
     pub icon: Icon,

--- a/syntax/clap_tagfiles.vim
+++ b/syntax/clap_tagfiles.vim
@@ -1,0 +1,14 @@
+setlocal conceallevel=3
+
+syntax match ClapTagfilesInfo     /\v:::.*$/            conceal
+
+syntax match ClapTagfilesName     /\v^.*\ze\s+\[.*\]/   contains=ClapTagfilesLnum
+syntax match ClapTagfilesBrackets /\[\|\]/              contained
+syntax match ClapTagfilesFilename /\v\f*\/\zs[^\]]+\ze/ contained
+syntax match ClapTagfilesFilename /\v\[@<=[^/]+\]@=/    contained
+syntax match ClapTagfilesPath     /\[\f\+\]/            contains=ClapTagfilesBrackets,ClapTagfilesFilename
+
+hi default link ClapTagfilesName              Special
+hi default link ClapTagfilesPath              Comment
+hi default link ClapTagfilesBrackets          Comment
+hi default link ClapTagfilesFilename          Directory


### PR DESCRIPTION
This PR implements a new provider `tagfiles` which reads the `tags` file from `cwd`, a continuation of the work from #557 (Thanks to @romgrk!). The architecture has been heavily reworked, it's now much easier to integrate it. There are some obvious room for improvement, I have marked TODOs there, please go ahead if anyone is interested in fixing them.

Close #446