### PR TITLE
Initiall support of preview scrollbar for neovim

### DIFF
--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -83,6 +83,13 @@ let g:clap_enable_background_shadow = get(g:, 'clap_enable_background_shadow', v
 let g:clap_disable_matches_indicator = get(g:, 'clap_disable_matches_indicator', v:false)
 let g:clap_multi_selection_warning_silent = get(g:, 'clap_multi_selection_warning_silent', 0)
 
+let s:default_clap_preview = { 'scrollbar': { 'fill_char': '▌' } }
+if exists('g:clap_preview')
+  call extend(g:clap_preview, s:default_clap_preview, 'keep')
+else
+  let g:clap_preview = s:default_clap_preview
+endif
+
 function! clap#builtin_providers() abort
   if !exists('s:builtin_providers')
     let s:builtin_providers = map(

--- a/autoload/clap/floating_win.vim
+++ b/autoload/clap/floating_win.vim
@@ -40,30 +40,28 @@ let s:symbol_left = g:__clap_search_box_border_symbol.left
 let s:symbol_right = g:__clap_search_box_border_symbol.right
 let s:symbol_width = strdisplaywidth(s:symbol_right)
 
-let g:clap_preview_scrollbar_fill_char = '▌'
+let s:shadow_winhl = 'Normal:ClapShadow,NormalNC:ClapShadow,EndOfBuffer:ClapShadow'
+let s:display_winhl = 'Normal:ClapDisplay,EndOfBuffer:ClapDisplayInvisibleEndOfBuffer,SignColumn:ClapDisplay,ColorColumn:ClapDisplay'
+let s:preview_winhl = 'Normal:ClapPreview,EndOfBuffer:ClapPreviewInvisibleEndOfBuffer,SignColumn:ClapPreview,ColorColumn:ClapPreview'
+let s:preview_scrollbar_winhl = 'Normal:ClapPreviewScrollbar,EndOfBuffer:ClapPreviewInvisibleEndOfBuffer,SignColumn:ClapPreviewScrollbar,ColorColumn:ClapPreviewScrollbar'
 
 if &background ==# 'dark'
-  if empty(get(g:, 'clap_preview_scrollbar_fill_char', ''))
+  if empty(get(g:clap_preview.scrollbar, 'fill_char', ''))
     hi ClapDefaultPreviewScrollbar ctermbg=237 guibg=#3E4452 ctermfg=173 guifg=#e18254 cterm=bold,reverse gui=bold,reverse
   else
-    let s:preview_scrollbar_fill_char = g:clap_preview_scrollbar_fill_char
+    let s:preview_scrollbar_fill_char = g:clap_preview.scrollbar.fill_char
     hi ClapDefaultPreviewScrollbar ctermbg=237 guibg=#3E4452 ctermfg=173 guifg=#e18254 cterm=bold gui=bold
   endif
 else
-  if empty(get(g:, 'clap_preview_scrollbar_fill_char', ''))
+  if empty(get(g:clap_preview.scrollbar, 'fill_char', ''))
     hi ClapDefaultPreviewScrollbar ctermbg=7 guibg=#ecf5ff ctermfg=173 guifg=#e18254 cterm=bold,reverse gui=bold,reverse
   else
-    let s:preview_scrollbar_fill_char = g:clap_preview_scrollbar_fill_char
+    let s:preview_scrollbar_fill_char = g:clap_preview.scrollbar.fill_char
     hi ClapDefaultPreviewScrollbar ctermbg=7 guibg=#ecf5ff ctermfg=173 guifg=#e18254 cterm=bold gui=bold
   endif
 endif
 
 hi default link ClapPreviewScrollbar ClapDefaultPreviewScrollbar
-
-let s:shadow_winhl = 'Normal:ClapShadow,NormalNC:ClapShadow,EndOfBuffer:ClapShadow'
-let s:display_winhl = 'Normal:ClapDisplay,EndOfBuffer:ClapDisplayInvisibleEndOfBuffer,SignColumn:ClapDisplay,ColorColumn:ClapDisplay'
-let s:preview_winhl = 'Normal:ClapPreview,EndOfBuffer:ClapPreviewInvisibleEndOfBuffer,SignColumn:ClapPreview,ColorColumn:ClapPreview'
-let s:preview_scrollbar_winhl = 'Normal:ClapPreviewScrollbar,EndOfBuffer:ClapPreviewInvisibleEndOfBuffer,SignColumn:ClapPreviewScrollbar,ColorColumn:ClapPreviewScrollbar'
 
 " shadow
 "  -----------------------------
@@ -408,22 +406,20 @@ function! clap#floating_win#show_preview_scrollbar(top_position, length) abort
     let config.height = a:length
     call nvim_win_set_config(s:preview_scrollbar_winid, config)
     if exists('s:preview_scrollbar_fill_char')
-      call s:update_preview_scrollbar_buf(a:length)
+      call s:update_preview_scrollbar(a:length)
     endif
   else
     call s:create_preview_scrollbar_win(a:top_position, a:length)
   endif
 endfunction
 
-function! s:update_preview_scrollbar_buf(length) abort
-  let fill_char = '▌'
-  " let fill_char = '│'
-  let lines = repeat([fill_char], a:length)
+function! s:update_preview_scrollbar(length) abort
+  let lines = repeat([s:preview_scrollbar_fill_char], a:length)
   call clap#util#nvim_buf_set_lines(s:preview_scrollbar_buf, lines)
 endfunction
 
 function! s:create_preview_scrollbar_win(top_position, length) abort
-  if !exists('s:preview_winid') || !nvim_win_is_valid(s:preview_winid)
+  if !exists('s:preview_winid') || !nvim_win_is_valid(s:preview_winid) || !exists('s:preview_scrollbar_fill_char')
     return
   endif
 
@@ -456,9 +452,7 @@ function! s:create_preview_scrollbar_win(top_position, length) abort
 
   call setwinvar(s:preview_scrollbar_winid, '&winhl', s:preview_scrollbar_winhl)
 
-  if exists('s:preview_scrollbar_fill_char')
-    call s:update_preview_scrollbar_buf(a:length)
-  endif
+  call s:update_preview_scrollbar(a:length)
 endfunction
 
 function! s:max_preview_size() abort

--- a/autoload/clap/state.vim
+++ b/autoload/clap/state.vim
@@ -119,6 +119,12 @@ function! clap#state#render_preview(preview) abort
     if has_key(a:preview, 'hi_lnum')
       call g:clap.preview.add_highlight(a:preview.hi_lnum+1)
     endif
+
+    if has_key(a:preview, 'scrollbar')
+      let g:scrollbar = copy(a:preview.scrollbar)
+      let [top_position, length] = a:preview.scrollbar
+      call clap#floating_win#show_scrollbar(top_position, length)
+    endif
   endif
 endfunction
 

--- a/autoload/clap/state.vim
+++ b/autoload/clap/state.vim
@@ -123,7 +123,7 @@ function! clap#state#render_preview(preview) abort
     if has_key(a:preview, 'scrollbar')
       let g:scrollbar = copy(a:preview.scrollbar)
       let [top_position, length] = a:preview.scrollbar
-      call clap#floating_win#show_scrollbar(top_position, length)
+      call clap#floating_win#show_preview_scrollbar(top_position, length)
     endif
   endif
 endfunction

--- a/autoload/clap/themes.vim
+++ b/autoload/clap/themes.vim
@@ -205,9 +205,10 @@ function! s:init_theme() abort
 endfunction
 
 function! clap#themes#init() abort
-  hi default link ClapMatches Search
+  hi default link ClapMatches        Search
   hi default link ClapNoMatchesFound ErrorMsg
-  hi default link ClapPopupCursor Type
+  hi default link ClapPopupCursor    Type
+  hi default link ClapScrollbar      IncSearch
 
   if exists('g:clap_theme')
     " If anything is wrong, just use the default theme.

--- a/autoload/clap/themes.vim
+++ b/autoload/clap/themes.vim
@@ -208,7 +208,6 @@ function! clap#themes#init() abort
   hi default link ClapMatches        Search
   hi default link ClapNoMatchesFound ErrorMsg
   hi default link ClapPopupCursor    Type
-  hi default link ClapScrollbar      IncSearch
 
   if exists('g:clap_theme')
     " If anything is wrong, just use the default theme.

--- a/crates/maple_core/src/config.rs
+++ b/crates/maple_core/src/config.rs
@@ -78,19 +78,11 @@ impl MatcherConfig {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Default)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct PickerConfig {
     /// Specifies how many items will be displayed in the results window.
-    pub display_limit: Option<usize>,
-}
-
-impl Default for PickerConfig {
-    fn default() -> Self {
-        Self {
-            display_limit: None,
-        }
-    }
+    pub max_display_size: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -268,13 +260,13 @@ mod tests {
           "files" = 100
 
           [global-ignore]
-          file-path-pattern = ["test", "build"]
+          ignore-file-path-pattern = ["test", "build"]
 
           # [project-ignore."~/src/github.com/subspace/subspace"]
-          # comment-line = true
+          # ignore-comments = true
 
           [provider.ignore.dumb_jump]
-          comment-line = true
+          ignore-comments = true
 "#;
         let user_config: Config =
             toml::from_str(toml_content).expect("Failed to deserialize config");

--- a/crates/maple_core/src/config.rs
+++ b/crates/maple_core/src/config.rs
@@ -80,6 +80,21 @@ impl MatcherConfig {
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
+pub struct PickerConfig {
+    /// Specifies how many items will be displayed in the results window.
+    pub display_limit: Option<usize>,
+}
+
+impl Default for PickerConfig {
+    fn default() -> Self {
+        Self {
+            display_limit: None,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct LogConfig {
     pub log_file: Option<String>,
     pub max_level: String,
@@ -133,13 +148,13 @@ pub struct PluginConfig {
 #[serde(rename_all = "kebab-case", default, deny_unknown_fields)]
 pub struct IgnoreConfig {
     /// Whether to ignore the comment line when it's possible.
-    pub comment_line: bool,
+    pub ignore_comments: bool,
     /// Only include the results from the files being tracked by git if in a git repo.
     pub git_tracked_only: bool,
     /// Ignore the results from the files whose file name matches this pattern.
-    pub file_name_pattern: Vec<String>,
+    pub ignore_file_name_pattern: Vec<String>,
     /// Ignore the results from the files whose file path matches this pattern.
-    pub file_path_pattern: Vec<String>,
+    pub ignore_file_path_pattern: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
@@ -183,6 +198,9 @@ pub struct Config {
 
     /// Matcher configuration.
     pub matcher: MatcherConfig,
+
+    /// Picker configuration.
+    pub picker: PickerConfig,
 
     /// Plugin configuration.
     pub plugin: PluginConfig,

--- a/crates/maple_core/src/previewer/mod.rs
+++ b/crates/maple_core/src/previewer/mod.rs
@@ -10,10 +10,12 @@ use utils::read_first_lines;
 /// Preview of a file.
 #[derive(Clone, Debug)]
 pub struct FilePreview {
-    /// Line number at which the preview starts (exclusive).
+    /// Line number of source file at which the preview starts (exclusive).
     pub start: usize,
-    /// Line number at which the preview ends (inclusive).
+    /// Line number of source file at which the preview ends (inclusive).
     pub end: usize,
+    /// Total lines in the source file.
+    pub total: usize,
     /// Line number of the line that should be highlighed in the preview window.
     pub highlight_lnum: usize,
     /// [start, end] of the source file.
@@ -36,11 +38,15 @@ pub fn get_file_preview<P: AsRef<Path>>(
         (0, winheight, target_line_number)
     };
 
+    let total = utils::count_lines(std::fs::File::open(path.as_ref())?)?;
+
     let lines = read_preview_lines(path, start, end)?;
+    let end = end.min(total);
 
     Ok(FilePreview {
         start,
         end,
+        total,
         highlight_lnum,
         lines,
     })

--- a/crates/maple_core/src/stdio_server/handler/on_move.rs
+++ b/crates/maple_core/src/stdio_server/handler/on_move.rs
@@ -342,24 +342,15 @@ impl<'a> CachedPreviewImpl<'a> {
         let total = utils::count_lines(std::fs::File::open(path)?)?;
         let end = lines.len();
 
-        let scrollbar = if end > 0 {
+        let scrollbar = if self.ctx.env.is_nvim && end > 0 {
             let preview_winheight = self.ctx.env.display_winheight;
 
-            let length = (end * preview_winheight) as f32 / total as f32;
+            let length = ((end * preview_winheight) as f32 / total as f32) as usize;
 
-            tracing::debug!(
-                end,
-                total,
-                preview_winheight,
-                length,
-                border_enabled = self.ctx.env.preview_border_enabled,
-                "============== calculate_hash"
-            );
-
-            if length as usize == 0 {
+            if length == 0 {
                 None
             } else {
-                let mut length = preview_winheight.min(length as usize);
+                let mut length = preview_winheight.min(length);
                 let top_position = if self.ctx.env.preview_border_enabled {
                     length -= if length == preview_winheight { 1 } else { 0 };
 
@@ -487,30 +478,21 @@ impl<'a> CachedPreviewImpl<'a> {
                     .chain(self.truncate_preview_lines(lines.into_iter()))
                     .collect::<Vec<_>>();
 
-                let scrollbar = if total > 0 {
+                let scrollbar = if self.ctx.env.is_nvim && total > 0 {
                     let start = if context_lines_not_empty {
                         start.saturating_sub(3)
                     } else {
                         start
                     };
                     let preview_winheight = self.ctx.env.display_winheight;
-                    let length = ((end - start) * preview_winheight) as f32 / total as f32;
+                    let length =
+                        (((end - start) * preview_winheight) as f32 / total as f32) as usize;
                     let top_position = (start * preview_winheight) as f32 / total as f32;
 
-                    tracing::debug!(
-                        start,
-                        end,
-                        total,
-                        preview_winheight,
-                        length,
-                        top_position,
-                        "============== calculate_hash"
-                    );
-
-                    if length as usize == 0 {
+                    if length == 0 {
                         None
                     } else {
-                        let mut length = preview_winheight.min(length as usize);
+                        let mut length = preview_winheight.min(length);
                         let top_position = if self.ctx.env.preview_border_enabled {
                             length -= if length == preview_winheight { 1 } else { 0 };
 

--- a/crates/maple_core/src/stdio_server/handler/on_move.rs
+++ b/crates/maple_core/src/stdio_server/handler/on_move.rs
@@ -24,6 +24,8 @@ pub struct Preview {
     pub fname: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hi_lnum: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scrollbar: Option<(usize, usize)>,
 }
 
 impl Preview {
@@ -261,6 +263,7 @@ impl<'a> CachedPreviewImpl<'a> {
                 hi_lnum: Some(1),
                 fname: Some(fname),
                 syntax: Some("help".into()),
+                scrollbar: None,
             }
         } else {
             tracing::debug!(?preview_tag, "Can not find the preview help lines");
@@ -336,24 +339,61 @@ impl<'a> CachedPreviewImpl<'a> {
             }
         };
 
+        let total = utils::count_lines(std::fs::File::open(path)?)?;
+        let end = lines.len();
+
+        let scrollbar = if end > 0 {
+            let preview_winheight = self.ctx.env.display_winheight;
+
+            let length = (end * preview_winheight) as f32 / total as f32;
+
+            tracing::debug!(
+                end,
+                total,
+                preview_winheight,
+                length,
+                border_enabled = self.ctx.env.preview_border_enabled,
+                "============== calculate_hash"
+            );
+
+            if length as usize == 0 {
+                None
+            } else {
+                let mut length = preview_winheight.min(length as usize);
+                let top_position = if self.ctx.env.preview_border_enabled {
+                    length -= if length == preview_winheight { 1 } else { 0 };
+
+                    1usize
+                } else {
+                    0usize
+                };
+                Some((top_position, length))
+            }
+        } else {
+            None
+        };
+
         if std::fs::metadata(path)?.len() == 0 {
             let mut lines = lines;
             lines.push("<Empty file>".to_string());
             Ok(Preview {
                 lines,
                 fname: Some(fname),
+                scrollbar,
                 ..Default::default()
             })
         } else if let Some(syntax) = preview_syntax(path) {
             Ok(Preview {
                 lines,
                 syntax: Some(syntax.into()),
+                scrollbar,
                 ..Default::default()
             })
         } else {
             Ok(Preview {
                 lines,
                 fname: Some(fname),
+                scrollbar,
                 ..Default::default()
             })
         }
@@ -379,10 +419,11 @@ impl<'a> CachedPreviewImpl<'a> {
 
         match get_file_preview(path, lnum, self.preview_height) {
             Ok(FilePreview {
-                lines,
-                highlight_lnum,
                 start,
-                ..
+                end,
+                total,
+                highlight_lnum,
+                lines,
             }) => {
                 let mut context_lines = Vec::new();
 
@@ -438,11 +479,51 @@ impl<'a> CachedPreviewImpl<'a> {
 
                 let highlight_lnum = highlight_lnum + context_lines.len();
 
+                let context_lines_not_empty = context_lines.is_empty();
+
                 let header_line = truncated_preview_header();
                 let lines = std::iter::once(header_line)
                     .chain(context_lines.into_iter())
                     .chain(self.truncate_preview_lines(lines.into_iter()))
                     .collect::<Vec<_>>();
+
+                let scrollbar = if total > 0 {
+                    let start = if context_lines_not_empty {
+                        start.saturating_sub(3)
+                    } else {
+                        start
+                    };
+                    let preview_winheight = self.ctx.env.display_winheight;
+                    let length = ((end - start) * preview_winheight) as f32 / total as f32;
+                    let top_position = (start * preview_winheight) as f32 / total as f32;
+
+                    tracing::debug!(
+                        start,
+                        end,
+                        total,
+                        preview_winheight,
+                        length,
+                        top_position,
+                        "============== calculate_hash"
+                    );
+
+                    if length as usize == 0 {
+                        None
+                    } else {
+                        let mut length = preview_winheight.min(length as usize);
+                        let top_position = if self.ctx.env.preview_border_enabled {
+                            length -= if length == preview_winheight { 1 } else { 0 };
+
+                            1usize.max(top_position as usize)
+                        } else {
+                            top_position as usize
+                        };
+
+                        Some((top_position, length))
+                    }
+                } else {
+                    None
+                };
 
                 if let Some(syntax) = preview_syntax(path) {
                     Preview {
@@ -450,6 +531,7 @@ impl<'a> CachedPreviewImpl<'a> {
                         syntax: Some(syntax.into()),
                         hi_lnum: Some(highlight_lnum),
                         fname: None,
+                        scrollbar,
                     }
                 } else {
                     Preview {
@@ -457,6 +539,7 @@ impl<'a> CachedPreviewImpl<'a> {
                         syntax: None,
                         hi_lnum: Some(highlight_lnum),
                         fname: Some(fname),
+                        scrollbar,
                     }
                 }
             }

--- a/crates/maple_core/src/stdio_server/handler/on_move.rs
+++ b/crates/maple_core/src/stdio_server/handler/on_move.rs
@@ -342,7 +342,10 @@ impl<'a> CachedPreviewImpl<'a> {
         let total = utils::count_lines(std::fs::File::open(path)?)?;
         let end = lines.len();
 
-        let scrollbar = if self.ctx.env.is_nvim && end > 0 {
+        let scrollbar = if self.ctx.env.is_nvim
+            && self.ctx.env.preview_direction.to_uppercase() == "LR"
+            && end > 0
+        {
             let preview_winheight = self.ctx.env.display_winheight;
 
             let length = ((end * preview_winheight) as f32 / total as f32) as usize;
@@ -478,7 +481,10 @@ impl<'a> CachedPreviewImpl<'a> {
                     .chain(self.truncate_preview_lines(lines.into_iter()))
                     .collect::<Vec<_>>();
 
-                let scrollbar = if self.ctx.env.is_nvim && total > 0 {
+                let scrollbar = if self.ctx.env.is_nvim
+                    && self.ctx.env.preview_direction.to_uppercase() == "LR"
+                    && total > 0
+                {
                     let start = if context_lines_not_empty {
                         start.saturating_sub(3)
                     } else {

--- a/crates/maple_core/src/stdio_server/provider/dumb_jump/searcher.rs
+++ b/crates/maple_core/src/stdio_server/provider/dumb_jump/searcher.rs
@@ -178,7 +178,7 @@ fn filter_usages(
 ) -> Vec<AddressableUsage> {
     let IgnoreConfig {
         git_tracked_only,
-        file_path_pattern,
+        ignore_file_path_pattern,
         ..
     } = crate::config::config().ignore_config("dumb_jump", cwd);
 
@@ -201,7 +201,7 @@ fn filter_usages(
 
     // Ignore the results from the file whose path contains `test`
     addressable_usages.retain(|usage| {
-        !file_path_pattern
+        !ignore_file_path_pattern
             .iter()
             .any(|ignore_pattern| usage.path.contains(ignore_pattern))
     });

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -357,6 +357,7 @@ impl Context {
         self.env.matcher_builder.clone().build(query.into())
     }
 
+    /// Constructs a [`SearchContext`] for the searching worker.
     pub fn search_context(&self, stop_signal: Arc<AtomicBool>) -> SearchContext {
         SearchContext {
             icon: self.env.icon,

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -105,6 +105,7 @@ pub struct ProviderEnvironment {
     pub no_cache: bool,
     pub source_is_list: bool,
     pub preview_enabled: bool,
+    pub preview_border_enabled: bool,
     pub display_winwidth: usize,
     pub display_winheight: usize,
     /// Actual width for displaying the line content due to the sign column is included in
@@ -297,6 +298,7 @@ impl Context {
         let is_nvim: usize = vim.call("has", ["nvim"]).await?;
         let has_nvim_09: usize = vim.call("has", ["nvim-0.9"]).await?;
         let preview_enabled: usize = vim.bare_call("clap#preview#is_enabled").await?;
+        let popup_border: String = vim.eval("g:clap_popup_border").await?;
 
         let input_history = crate::datastore::INPUT_HISTORY_IN_MEMORY.lock();
         let inputs = if crate::config::config().input_history.share_all_inputs {
@@ -316,6 +318,7 @@ impl Context {
             no_cache,
             source_is_list,
             preview_enabled: preview_enabled == 1,
+            preview_border_enabled: popup_border != "nil",
             start_buffer_path,
             display_winwidth,
             display_winheight,

--- a/crates/maple_core/src/stdio_server/provider/mod.rs
+++ b/crates/maple_core/src/stdio_server/provider/mod.rs
@@ -106,6 +106,7 @@ pub struct ProviderEnvironment {
     pub source_is_list: bool,
     pub preview_enabled: bool,
     pub preview_border_enabled: bool,
+    pub preview_direction: String,
     pub display_winwidth: usize,
     pub display_winheight: usize,
     /// Actual width for displaying the line content due to the sign column is included in
@@ -298,6 +299,8 @@ impl Context {
         let is_nvim: usize = vim.call("has", ["nvim"]).await?;
         let has_nvim_09: usize = vim.call("has", ["nvim-0.9"]).await?;
         let preview_enabled: usize = vim.bare_call("clap#preview#is_enabled").await?;
+        let preview_direction: String = vim.bare_call("clap#preview#direction").await?;
+
         let popup_border: String = vim.eval("g:clap_popup_border").await?;
 
         let input_history = crate::datastore::INPUT_HISTORY_IN_MEMORY.lock();
@@ -319,6 +322,7 @@ impl Context {
             source_is_list,
             preview_enabled: preview_enabled == 1,
             preview_border_enabled: popup_border != "nil",
+            preview_direction,
             start_buffer_path,
             display_winwidth,
             display_winheight,

--- a/doc/clap.txt
+++ b/doc/clap.txt
@@ -300,6 +300,15 @@ g:clap_selected_sign                                     *g:clap_selected_sign*
   Default: `{ 'text': ' >', 'texthl': 'ClapSelectedSign', 'linehl': 'ClapSelected' }`
 
 
+g:clap_preview                                                 *g:clap_preview*
+
+  Type: |Dict|
+  Default: `{ 'scrollbar': { 'fill_char': '▌' } }`
+
+  This variable controls the scrollbar for preview window, available for
+  neovim only.
+
+
 g:clap_open_preview                                       *g:clap_open_preview*
 
   Type: |String|


### PR DESCRIPTION
When the preview direction is `LR` for neovim, the scrollbar will be enabled automatically. If you'd like to customize the scrollbar or disable it,

```vim
" Change the fill char of scrollbar
let g:clap_preview = { 'scrollbar': { 'fill_char': '▌' } }

" Disable the scrollbar
let g:clap_preview = { 'scrollbar': { 'fill_char': '' } }
```