### PR TITLE
Eliminate `cut` usage from install.sh

### DIFF
--- a/crates/icon/Cargo.toml
+++ b/crates/icon/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Liu-Cheng Xu <xuliuchengxlc@gmail.com>"]
 edition = "2021"
 license = "MIT"
 publish = false
+include = ["/Cargo.toml", "src/*.rs"]
 homepage = "https://github.com/liuchengxu/vim-clap"
 description = """
 icon is a tool for drawing an icon according to the path name for vim-clap.

--- a/crates/upgrade/src/lib.rs
+++ b/crates/upgrade/src/lib.rs
@@ -56,7 +56,7 @@ impl Upgrade {
                 }
             }
         } else {
-            println!("No newer release, current maple version: {latest_tag}");
+            println!("No newer prebuilt binary release, current maple version: {local_version}");
         }
 
         Ok(())


### PR DESCRIPTION
Replace `cut` with `awk` in `install.sh`.

Resolves #946
Resolves #947 