### PR TITLE
Refine linter plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "camino"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-lock"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,6 +219,29 @@ dependencies = [
  "serde",
  "toml 0.7.6",
  "url",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfa25e60aea747ec7e1124f238816749faa93759c6ff5b31f1ccdda137f4479"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb9ac64500cc83ce4b9f8dafa78186aa008c8dea77a09b94cd307fd0cd5022a8"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1099,6 +1131,7 @@ dependencies = [
 name = "linter"
 version = "0.1.0"
 dependencies = [
+ "cargo_metadata",
  "once_cell",
  "parking_lot",
  "paths",

--- a/autoload/clap/plugin/git.vim
+++ b/autoload/clap/plugin/git.vim
@@ -46,32 +46,19 @@ if has('nvim')
 else
 
   function! clap#plugin#git#clear_blame_info(bufnr) abort
-    let popup_id = getbufvar(a:bufnr, 'clap_git_blame_popup_id')
-    if !empty(popup_id)
-      call popup_hide(popup_id)
-    endif
+    " Popup will be closed automatically due to the `moved` option.
   endfunction
 
   function! clap#plugin#git#show_cursor_blame_info(bufnr, text) abort
     let col_offset = 4 + col('$') - col('.')
-    let popup_id = getbufvar(a:bufnr, 'clap_git_blame_popup_id')
-    if empty(popup_id) || empty(popup_getpos(popup_id))
-      if !empty(popup_id)
-        call popup_close(popup_id)
-      endif
-      let popup_id = popup_create(a:text, {
-            \ 'line': 'cursor',
-            \ 'col': printf('cursor+%d', col_offset),
-            \ 'highlight': 'ClapBlameInfo',
-            \ 'wrap': v:true,
-            \ 'zindex': 100,
-            \ })
-      call setbufvar(a:bufnr, 'clap_git_blame_popup_id', popup_id)
-    else
-      call popup_settext(popup_id, a:text)
-      call popup_move(popup_id, { 'line': 'cursor', 'col': printf('cursor+%d', col_offset) })
-      call popup_show(popup_id)
-    endif
+    let popup_id = popup_create(a:text, {
+          \ 'line': 'cursor',
+          \ 'col': printf('cursor+%d', col_offset),
+          \ 'highlight': 'ClapBlameInfo',
+          \ 'wrap': v:true,
+          \ 'zindex': 100,
+          \ 'moved': [line('.'), 1, -1],
+          \ })
   endfunction
 
 endif

--- a/autoload/clap/plugin/linter.vim
+++ b/autoload/clap/plugin/linter.vim
@@ -123,6 +123,8 @@ function! clap#plugin#linter#clear_top_right() abort
   endif
 endfunction
 
+" FIXME: The top right floating win can disturb the editing area when cursor
+" is at the top right location.
 function! clap#plugin#linter#display_top_right(current_diagnostics) abort
   if !empty(a:current_diagnostics)
     let [lines, line_highlights] = s:convert_diagnostics_to_lines(a:current_diagnostics)

--- a/crates/Cargo.toml
+++ b/crates/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 base64 = "0.13"
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
+cargo_metadata = "0.18.0"
 chrono = { version = "0.4", features = ["serde"] }
 chrono-humanize = "0.2.3"
 clap = { version = "4.2", features = ["derive"] }

--- a/crates/linter/Cargo.toml
+++ b/crates/linter/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+cargo_metadata = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true }
 regex = { workspace = true }

--- a/crates/linter/src/lib.rs
+++ b/crates/linter/src/lib.rs
@@ -20,17 +20,28 @@ pub enum Severity {
     Warning,
     Info,
     Hint,
+    Note,
     Help,
     Style,
     Unknown,
 }
 
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
+pub struct DiagnosticSpan {
+    /// 1-based.
+    pub line_start: usize,
+    /// 1-based.
+    pub line_end: usize,
+    /// 1-based. Character offset.
+    pub column_start: usize,
+    /// 1-based. Character offset
+    pub column_end: usize,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Diagnostic {
-    pub line_start: usize,
-    pub line_end: usize,
-    pub column_start: usize,
-    pub column_end: usize,
+    /// A list of source code spans this diagnostic is associated with.
+    pub spans: Vec<DiagnosticSpan>,
     #[serde(flatten)]
     pub code: Code,
     pub severity: Severity,
@@ -45,9 +56,13 @@ impl PartialEq for Diagnostic {
         // same message, they visually make no differences. For instance,
         // some linter does not provide the severity property but has the
         // rest fields as same as the other linters.
-        self.line_start == other.line_start
-            && self.column_start == other.column_start
-            && self.column_end == other.column_end
+        //
+        // TODO: custom DiagnosticSpan PartialEq impl?
+        // self.line_start == other.line_start
+        // && self.column_start == other.column_start
+        // && self.column_end == other.column_end
+
+        self.spans == other.spans
             // Having two diagnostics with the same code but different message is possible, which
             // points to the same error essentially.
             && (is_same_code() || self.message == other.message)

--- a/crates/linter/src/linters/go.rs
+++ b/crates/linter/src/linters/go.rs
@@ -7,14 +7,16 @@ use std::path::Path;
 static RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"(?m)^([^:]+):([0-9]+):([0-9]+)-([0-9]+): (.+)$").unwrap());
 
-pub async fn run_gopls(source_file: &Path, workspace: &Path) -> std::io::Result<LinterResult> {
+pub async fn run_gopls(source_file: &Path, workspace_root: &Path) -> std::io::Result<LinterResult> {
     // Use relative path as the workspace is specified explicitly, otherwise it's
     // possible to run into a glitch when the directory is a symlink?
-    let source_file = source_file.strip_prefix(workspace).unwrap_or(source_file);
+    let source_file = source_file
+        .strip_prefix(workspace_root)
+        .unwrap_or(source_file);
     let output = tokio::process::Command::new("gopls")
         .arg("check")
         .arg(source_file)
-        .current_dir(workspace)
+        .current_dir(workspace_root)
         .output()
         .await?;
 

--- a/crates/linter/src/linters/go.rs
+++ b/crates/linter/src/linters/go.rs
@@ -1,4 +1,4 @@
-use crate::{Code, Diagnostic, LinterResult, Severity};
+use crate::{Code, Diagnostic, DiagnosticSpan, LinterResult, Severity};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::path::Path;
@@ -35,10 +35,12 @@ pub async fn run_gopls(source_file: &Path, workspace: &Path) -> std::io::Result<
                     .parse::<usize>()
                     .expect("column_end must be a Number");
                 diagnostics.push(Diagnostic {
-                    line_start: line,
-                    line_end: line,
-                    column_start,
-                    column_end,
+                    spans: vec![DiagnosticSpan {
+                        line_start: line,
+                        line_end: line,
+                        column_start,
+                        column_end,
+                    }],
                     code: Code::default(),
                     severity: Severity::Error,
                     message: message.to_string(),

--- a/crates/linter/src/linters/rust.rs
+++ b/crates/linter/src/linters/rust.rs
@@ -181,6 +181,7 @@ enum JsonMessage {
 
 // https://github.com/rust-lang/rust-analyzer/blob/12e28c35758051dd6bc9cdf419a50dff80fab64d/crates/flycheck/src/lib.rs#L483
 // Try to deserialize a message from Cargo or Rustc.
+#[allow(clippy::single_match)]
 fn process_line(line: &[u8]) -> Option<CargoMessage> {
     let mut deserializer = serde_json::Deserializer::from_slice(line);
     deserializer.disable_recursion_limit();

--- a/crates/linter/src/linters/rust.rs
+++ b/crates/linter/src/linters/rust.rs
@@ -10,14 +10,14 @@ use tokio::task::JoinHandle;
 #[derive(Clone)]
 pub struct RustLinter {
     source_file: PathBuf,
-    workspace: PathBuf,
+    workspace_root: PathBuf,
 }
 
 impl RustLinter {
-    pub fn new(source_file: PathBuf, workspace: PathBuf) -> Self {
+    pub fn new(source_file: PathBuf, workspace_root: PathBuf) -> Self {
         Self {
             source_file,
-            workspace,
+            workspace_root,
         }
     }
 
@@ -56,7 +56,7 @@ impl RustLinter {
         let output = std::process::Command::new("cargo")
             .args(["check", "--frozen", "--message-format=json", "-q"])
             .stderr(Stdio::null())
-            .current_dir(&self.workspace)
+            .current_dir(&self.workspace_root)
             .output()?;
 
         Ok(LinterResult {
@@ -79,7 +79,7 @@ impl RustLinter {
                 "warnings",
             ])
             .stderr(Stdio::null())
-            .current_dir(&self.workspace)
+            .current_dir(&self.workspace_root)
             .output()?;
 
         Ok(LinterResult {
@@ -91,7 +91,7 @@ impl RustLinter {
     fn parse_cargo_message(&self, stdout: &[u8]) -> Vec<Diagnostic> {
         let Some(source_filename) = self
             .source_file
-            .strip_prefix(self.workspace.parent().unwrap_or(&self.workspace))
+            .strip_prefix(self.workspace_root.parent().unwrap_or(&self.workspace_root))
             .unwrap_or(self.source_file.as_ref())
             .to_str()
         else {

--- a/crates/linter/src/linters/rust.rs
+++ b/crates/linter/src/linters/rust.rs
@@ -1,35 +1,11 @@
 use crate::{
-    Code, Diagnostic, HandleLinterResult, LintEngine, LinterResult, RustLintEngine, Severity,
+    Code, Diagnostic, DiagnosticSpan, HandleLinterResult, LintEngine, LinterResult, RustLintEngine,
+    Severity,
 };
 use serde::Deserialize;
-use serde_json::Value;
-use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;
 use tokio::task::JoinHandle;
-
-#[derive(Deserialize, Debug)]
-pub struct PartialSpan {
-    line_start: usize,
-    line_end: usize,
-    column_start: usize,
-    column_end: usize,
-    file_name: String,
-    #[allow(unused)]
-    label: Option<String>,
-    #[allow(unused)]
-    level: Option<String>,
-    #[allow(unused)]
-    rendered: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-struct CargoCheckErrorMessage {
-    code: Code,
-    level: String,
-    message: String,
-    spans: Vec<PartialSpan>,
-}
 
 #[derive(Clone)]
 pub struct RustLinter {
@@ -122,53 +98,106 @@ impl RustLinter {
             return Vec::new();
         };
 
-        let mut diagonostics = Vec::new();
-
-        let lines = stdout
+        stdout
             .split(|&b| b == b'\n')
-            .map(|line| line.strip_suffix(b"\r").unwrap_or(line));
-
-        for line in lines {
-            if let Ok(mut line) = serde_json::from_slice::<HashMap<String, Value>>(line) {
-                if let Some(message) = line.remove("message") {
-                    if let Ok(error_message) =
-                        serde_json::from_value::<CargoCheckErrorMessage>(message)
-                    {
-                        let CargoCheckErrorMessage {
-                            code,
-                            level,
-                            message,
-                            spans,
-                        } = error_message;
-
-                        let severity = match level.as_str() {
-                            "error" => Severity::Error,
-                            "warning" => Severity::Warning,
-                            _ => Severity::Unknown,
-                        };
-
-                        let line_diagnostics = spans.into_iter().filter_map(|span| {
-                            if span.file_name == source_filename {
-                                Some(Diagnostic {
-                                    line_start: span.line_start,
-                                    line_end: span.line_end,
-                                    column_start: span.column_start,
-                                    column_end: span.column_end,
-                                    code: code.clone(),
-                                    severity,
-                                    message: message.clone(),
-                                })
-                            } else {
-                                None
-                            }
-                        });
-
-                        diagonostics.extend(line_diagnostics);
-                    }
+            .map(|line| line.strip_suffix(b"\r").unwrap_or(line))
+            .filter_map(process_line)
+            .filter_map(|cargo_message| match cargo_message {
+                CargoMessage::Diagnostic(diagonostic) => {
+                    convert_cargo_diagnostic_to_our_diagnostic(diagonostic, source_filename)
                 }
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+fn convert_cargo_diagnostic_to_our_diagnostic(
+    cargo_diagnostic: cargo_metadata::diagnostic::Diagnostic,
+    source_filename: &str,
+) -> Option<Diagnostic> {
+    use cargo_metadata::diagnostic::DiagnosticLevel;
+
+    let severity = match cargo_diagnostic.level {
+        DiagnosticLevel::Error | DiagnosticLevel::Ice => Severity::Error,
+        DiagnosticLevel::Warning | DiagnosticLevel::FailureNote => Severity::Warning,
+        DiagnosticLevel::Note => Severity::Note,
+        DiagnosticLevel::Help => Severity::Help,
+        _ => Severity::Unknown,
+    };
+
+    let code = cargo_diagnostic
+        .code
+        .map(|c| Code { code: c.code })
+        .unwrap_or_default();
+
+    // Ignore the diagnostics without span.
+    if cargo_diagnostic.spans.is_empty() {
+        return None;
+    }
+
+    let spans = cargo_diagnostic
+        .spans
+        .iter()
+        .filter_map(|span| {
+            if span.file_name == source_filename {
+                Some(DiagnosticSpan {
+                    line_start: span.line_start,
+                    line_end: span.line_end,
+                    column_start: span.column_start,
+                    column_end: span.column_end,
+                })
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if spans.is_empty() {
+        return None;
+    }
+
+    Some(Diagnostic {
+        spans,
+        code,
+        severity,
+        message: cargo_diagnostic.message,
+    })
+}
+
+enum CargoMessage {
+    CompilerArtifact(cargo_metadata::Artifact),
+    Diagnostic(cargo_metadata::diagnostic::Diagnostic),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum JsonMessage {
+    Cargo(cargo_metadata::Message),
+    Rustc(cargo_metadata::diagnostic::Diagnostic),
+}
+
+// https://github.com/rust-lang/rust-analyzer/blob/12e28c35758051dd6bc9cdf419a50dff80fab64d/crates/flycheck/src/lib.rs#L483
+// Try to deserialize a message from Cargo or Rustc.
+fn process_line(line: &[u8]) -> Option<CargoMessage> {
+    let mut deserializer = serde_json::Deserializer::from_slice(line);
+    deserializer.disable_recursion_limit();
+    if let Ok(message) = JsonMessage::deserialize(&mut deserializer) {
+        match message {
+            // Skip certain kinds of messages to only spend time on what's useful
+            JsonMessage::Cargo(message) => match message {
+                cargo_metadata::Message::CompilerArtifact(artifact) if !artifact.fresh => {
+                    return Some(CargoMessage::CompilerArtifact(artifact));
+                }
+                cargo_metadata::Message::CompilerMessage(msg) => {
+                    return Some(CargoMessage::Diagnostic(msg.message));
+                }
+                _ => (),
+            },
+            JsonMessage::Rustc(message) => {
+                return Some(CargoMessage::Diagnostic(message));
             }
         }
-
-        diagonostics
     }
+    None
 }

--- a/crates/linter/src/linters/rust.rs
+++ b/crates/linter/src/linters/rust.rs
@@ -104,7 +104,7 @@ impl RustLinter {
             .filter_map(process_line)
             .filter_map(|cargo_message| match cargo_message {
                 CargoMessage::Diagnostic(diagonostic) => {
-                    convert_cargo_diagnostic_to_our_diagnostic(diagonostic, source_filename)
+                    process_cargo_diagnostic(diagonostic, source_filename)
                 }
                 _ => None,
             })
@@ -112,7 +112,10 @@ impl RustLinter {
     }
 }
 
-fn convert_cargo_diagnostic_to_our_diagnostic(
+/// Filter out the diagnostics specific to `source_filename` and convert it to [`Diagnostic`].
+///
+/// NOTE: The diagnostic with empty spans will be discarded.
+fn process_cargo_diagnostic(
     cargo_diagnostic: cargo_metadata::diagnostic::Diagnostic,
     source_filename: &str,
 ) -> Option<Diagnostic> {

--- a/crates/linter/src/linters/rust.rs
+++ b/crates/linter/src/linters/rust.rs
@@ -106,7 +106,6 @@ impl RustLinter {
                 CargoMessage::Diagnostic(diagonostic) => {
                     process_cargo_diagnostic(diagonostic, source_filename)
                 }
-                _ => None,
             })
             .collect()
     }
@@ -169,7 +168,7 @@ fn process_cargo_diagnostic(
 }
 
 enum CargoMessage {
-    CompilerArtifact(cargo_metadata::Artifact),
+    // CompilerArtifact(cargo_metadata::Artifact),
     Diagnostic(cargo_metadata::diagnostic::Diagnostic),
 }
 
@@ -189,9 +188,10 @@ fn process_line(line: &[u8]) -> Option<CargoMessage> {
         match message {
             // Skip certain kinds of messages to only spend time on what's useful
             JsonMessage::Cargo(message) => match message {
-                cargo_metadata::Message::CompilerArtifact(artifact) if !artifact.fresh => {
-                    return Some(CargoMessage::CompilerArtifact(artifact));
-                }
+                // CompilerArtifact can be used to report the progress, which is useless on our end.
+                // cargo_metadata::Message::CompilerArtifact(artifact) if !artifact.fresh => {
+                // return Some(CargoMessage::CompilerArtifact(artifact));
+                // }
                 cargo_metadata::Message::CompilerMessage(msg) => {
                     return Some(CargoMessage::Diagnostic(msg.message));
                 }

--- a/crates/linter/src/linters/sh.rs
+++ b/crates/linter/src/linters/sh.rs
@@ -47,11 +47,14 @@ impl ShellCheckMessage {
     }
 }
 
-pub async fn run_shellcheck(script_file: &Path, workspace: &Path) -> std::io::Result<LinterResult> {
+pub async fn run_shellcheck(
+    script_file: &Path,
+    workspace_root: &Path,
+) -> std::io::Result<LinterResult> {
     let output = tokio::process::Command::new("shellcheck")
         .arg("--format=json")
         .arg(script_file)
-        .current_dir(workspace)
+        .current_dir(workspace_root)
         .output()
         .await?;
 

--- a/crates/linter/src/linters/sh.rs
+++ b/crates/linter/src/linters/sh.rs
@@ -1,4 +1,4 @@
-use crate::{Code, Diagnostic, LinterResult};
+use crate::{Code, Diagnostic, DiagnosticSpan, LinterResult};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -34,10 +34,12 @@ impl ShellCheckMessage {
             Severity::Style => crate::Severity::Style,
         };
         Diagnostic {
-            line_start: self.line,
-            line_end: self.end_line,
-            column_start: self.column,
-            column_end: self.end_column,
+            spans: vec![DiagnosticSpan {
+                line_start: self.line,
+                line_end: self.end_line,
+                column_start: self.column,
+                column_end: self.end_column,
+            }],
             code: Code::default(),
             severity,
             message: self.message,

--- a/crates/linter/src/linters/typos.rs
+++ b/crates/linter/src/linters/typos.rs
@@ -107,11 +107,11 @@ impl<'m> Message<'m> {
     }
 }
 
-pub async fn run_typos(source_file: &Path, workspace: &Path) -> std::io::Result<LinterResult> {
+pub async fn run_typos(source_file: &Path, workspace_root: &Path) -> std::io::Result<LinterResult> {
     let output = tokio::process::Command::new("typos")
         .arg("--format=json")
         .arg(source_file)
-        .current_dir(workspace)
+        .current_dir(workspace_root)
         .output()
         .await?;
 

--- a/crates/linter/src/linters/typos.rs
+++ b/crates/linter/src/linters/typos.rs
@@ -1,4 +1,4 @@
-use crate::{Code, Diagnostic, LinterResult, Severity};
+use crate::{Code, Diagnostic, DiagnosticSpan, LinterResult, Severity};
 use std::borrow::Cow;
 use std::path::Path;
 
@@ -89,10 +89,12 @@ impl<'m> Message<'m> {
                 if let Some(line_num) = context.and_then(|cx| cx.line_num()) {
                     let message = corrections.message().into_owned();
                     Some(Diagnostic {
-                        line_start: line_num,
-                        line_end: line_num,
-                        column_start: byte_offset + 1,
-                        column_end: byte_offset + 1 + typo.len(),
+                        spans: vec![DiagnosticSpan {
+                            line_start: line_num,
+                            line_end: line_num,
+                            column_start: byte_offset + 1,
+                            column_end: byte_offset + 1 + typo.len(),
+                        }],
                         code: Code::default(),
                         severity: Severity::Warning,
                         message,

--- a/crates/linter/src/linters/vim.rs
+++ b/crates/linter/src/linters/vim.rs
@@ -1,4 +1,4 @@
-use crate::{Code, Diagnostic, LinterResult, Severity};
+use crate::{Code, Diagnostic, DiagnosticSpan, LinterResult, Severity};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -24,10 +24,12 @@ impl VintMessage {
         };
 
         Diagnostic {
-            line_start: self.line_number,
-            line_end: self.line_number,
-            column_start: self.column_number,
-            column_end: self.column_number + 1,
+            spans: vec![DiagnosticSpan {
+                line_start: self.line_number,
+                line_end: self.line_number,
+                column_start: self.column_number,
+                column_end: self.column_number + 1,
+            }],
             code: Code::default(),
             severity,
             message: self.description,

--- a/crates/linter/src/linters/vim.rs
+++ b/crates/linter/src/linters/vim.rs
@@ -37,11 +37,11 @@ impl VintMessage {
     }
 }
 
-pub async fn run_vint(source_file: &Path, workspace: &Path) -> std::io::Result<LinterResult> {
+pub async fn run_vint(source_file: &Path, workspace_root: &Path) -> std::io::Result<LinterResult> {
     let output = tokio::process::Command::new("vint")
         .arg("-j")
         .arg(source_file)
-        .current_dir(workspace)
+        .current_dir(workspace_root)
         .output()
         .await?;
 

--- a/crates/maple_core/src/stdio_server/plugin/linter.rs
+++ b/crates/maple_core/src/stdio_server/plugin/linter.rs
@@ -93,7 +93,7 @@ impl linter::HandleLinterResult for LinterResultHandler {
 
             if !followup_diagnostics.is_empty() {
                 let _ = self.vim.exec(
-                    "clap#plugin#linter#update_highlights",
+                    "clap#plugin#linter#add_highlights",
                     (self.bufnr, &followup_diagnostics),
                 );
             }
@@ -309,8 +309,7 @@ impl ClapPlugin for LinterPlugin {
                         match self.toggle {
                             Toggle::On => {
                                 for bufnr in self.bufs.keys() {
-                                    self.vim
-                                        .exec("clap#plugin#linter#clear_highlights", [bufnr])?;
+                                    self.vim.exec("clap#plugin#linter#toggle_off", [bufnr])?;
                                 }
                             }
                             Toggle::Off => {

--- a/crates/maple_core/src/stdio_server/plugin/linter.rs
+++ b/crates/maple_core/src/stdio_server/plugin/linter.rs
@@ -61,7 +61,7 @@ impl LinterResultHandler {
 impl linter::HandleLinterResult for LinterResultHandler {
     fn handle_linter_result(&self, linter_result: linter::LinterResult) -> std::io::Result<()> {
         let mut new_diagnostics = linter_result.diagnostics;
-        new_diagnostics.sort_by(|a, b| a.line_start.cmp(&b.line_start));
+        new_diagnostics.sort_by(|a, b| a.spans[0].line_start.cmp(&b.spans[0].line_start));
         new_diagnostics.dedup();
 
         let first_lint_result_arrives = self
@@ -240,7 +240,7 @@ impl ClapPlugin for LinterPlugin {
 
                             let current_diagnostics = diagnostics
                                 .iter()
-                                .filter(|d| d.line_start == lnum)
+                                .filter(|d| d.spans.iter().any(|span| span.line_start == lnum))
                                 .collect::<Vec<_>>();
 
                             if current_diagnostics.is_empty() {
@@ -269,7 +269,7 @@ impl ClapPlugin for LinterPlugin {
                             let diagnostics = buf_linter_info.diagnostics.diagnostics.read();
                             let current_diagnostics = diagnostics
                                 .iter()
-                                .filter(|d| d.line_start == lnum)
+                                .filter(|d| d.spans.iter().any(|span| span.line_start == lnum))
                                 .collect::<Vec<_>>();
 
                             for diagnostic in current_diagnostics {

--- a/crates/maple_core/src/stdio_server/service.rs
+++ b/crates/maple_core/src/stdio_server/service.rs
@@ -307,6 +307,8 @@ impl PluginSession {
                     maybe_plugin_event = self.plugin_events.recv() => {
                         match maybe_plugin_event {
                             Some(plugin_event) => {
+                                tracing::trace!(?plugin_event, "[{id}] Received event");
+
                                 if plugin_event.should_debounce() {
                                     pending_plugin_event.replace(plugin_event);
                                     notification_dirty = true;


### PR DESCRIPTION
This PR brings a number of improvements to the linter plugin, mostly UI-related.

- Support multiple spans for a single diagnostic, especially useful for Rust.
- Show the exact diagnostic when the cursor is right in the corresponding span, otherwise, if the cursor is not in any of the range of diagnostics in this line, show all the diagnostics in this line.
- Add icon to diagnostic severity.
- Make sure the diagnostic window on the top right won't interfere with the regular source code display.

<img width="1512" alt="截屏2023-09-19 10 50 12" src="https://github.com/liuchengxu/vim-clap/assets/8850248/628b868b-6029-48d2-96f9-8b127ebc1c33">
