### PR TITLE
Improve syntax highlight of clap files

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ See `:help clap-options` for more information.
 
 - [x] Use `:q` to exit.
 
-See `:help clap-keybindings` for more information.
+See `:help clap-keybindings` for more information. Note that the [keybindings are not consistent](https://github.com/liuchengxu/vim-clap/issues/864) due to discrepancies between Vim/Neovim and different providers.
 
 ### Execute some code during the process
 

--- a/README.md
+++ b/README.md
@@ -151,15 +151,14 @@ Note the `*` in the spinner, it tells you are using the cache, use `g:clap_forer
 | `Clap filer`                           | Ivy-like file explorer                                 | **[maple][maple]**                                                      |
 | `Clap grep`**<sup>+</sup>**            | Grep using fuzzy matcher                               | **[maple][maple]**                                                      |
 | `Clap igrep`                           | A combo of `filer` and `grep`                          | **[maple][maple]**                                                      |
-| `Clap tags`                            | Tags in the current buffer                             | **[maple][maple]**/**[vista.vim][vista.vim]**                           |
-| `Clap tagfiles`                        | Search existing `tagfiles`                             | **[maple][maple]**/**[vista.vim][vista.vim]**                           |
+| `Clap tags`                            | Tags in the current buffer                             | **[maple][maple]**                                     |
+| `Clap tagfiles`                        | Search existing `tagfiles`                             | **[maple][maple]**                                                      |
 | `Clap proj_tags`                       | Tags in the current project                            | **[maple][maple]** and **[universal-ctags][universal-ctags]** (`+json`) |
 | `Clap recent_files`                    | Persistent ordered history of recent files             | **[maple][maple]**                                                      |
 
 [fd]: https://github.com/sharkdp/fd
 [rg]: https://github.com/BurntSushi/ripgrep
 [git]: https://github.com/git/git
-[vista.vim]: https://github.com/liuchengxu/vista.vim
 [maple]: https://github.com/liuchengxu/vim-clap/blob/master/INSTALL.md#maple-binary
 [universal-ctags]: https://github.com/universal-ctags/ctags
 

--- a/ftplugin/clap_input.vim
+++ b/ftplugin/clap_input.vim
@@ -129,3 +129,9 @@ nnoremap <silent> <buffer> <S-Down> :<c-u>call clap#client#notify_provider('shif
 
 inoremap <silent> <buffer> <S-Up>   <C-R>=<SID>Notify('shift-up')<CR>
 inoremap <silent> <buffer> <S-Down> <C-R>=<SID>Notify('shift-down')<CR>
+
+nnoremap <silent> <buffer> <S-ScrollWheelUp>   :<c-u>call clap#client#notify_provider('shift-up')<CR>
+nnoremap <silent> <buffer> <S-ScrollWheelDown> :<c-u>call clap#client#notify_provider('shift-down')<CR>
+
+inoremap <silent> <buffer> <S-ScrollWheelUp>   <C-R>=<SID>Notify('shift-up')<CR>
+inoremap <silent> <buffer> <S-ScrollWheelDown> <C-R>=<SID>Notify('shift-down')<CR>

--- a/syntax/clap_files.vim
+++ b/syntax/clap_files.vim
@@ -1,4 +1,5 @@
-hi TNormal ctermfg=249 ctermbg=NONE guifg=#b2b2b2 guibg=NONE
-execute 'syntax match ClapFile' '/^.*/' 'contains='.join(clap#icon#add_head_hl_groups(), ',')
+syntax match ClapFileName /\v(\/|\s)\zs(\w|[-.])+(\.\w+)?$/ contained
+execute 'syntax region ClapFilePath' 'start=/^\s*\S/ end=/(\w|[-.])+(\.\w\+)?$/' 'contains='.join(clap#icon#add_head_hl_groups(), ',').',ClapFileName'
 
-hi default link ClapFile TNormal
+highlight default link ClapFilePath Normal
+highlight default link ClapFileName Special


### PR DESCRIPTION
<img width="1512" alt="截屏2023-06-11 10 06 57" src="https://github.com/liuchengxu/vim-clap/assets/8850248/f926be8a-5405-4187-aa19-724a9f806387">
