### PR TITLE
Fix `g:clap_layout` is not applied in v0.49

### DIFF
--- a/autoload/clap/layout.vim
+++ b/autoload/clap/layout.vim
@@ -90,7 +90,7 @@ endfunction
 function! s:layout() abort
   let layout = s:get_base_layout()
   if exists('g:clap_layout')
-    call extend(copy(layout), g:clap_layout)
+    let layout = extend(copy(layout), g:clap_layout)
   endif
   return layout
 endfunction

--- a/autoload/clap/layout.vim
+++ b/autoload/clap/layout.vim
@@ -90,7 +90,7 @@ endfunction
 function! s:layout() abort
   let layout = s:get_base_layout()
   if exists('g:clap_layout')
-    let layout = extend(copy(layout), g:clap_layout)
+    call extend(layout, g:clap_layout)
   endif
   return layout
 endfunction


### PR DESCRIPTION
I fixed extending `layout` with `g:clap_layout`.