### PR TITLE
Support tree-sitter highlight for provider preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -376,33 +376,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color-eyre"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
-dependencies = [
- "backtrace",
- "color-spantrace",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors",
- "tracing-error",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
-dependencies = [
- "once_cell",
- "owo-colors",
- "tracing-core",
- "tracing-error",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,16 +607,6 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "extracted_fzy"
 version = "0.1.0"
-
-[[package]]
-name = "eyre"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
-dependencies = [
- "indenter",
- "once_cell",
-]
 
 [[package]]
 name = "filter"
@@ -1085,12 +1048,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indenter"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
-
-[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,7 +1236,6 @@ dependencies = [
  "chrono",
  "clap",
  "cli",
- "color-eyre",
  "tokio",
  "upgrade",
 ]
@@ -1541,12 +1497,6 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
-name = "owo-colors"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "parking_lot"
@@ -2337,16 +2287,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
-dependencies = [
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2325,6 +2325,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-bash"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "096f57b3b44c04bfc7b21a4da44bfa16adf1f88aba18993b8478a091076d0968"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b03bdf218020057abee831581a74bff8c298323d6c6cd1a70556430ded9f4b"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b4b625f46a7370544b9cf0545532c26712ae49bfc02eb09825db358b9f79e1"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2346,10 +2376,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-javascript"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edbc663376bdd294bd1f0a6daf859aedb9aa5bdb72217d7ad8ba2d5314102cf7"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d82d2e33ee675dc71289e2ace4f8f9cf96d36d81400e9dae5ea61edaf5dea6"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
 name = "tree-sitter-md"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c20d3ef8d202430b644a307e6299d84bf8ed87fa1b796e4638f8805a595060c"
+dependencies = [
+ "cc",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c93b1b1fbd0d399db3445f51fd3058e43d0b4dcff62ddbdb46e66550978aa5"
 dependencies = [
  "cc",
  "tree-sitter",
@@ -2390,9 +2450,15 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-highlight",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
  "tree-sitter-md",
+ "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-toml",
  "tree-sitter-vim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ tokio = { version = "1.31", features = ["rt"] }
 
 cli = { path = "crates/cli" }
 upgrade = { path = "crates/upgrade" }
-color-eyre = "0.6.2"
 
 [build-dependencies]
 built = { package = "built", version = "0.6", features = ["git2"] }

--- a/autoload/clap/helper.vim
+++ b/autoload/clap/helper.vim
@@ -48,7 +48,10 @@ function! clap#helper#complete(ArgLead, CmdLine, P) abort
   if !exists('s:autoload_providers')
     let s:autoload_providers = map(split(globpath(&runtimepath, 'autoload/clap/provider/*.vim'), "\n"), 'fnamemodify(v:val, ":t:r")')
   endif
-  return filter(uniq(sort(s:autoload_providers + keys(g:clap#provider_alias) + registered)), 'v:val =~# "^".a:ArgLead')
+  if !exists('s:user_providers')
+    let s:user_providers = map(clap#provider#providers#get_user_defined(), 'split(v:val, ":")[0]')
+  endif
+  return filter(uniq(sort(s:autoload_providers + s:user_providers + keys(g:clap#provider_alias) + registered)), 'v:val =~# "^".a:ArgLead')
 endfunction
 
 function! clap#helper#echo_message(msg) abort

--- a/autoload/clap/helper.vim
+++ b/autoload/clap/helper.vim
@@ -54,6 +54,18 @@ function! clap#helper#complete(ArgLead, CmdLine, P) abort
   return filter(uniq(sort(s:autoload_providers + s:user_providers + keys(g:clap#provider_alias) + registered)), 'v:val =~# "^".a:ArgLead')
 endfunction
 
+function! clap#helper#complete_actions(A, L, P) abort
+  if !exists('g:clap_actions')
+      echoerr '`g:clap_actions` not found'
+      return []
+  endif
+  if empty(a:A)
+    return g:clap_actions
+  else
+    return filter(g:clap_actions, printf('v:val =~ "^%s"', a:A))
+  endif
+endfunction
+
 function! clap#helper#echo_message(msg) abort
   echohl Function
   echo 'vim-clap: '

--- a/autoload/clap/highlighter.vim
+++ b/autoload/clap/highlighter.vim
@@ -84,7 +84,12 @@ else
 
   " lnum is 0-based.
   function! s:add_ts_highlight_at(bufnr, lnum, col, length, hl_group) abort
-    call prop_add(a:lnum+1, a:col+1, {'length': a:length, 'type': a:hl_group, 'bufnr': a:bufnr})
+    try
+      call prop_add(a:lnum+1, a:col+1, {'length': a:length, 'type': a:hl_group, 'bufnr': a:bufnr})
+    catch
+      " Not sure why, but I keep run into error: Invalid line number, neovim
+      " does not have this issue.
+    endtry
   endfunction
 
   function! s:add_display_highlights(hl_lines) abort
@@ -170,7 +175,7 @@ function! clap#highlighter#add_ts_highlights(bufnr, to_replace_line_ranges, high
       call prop_remove({ 'types': s:ts_types, 'all': v:true, 'bufnr': a:bufnr } )
     else
       for [start, end] in a:to_replace_line_ranges
-        call prop_remove({ 'types': s:ts_types, 'all': v:true, 'bufnr': a:bufnr }, start + 1, end - 1)
+        call prop_remove({ 'types': s:ts_types, 'all': v:true, 'bufnr': a:bufnr }, start, end)
       endfor
     endif
   endif

--- a/autoload/clap/highlighter.vim
+++ b/autoload/clap/highlighter.vim
@@ -160,6 +160,14 @@ function! clap#highlighter#add_sublime_highlights(bufnr, line_highlights) abort
   endfor
 endfunction
 
+function! clap#highlighter#disable_tree_sitter(bufnr) abort
+  if has('nvim')
+    call nvim_buf_clear_namespace(a:bufnr, s:tree_sitter_ns_id, 0, -1)
+  elseif !empty(s:ts_types)
+    call prop_remove({ 'types': s:ts_types, 'all': v:true, 'bufnr': a:bufnr } )
+  endif
+endfunction
+
 function! clap#highlighter#add_ts_highlights(bufnr, to_replace_line_ranges, highlights) abort
   if has('nvim')
     " All old highlights need to be replaced.

--- a/autoload/clap/highlighter.vim
+++ b/autoload/clap/highlighter.vim
@@ -148,6 +148,13 @@ function! clap#highlighter#highlight_line(bufnr, lnum, token_highlights) abort
   endfor
 endfunction
 
+" Highlight a list of lines.
+function! clap#highlighter#add_sublime_highlights(bufnr, line_highlights) abort
+  for [lnum, line_highlight] in a:line_highlights
+    call clap#highlighter#highlight_line(a:bufnr, lnum, line_highlight)
+  endfor
+endfunction
+
 function! clap#highlighter#add_ts_highlights(bufnr, to_replace_line_ranges, highlights) abort
   if has('nvim')
     " All old highlights need to be replaced.
@@ -178,13 +185,6 @@ function! clap#highlighter#add_ts_highlights(bufnr, to_replace_line_ranges, high
       endif
       call s:add_ts_highlight_at(a:bufnr, line_number, column_start, length, group_name)
     endfor
-  endfor
-endfunction
-
-" Highlight a list of lines.
-function! clap#highlighter#highlight_lines(bufnr, line_highlights) abort
-  for [lnum, line_highlight] in a:line_highlights
-    call clap#highlighter#highlight_line(a:bufnr, lnum, line_highlight)
   endfor
 endfunction
 

--- a/autoload/clap/state.vim
+++ b/autoload/clap/state.vim
@@ -123,7 +123,6 @@ function! clap#state#render_preview(preview) abort
         endtry
       endfor
     elseif has_key(a:preview, 'tree_sitter_highlights')
-      " echom string(a:preview.tree_sitter_highlights)
       call clap#highlighter#add_ts_highlights(g:clap.preview.bufnr, [], a:preview.tree_sitter_highlights)
     elseif has_key(a:preview, 'vim_syntax_info')
       let vim_syntax_info = a:preview.vim_syntax_info

--- a/autoload/clap/state.vim
+++ b/autoload/clap/state.vim
@@ -122,6 +122,9 @@ function! clap#state#render_preview(preview) abort
           " Ignore any potential errors as the line might be truncated.
         endtry
       endfor
+    elseif has_key(a:preview, 'tree_sitter_highlights')
+      " echom string(a:preview.tree_sitter_highlights)
+      call clap#highlighter#add_ts_highlights(g:clap.preview.bufnr, [], a:preview.tree_sitter_highlights)
     elseif has_key(a:preview, 'vim_syntax_info')
       let vim_syntax_info = a:preview.vim_syntax_info
       if !empty(vim_syntax_info.syntax)

--- a/autoload/clap/state.vim
+++ b/autoload/clap/state.vim
@@ -114,18 +114,21 @@ function! clap#state#render_preview(preview) abort
       call g:clap.preview.show(['Error occurred while showing the preview:', v:exception, '', string(a:preview.lines)])
       return
     endtry
-    if has_key(a:preview, 'syntax')
-      call g:clap.preview.set_syntax(a:preview.syntax)
-    elseif has_key(a:preview, 'fname')
-      call g:clap.preview.set_syntax(clap#ext#into_filetype(a:preview.fname))
-    elseif has_key(a:preview, 'syntax_highlights')
-      for [lnum, line_highlight] in a:preview.syntax_highlights
+    if has_key(a:preview, 'sublime_syntax_highlights')
+      for [lnum, line_highlight] in a:preview.sublime_syntax_highlights
         try
           call clap#highlighter#highlight_line(g:clap.preview.bufnr, lnum, line_highlight)
         catch
           " Ignore any potential errors as the line might be truncated.
         endtry
       endfor
+    elseif has_key(a:preview, 'vim_syntax_info')
+      let vim_syntax_info = a:preview.vim_syntax_info
+      if !empty(vim_syntax_info.syntax)
+        call g:clap.preview.set_syntax(vim_syntax_info.syntax)
+      elseif !empty(vim_syntax_info.fname)
+        call g:clap.preview.set_syntax(clap#ext#into_filetype(vim_syntax_info.fname))
+      endif
     endif
     call clap#preview#highlight_header()
 

--- a/crates/maple_core/src/config.rs
+++ b/crates/maple_core/src/config.rs
@@ -223,7 +223,7 @@ pub struct ProviderConfig {
     ///
     /// If the theme is not found and the engine is [`HighlightEngine::SublimeSyntax`],
     /// the default theme (`Visual Studio Dark+`) will be used.
-    pub preview_color_scheme: Option<String>,
+    pub sublime_syntax_color_scheme: Option<String>,
 
     /// Whether to share the input history of each provider.
     pub share_input_history: bool,

--- a/crates/maple_core/src/stdio_server/mod.rs
+++ b/crates/maple_core/src/stdio_server/mod.rs
@@ -94,7 +94,7 @@ struct InitializedService {
 fn initialize_service(vim: Vim) -> InitializedService {
     use self::plugin::{
         ActionType, ClapPlugin, ColorizerPlugin, CtagsPlugin, CursorwordPlugin, GitPlugin,
-        LinterPlugin, MarkdownPlugin, SyntaxHighlighterPlugin, SystemPlugin,
+        LinterPlugin, MarkdownPlugin, SyntaxPlugin, SystemPlugin,
     };
 
     let mut callable_actions = Vec::new();
@@ -115,11 +115,13 @@ fn initialize_service(vim: Vim) -> InitializedService {
     };
 
     register_plugin(Box::new(SystemPlugin::new(vim.clone())), None);
-    register_plugin(Box::new(GitPlugin::new(vim.clone())), None);
-    register_plugin(Box::new(SyntaxHighlighterPlugin::new(vim.clone())), None);
+    register_plugin(Box::new(SyntaxPlugin::new(vim.clone())), None);
 
     let plugin_config = &crate::config::config().plugin;
 
+    if plugin_config.git.enable {
+        register_plugin(Box::new(GitPlugin::new(vim.clone())), None);
+    }
     if plugin_config.colorizer.enable {
         register_plugin(
             Box::new(ColorizerPlugin::new(vim.clone())),

--- a/crates/maple_core/src/stdio_server/plugin/markdown.rs
+++ b/crates/maple_core/src/stdio_server/plugin/markdown.rs
@@ -286,7 +286,7 @@ mod tests {
             .unwrap()
             .join("README.md");
         println!();
-        for line in generate_toc(&file, 0, 2).unwrap() {
+        for line in generate_toc(file, 0, 2).unwrap() {
             println!("{line}");
         }
     }

--- a/crates/maple_core/src/stdio_server/plugin/mod.rs
+++ b/crates/maple_core/src/stdio_server/plugin/mod.rs
@@ -17,7 +17,7 @@ pub use self::cursorword::Cursorword as CursorwordPlugin;
 pub use self::git::Git as GitPlugin;
 pub use self::linter::Linter as LinterPlugin;
 pub use self::markdown::Markdown as MarkdownPlugin;
-pub use self::syntax::Syntax as SyntaxHighlighterPlugin;
+pub use self::syntax::Syntax as SyntaxPlugin;
 pub use self::system::System as SystemPlugin;
 pub use types::{Action, ActionType, ClapAction};
 

--- a/crates/maple_core/src/stdio_server/plugin/syntax.rs
+++ b/crates/maple_core/src/stdio_server/plugin/syntax.rs
@@ -159,7 +159,7 @@ impl Syntax {
         let line_highlights = sublime_syntax_highlight(syntax, lines.iter(), line_start, THEME);
 
         self.vim.exec(
-            "clap#highlighter#highlight_lines",
+            "clap#highlighter#add_sublime_highlights",
             (bufnr, &line_highlights),
         )?;
 

--- a/crates/maple_core/src/stdio_server/plugin/syntax.rs
+++ b/crates/maple_core/src/stdio_server/plugin/syntax.rs
@@ -74,6 +74,7 @@ struct TreeSitterInfo {
     "list-sublime-themes",
     "sublime-syntax-highlight",
     "tree-sitter-highlight",
+    "tree-sitter-highlight-disable",
     "tree-sitter-list-scopes",
     "tree-sitter-props-at-cursor",
     "toggle",
@@ -486,6 +487,12 @@ impl ClapPlugin for Syntax {
                 self.tree_sitter_highlight(bufnr, false, None).await?;
                 self.tree_sitter_enabled = true;
                 self.toggle.turn_on();
+            }
+            SyntaxAction::TreeSitterHighlightDisable => {
+                let bufnr = self.vim.bufnr("").await?;
+                self.vim
+                    .exec("clap#highlighter#disable_tree_sitter", bufnr)?;
+                self.tree_sitter_enabled = false;
             }
             SyntaxAction::TreeSitterListScopes => {
                 let bufnr = self.vim.bufnr("").await?;

--- a/crates/maple_core/src/stdio_server/plugin/syntax.rs
+++ b/crates/maple_core/src/stdio_server/plugin/syntax.rs
@@ -10,7 +10,7 @@ use once_cell::sync::Lazy;
 use sublime_syntax::{SyntaxReference, TokenHighlight};
 use tree_sitter::Language;
 
-pub static SUBLIME_SYNTAX_HIGHLIGHTER: Lazy<sublime_syntax::SyntaxHighlighter> =
+static SUBLIME_SYNTAX_HIGHLIGHTER: Lazy<sublime_syntax::SyntaxHighlighter> =
     Lazy::new(sublime_syntax::SyntaxHighlighter::new);
 
 #[allow(unused)]
@@ -359,6 +359,16 @@ impl Syntax {
 
         Ok(())
     }
+}
+
+pub fn sublime_theme_exists(theme: &str) -> bool {
+    SUBLIME_SYNTAX_HIGHLIGHTER.theme_exists(theme)
+}
+
+pub fn sublime_syntax_by_extension(extension: &str) -> Option<&SyntaxReference> {
+    SUBLIME_SYNTAX_HIGHLIGHTER
+        .syntax_set
+        .find_syntax_by_extension(extension)
 }
 
 pub fn sublime_syntax_highlight<T: AsRef<str>>(

--- a/crates/maple_core/src/stdio_server/plugin/system.rs
+++ b/crates/maple_core/src/stdio_server/plugin/system.rs
@@ -97,7 +97,6 @@ impl ClapPlugin for System {
                 })?;
 
                 let mut ctx = ClipboardContext::new().map_err(PluginError::Clipboard)?;
-                tracing::debug!("{content} copied to clipboard");
                 match ctx.set_contents(content) {
                     Ok(()) => {
                         self.vim.echo_info("copied to clipboard successfully")?;

--- a/crates/maple_core/src/stdio_server/plugin/system.rs
+++ b/crates/maple_core/src/stdio_server/plugin/system.rs
@@ -97,6 +97,7 @@ impl ClapPlugin for System {
                 })?;
 
                 let mut ctx = ClipboardContext::new().map_err(PluginError::Clipboard)?;
+                tracing::debug!("{content} copied to clipboard");
                 match ctx.set_contents(content) {
                     Ok(()) => {
                         self.vim.echo_info("copied to clipboard successfully")?;

--- a/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
+++ b/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
@@ -23,6 +23,7 @@ type SyntaxHighlights = Vec<(usize, Vec<TokenHighlight>)>;
 pub struct Preview {
     pub lines: Vec<String>,
     /// Highlights from other highlight engine (sublime_syntax or tree_sitter).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub syntax_highlights: SyntaxHighlights,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub syntax: Option<String>,

--- a/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
+++ b/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
@@ -737,7 +737,7 @@ fn fetch_syntax_highlights(
         HighlightEngine::SublimeSyntax => {
             const THEME: &str = "Visual Studio Dark+";
 
-            let theme = match &provider_config.preview_color_scheme {
+            let theme = match &provider_config.sublime_syntax_color_scheme {
                 Some(theme) => {
                     if sublime_theme_exists(theme) {
                         theme.as_str()

--- a/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
+++ b/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
@@ -726,6 +726,8 @@ enum SublimeOrTreeSitter {
     Neither,
 }
 
+// TODO: this might be slow for larger files (over 100k lines) as tree-sitter will have to
+// parse the whole file to obtain the highlight info. We may make the highlighting async.
 fn fetch_syntax_highlights(
     lines: &[String],
     path: &Path,

--- a/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
+++ b/crates/maple_core/src/stdio_server/provider/hooks/on_move.rs
@@ -46,6 +46,10 @@ impl VimSyntaxInfo {
             ..Default::default()
         }
     }
+
+    fn is_empty(&self) -> bool {
+        self.syntax.is_empty() && self.fname.is_empty()
+    }
 }
 
 /// Preview content.
@@ -57,6 +61,7 @@ pub struct Preview {
     /// should be used for the highlighting. Ideally `syntax`
     /// is returned, otherwise `fname` is returned and
     /// Vim will inspect the syntax value from `fname`.
+    #[serde(skip_serializing_if = "VimSyntaxInfo::is_empty")]
     pub vim_syntax_info: VimSyntaxInfo,
     /// Highlights from sublime-syntax highlight engine.
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -800,8 +805,12 @@ fn fetch_syntax_highlights(
                                 // `group.to_string()` as it's essentially `&'static str`.
                                 let line_highlights = line_highlights
                                     .into_iter()
-                                    .map(|(start, length, group)| {
-                                        (start, length, group.to_string())
+                                    .filter_map(|(start, length, group)| {
+                                        if start + length > max_line_width {
+                                            None
+                                        } else {
+                                            Some((start, length, group.to_string()))
+                                        }
                                     })
                                     .collect();
 

--- a/crates/maple_core/src/tools/ctags/mod.rs
+++ b/crates/maple_core/src/tools/ctags/mod.rs
@@ -221,7 +221,7 @@ impl ProjectCtagsCommand {
     pub const TAGS_CMD: &'static [&'static str] =
         &["ctags", "-R", "-x", "--output-format=json", "--fields=+n"];
 
-    const BASE_TAGS_CMD: &str = "ctags -R -x --output-format=json --fields=+n";
+    const BASE_TAGS_CMD: &'static str = "ctags -R -x --output-format=json --fields=+n";
 
     /// Creates an instance of [`ProjectCtagsCommand`].
     pub fn new(std_cmd: std::process::Command, shell_cmd: ShellCommand) -> Self {

--- a/crates/maple_derive/src/impls/clap_plugin.rs
+++ b/crates/maple_derive/src/impls/clap_plugin.rs
@@ -143,14 +143,14 @@ pub fn clap_plugin_derive_impl(input: &DeriveInput) -> TokenStream {
             callable_actions_list.push(action_var.clone());
 
             quote! {
-                const #action_lit: &str = #namespaced_action;
+                const #action_lit: &'static str = #namespaced_action;
                 const #action_var: types::Action = types::Action::callable(Self::#action_lit);
             }
         } else {
             internal_actions_list.push(action_var.clone());
 
             quote! {
-                const #action_lit: &str = #namespaced_action;
+                const #action_lit: &'static str = #namespaced_action;
                 #[allow(non_upper_case_globals)]
                 const #action_var: types::Action = types::Action::internal(Self::#action_lit);
             }
@@ -204,9 +204,9 @@ pub fn clap_plugin_derive_impl(input: &DeriveInput) -> TokenStream {
         impl #ident {
             #(#constants)*
 
-            const CALLABLE_ACTIONS: &[types::Action] = &[#(Self::#callable_actions_list),*];
-            const INTERNAL_ACTIONS: &[types::Action] = &[#(Self::#internal_actions_list),*];
-            const ACTIONS: &[types::Action] = &[#(Self::#actions_list),*];
+            const CALLABLE_ACTIONS: &'static [types::Action] = &[#(Self::#callable_actions_list),*];
+            const INTERNAL_ACTIONS: &'static [types::Action] = &[#(Self::#internal_actions_list),*];
+            const ACTIONS: &'static [types::Action] = &[#(Self::#actions_list),*];
 
         }
 

--- a/crates/printer/src/lib.rs
+++ b/crates/printer/src/lib.rs
@@ -1,4 +1,4 @@
-//! This crate provides the feature of diplaying the information of filtered lines
+//! This crate provides the feature of displaying the information of filtered lines
 //! by printing them to stdout in JSON format.
 
 mod trimmer;

--- a/crates/sublime_syntax/src/lib.rs
+++ b/crates/sublime_syntax/src/lib.rs
@@ -181,7 +181,7 @@ impl Default for SyntaxHighlighter {
 }
 
 impl SyntaxHighlighter {
-    const DEFAULT_THEME: &str = "Solarized (dark)";
+    const DEFAULT_THEME: &'static str = "Solarized (dark)";
 
     /// Constructs a new instance of [`SyntaxHighlighter`].
     ///

--- a/crates/tree_sitter/Cargo.toml
+++ b/crates/tree_sitter/Cargo.toml
@@ -13,8 +13,14 @@ tree-sitter-highlight = "0.20"
 # tree-sitter-traversal = "0.1"
 
 # Languages
+tree-sitter-bash = "0.20"
+tree-sitter-c = "0.20"
+tree-sitter-cpp = "0.20"
 tree-sitter-go = "0.20"
+tree-sitter-javascript = "0.20"
+tree-sitter-json = "0.20"
 tree-sitter-md = "0.1.7"
+tree-sitter-python = "0.20"
 tree-sitter-rust = "0.20"
 tree-sitter-toml = "0.20"
 tree-sitter-vim = { git = "https://github.com/liuchengxu/tree-sitter-vim", rev = "a001587c17ab24fdade5403eb6c4763460d6814c" }

--- a/crates/tree_sitter/src/language.rs
+++ b/crates/tree_sitter/src/language.rs
@@ -85,12 +85,8 @@ impl Language {
     }
 
     pub fn highlight_names(&self) -> &[&str] {
-        match self {
-            Self::Markdown => {
-                todo!()
-            }
-            _ => Self::HIGHLIGHT_NAMES,
-        }
+        // TODO: configurable
+        Self::HIGHLIGHT_NAMES
     }
 
     pub fn highlight_name(&self, highlight: Highlight) -> &'static str {

--- a/crates/tree_sitter/src/language.rs
+++ b/crates/tree_sitter/src/language.rs
@@ -23,6 +23,8 @@ macro_rules! highlight_names {
     };
 }
 
+// language => scope, Link
+
 impl Language {
     highlight_names![
         ("comment", "Comment"),

--- a/docs/src/plugins/intro.md
+++ b/docs/src/plugins/intro.md
@@ -6,12 +6,18 @@ Vim-Clap was originally a mere Vim fuzzy picker plugin, however, the integration
 
 Note that the vim-Clap plugins were mainly created for the plugin author's personal uses, thus they may not be feature-complete as their alternatives. Bugs are expected as these plugins are not extensively tested, feel free to use if you are brave enough.
 
+You must enable the `g:clap_plugin_experimental` flag in your `.vimrc` and create a [config file](./config.md) beforehand.
 
-All the non-system plugins are disabled by default. To enable the plugins, you must create a [config file](./config.md) first and set `enable = true` explicitly for the plugins in the config file.
+```vim
+" Specify this variable to enable the plugin feature.
+let g:clap_plugin_experimental = v:true
+```
+
+All the non-system plugins are disabled by default. To enable the plugins, you need to set `enable = true` explicitly for the plugins in the config file.
 
 ```toml
 [plugin.git]
 enable = true
 ```
 
-Check out [Available Plugins](./plugins.md) for more info.
+Check out [Available Plugins](./plugins.md) for detailed introduction to the plugins. Try `:Clap clap_actions` to take a look at the existing actions.

--- a/docs/src/plugins/plugins.md
+++ b/docs/src/plugins/plugins.md
@@ -12,6 +12,7 @@ TODO: elaborate on plugins' usage.
 * [git](#git)
 * [linter](#linter)
 * [markdown](#markdown)
+* [syntax](#syntax)
 
 <!-- /clap-markdown-toc -->
 
@@ -81,3 +82,12 @@ enable = true
 
 - Features
     - Generate/Update/Delete toc
+
+## syntax
+
+```toml
+[plugin.syntax]
+enable = true
+```
+
+This plugin implements the sublime-syntax and tree-sitter highlighting. The plugin author already uses the latter a lot.

--- a/plugin/clap.vim
+++ b/plugin/clap.vim
@@ -66,6 +66,12 @@ augroup VimClap
     " Are these really needed?
     " autocmd TextChanged  * call clap#client#notify('TextChanged',  [+expand('<abuf>')])
     " autocmd TextChangedI * call clap#client#notify('TextChangedI', [+expand('<abuf>')])
+
+    " Create `clap_actions` provider so that it's convenient to interact with the plugins later.
+    let g:clap_provider_clap_actions = get(g:, 'clap_provider_clap_actions', {
+                \ 'source': { -> get(g:, 'clap_actions', []) },
+                \ 'sink': { line -> clap#client#notify(line, []) },
+                \ })
   endif
 
   " yanks provider

--- a/plugin/clap.vim
+++ b/plugin/clap.vim
@@ -72,6 +72,12 @@ augroup VimClap
                 \ 'source': { -> get(g:, 'clap_actions', []) },
                 \ 'sink': { line -> clap#client#notify(line, []) },
                 \ })
+
+    function! s:RequestClapAction(bang, action) abort
+      call clap#client#notify(a:action, [])
+    endfunction
+
+    command! -bang -nargs=* -bar -range -complete=customlist,clap#helper#complete_actions ClapAction call s:RequestClapAction(<bang>0, <f-args>)
   endif
 
   " yanks provider

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.73"
+channel = "1.74"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use cli::{Args, RunCmd};
-use color_eyre::eyre::Result;
 
 const BUILD_TIME: &str = include!(concat!(env!("OUT_DIR"), "/compiled_at.txt"));
 
@@ -41,9 +40,7 @@ pub struct Maple {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
-    color_eyre::install()?;
-
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let maple = Maple::parse();
 
     match maple.cmd {


### PR DESCRIPTION
Close #532

Add the following config in `config.toml` to enable the tree-sitter highlight:

```
[provider]
preview-highlight-engine = "tree-sitter"
```