### PR TITLE
`:Clap files --path foo --no-cwd` fails

### DIFF
--- a/crates/maple_core/src/stdio_server/provider/files.rs
+++ b/crates/maple_core/src/stdio_server/provider/files.rs
@@ -120,7 +120,7 @@ impl ClapProvider for FilesProvider {
                     }
                 }
 
-                ctx.vim.set_var("g:__clap_provider_cwd", json!([ctx.cwd]))?;
+                ctx.vim.set_var("g:__clap_provider_cwd", json!(ctx.cwd))?;
             }
         }
 


### PR DESCRIPTION
```
:Clap files --path /etc/ --no-cwd
```
And if I choose anything, it results in an error.

```
vim-clap: target_dir:['/etc/'], Run:function('42', {'is_sync': function('57'), 'init_display_win': function('59'), 'supp
ort_multi_select': function('52'), '_apply_sink': function('42'), 'id': 'files', 'filter': function('51'), 'sink_star': 
function('45'), 'sink': function('44'), 'support_open_action': function('53'), '_': function('40'), 'is_pure_async': fun
ction('58'), 'try_set_syntax': function('55'), 'on_typed': function('47'), 'on_exit': function('49'), 'has_enable_rooter
': function('43'), 'jobstop': function('50'), 'abort': function('41'), 'is_rpc_type': function('54'), 'on_enter': functi
on('46'), '_apply_source': function('56'), 'on_move': function('48')}), run_args:'rpc', exception:Vim(execute):E730: Usi
ng a List as a String
vim-clap: s:provider_sink: Vim(if):E691: Can only compare List with List, throwpoint:function clap#popup#move_manager#fi
lter[3]..<lambda>5[1]..clap#handler#handle_mapping[4]..<SNR>52_provider_sink[26]..44[1]..clap#rooter#run_sink_or_sink_st
ar[2]..<SNR>46_run_from_target_dir, line 16
```