### PR TITLE
Optimize searcher performance significantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Add `multi_select` property explicitly in provider, useful for the provider lsp.
 - Add `:ClapAction diagnostics.{first,last,next,prev}` for navigating between all kinds of the diagnostics.
 - Add `:ClapAction diagnostics.{firstHint,lastHint,nextHint,prevHint}` for navigating between the Hint diagnostics.
-- Optimize the grep search performance by 20+%.
+- Optimize the grep search performance significantly, 2x performance has been achieved compared to the last release.
 
 ## [0.52] 2024-2-29
 

--- a/crates/maple_core/src/searcher/file.rs
+++ b/crates/maple_core/src/searcher/file.rs
@@ -129,6 +129,10 @@ pub async fn search(
         best_items.on_new_match(matched_item, total_matched, total_processed);
     }
 
+    if stop_signal.load(Ordering::SeqCst) {
+        return;
+    }
+
     let elapsed = now.elapsed().as_millis();
 
     let BestItems {

--- a/crates/maple_core/src/searcher/files.rs
+++ b/crates/maple_core/src/searcher/files.rs
@@ -117,6 +117,10 @@ pub async fn search(query: String, hidden: bool, matcher: Matcher, search_contex
         best_items.on_new_match(matched_item, total_matched, total_processed);
     }
 
+    if stop_signal.load(Ordering::SeqCst) {
+        return;
+    }
+
     let elapsed = now.elapsed().as_millis();
 
     let BestItems {

--- a/crates/maple_core/src/searcher/files.rs
+++ b/crates/maple_core/src/searcher/files.rs
@@ -6,7 +6,7 @@ use ignore::{DirEntry, WalkState};
 use matcher::Matcher;
 use printer::Printer;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
@@ -17,7 +17,8 @@ fn search_files(
     hidden: bool,
     matcher: Matcher,
     stop_signal: Arc<AtomicBool>,
-    sender: UnboundedSender<Option<MatchedItem>>,
+    sender: UnboundedSender<MatchedItem>,
+    total_processed: Arc<AtomicUsize>,
 ) {
     let walk_config = WalkConfig {
         hidden,
@@ -31,14 +32,14 @@ fn search_files(
         let sender = sender.clone();
         let stop_signal = stop_signal.clone();
         let search_root = search_root.clone();
+        let total_processed = total_processed.clone();
         Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
             if stop_signal.load(Ordering::SeqCst) {
                 return WalkState::Quit;
             }
 
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(_) => return WalkState::Continue,
+            let Ok(entry) = entry else {
+                return WalkState::Continue;
             };
 
             // Only search file and skip everything else.
@@ -46,6 +47,8 @@ fn search_files(
                 Some(entry) if entry.is_file() => {}
                 _ => return WalkState::Continue,
             };
+
+            total_processed.fetch_add(1, Ordering::Relaxed);
 
             // TODO: Add match_file_path() in matcher to avoid allocation each time.
             let path = if let Ok(p) = entry.path().strip_prefix(&search_root) {
@@ -56,11 +59,15 @@ fn search_files(
 
             let maybe_matched_item = matcher.match_item(Arc::new(path));
 
-            if let Err(err) = sender.send(maybe_matched_item) {
-                tracing::debug!("Sender is dropped: {err:?}");
-                WalkState::Quit
-            } else {
-                WalkState::Continue
+            match maybe_matched_item {
+                Some(matched_item) => {
+                    if sender.send(matched_item).is_err() {
+                        WalkState::Quit
+                    } else {
+                        WalkState::Continue
+                    }
+                }
+                None => WalkState::Continue,
             }
         })
     });
@@ -81,38 +88,33 @@ pub async fn search(query: String, hidden: bool, matcher: Matcher, search_contex
 
     let (sender, mut receiver) = unbounded_channel();
 
-    std::thread::Builder::new()
-        .name("files-worker".into())
-        .spawn({
-            let stop_signal = stop_signal.clone();
-            move || search_files(paths, hidden, matcher, stop_signal, sender)
-        })
-        .expect("Failed to spawn blines worker thread");
+    let total_processed = Arc::new(AtomicUsize::new(0));
+
+    {
+        let total_processed = total_processed.clone();
+        std::thread::Builder::new()
+            .name("files-worker".into())
+            .spawn({
+                let stop_signal = stop_signal.clone();
+                move || search_files(paths, hidden, matcher, stop_signal, sender, total_processed)
+            })
+            .expect("Failed to spawn blines worker thread");
+    }
 
     let mut total_matched = 0usize;
-    let mut total_processed = 0usize;
 
     let printer = Printer::new(line_width, icon);
     let mut best_items = BestItems::new(printer, number, progressor, Duration::from_millis(200));
 
     let now = std::time::Instant::now();
 
-    while let Some(maybe_matched_item) = receiver.recv().await {
+    while let Some(matched_item) = receiver.recv().await {
         if stop_signal.load(Ordering::SeqCst) {
             return;
         }
-
-        match maybe_matched_item {
-            Some(matched_item) => {
-                total_matched += 1;
-                total_processed += 1;
-
-                best_items.on_new_match(matched_item, total_matched, total_processed);
-            }
-            None => {
-                total_processed += 1;
-            }
-        }
+        total_matched += 1;
+        let total_processed = total_processed.load(Ordering::Relaxed);
+        best_items.on_new_match(matched_item, total_matched, total_processed);
     }
 
     let elapsed = now.elapsed().as_millis();
@@ -125,6 +127,7 @@ pub async fn search(query: String, hidden: bool, matcher: Matcher, search_contex
     } = best_items;
 
     let display_lines = printer.to_display_lines(items);
+    let total_processed = total_processed.load(Ordering::SeqCst);
 
     progressor.on_finished(display_lines, total_matched, total_processed);
 

--- a/crates/maple_core/src/searcher/grep/stoppable_searcher.rs
+++ b/crates/maple_core/src/searcher/grep/stoppable_searcher.rs
@@ -329,6 +329,10 @@ pub async fn search(query: String, matcher: Matcher, search_context: SearchConte
         }
     }
 
+    if stop_signal.load(Ordering::SeqCst) {
+        return;
+    }
+
     let elapsed = now.elapsed().as_millis();
 
     let display_lines = to_display_lines(&best_results.results, icon);

--- a/crates/maple_core/src/searcher/grep/stoppable_searcher.rs
+++ b/crates/maple_core/src/searcher/grep/stoppable_searcher.rs
@@ -6,15 +6,13 @@ use icon::Icon;
 use ignore::{DirEntry, WalkState};
 use matcher::Matcher;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedSender};
 use types::{Rank, SearchProgressUpdate};
 
 pub(super) const UPDATE_INTERVAL: Duration = Duration::from_millis(200);
-
-pub(super) type SearcherMessage = crate::searcher::SearcherMessage<FileResult>;
 
 #[derive(Debug, Default)]
 struct MatchEverything;
@@ -52,7 +50,7 @@ pub struct FileResult {
 pub(super) struct StoppableSearchImpl {
     paths: Vec<PathBuf>,
     matcher: Matcher,
-    sender: UnboundedSender<SearcherMessage>,
+    sender: UnboundedSender<FileResult>,
     stop_signal: Arc<AtomicBool>,
 }
 
@@ -60,7 +58,7 @@ impl StoppableSearchImpl {
     pub(super) fn new(
         paths: Vec<PathBuf>,
         matcher: Matcher,
-        sender: UnboundedSender<SearcherMessage>,
+        sender: UnboundedSender<FileResult>,
         stop_signal: Arc<AtomicBool>,
     ) -> Self {
         Self {
@@ -71,7 +69,7 @@ impl StoppableSearchImpl {
         }
     }
 
-    pub(super) fn run(self) {
+    pub(super) fn run(self, total_processed: Arc<AtomicUsize>) {
         let Self {
             paths,
             matcher,
@@ -91,6 +89,7 @@ impl StoppableSearchImpl {
             let sender = sender.clone();
             let stop_signal = stop_signal.clone();
             let search_root = search_root.clone();
+            let total_processed = total_processed.clone();
             Box::new(move |entry: Result<DirEntry, ignore::Error>| -> WalkState {
                 if stop_signal.load(Ordering::SeqCst) {
                     return WalkState::Quit;
@@ -117,12 +116,14 @@ impl StoppableSearchImpl {
                     &MatchEverything,
                     entry.path(),
                     sinks::Lossy(|line_number, line| {
+                        total_processed.fetch_add(1, Ordering::Relaxed);
+
                         if line.is_empty() {
-                            // Discontinue if the sender has been dropped.
-                            return Ok(sender.send(SearcherMessage::ProcessedOne).is_ok());
+                            return Ok(true);
                         }
 
                         let line = line.trim();
+
                         let maybe_file_result =
                             matcher
                                 .match_file_result(relative_path, line)
@@ -135,14 +136,12 @@ impl StoppableSearchImpl {
                                     indices_in_line: matched.fuzzy_indices,
                                 });
 
-                        let searcher_message = if let Some(file_result) = maybe_file_result {
-                            SearcherMessage::Match(file_result)
-                        } else {
-                            SearcherMessage::ProcessedOne
-                        };
+                        if let Some(file_result) = maybe_file_result {
+                            // Discontinue if the sender has been dropped.
+                            return Ok(sender.send(file_result).is_ok());
+                        }
 
-                        // Discontinue if the sender has been dropped.
-                        Ok(sender.send(searcher_message).is_ok())
+                        Ok(true)
                     }),
                 );
 
@@ -200,16 +199,20 @@ pub async fn search(query: String, matcher: Matcher, search_context: SearchConte
 
     let (sender, mut receiver) = unbounded_channel();
 
+    let total_processed = Arc::new(AtomicUsize::new(0));
+
     std::thread::Builder::new()
         .name("grep-worker".into())
         .spawn({
             let stop_signal = stop_signal.clone();
-            move || StoppableSearchImpl::new(paths, matcher, sender, stop_signal).run()
+            let total_processed = total_processed.clone();
+            move || {
+                StoppableSearchImpl::new(paths, matcher, sender, stop_signal).run(total_processed)
+            }
         })
         .expect("Failed to spawn grep-worker thread");
 
     let mut total_matched = 0usize;
-    let mut total_processed = 0usize;
 
     let to_display_lines = |best_results: &[FileResult], icon: Icon| {
         let grep_results = best_results
@@ -261,77 +264,67 @@ pub async fn search(query: String, matcher: Matcher, search_context: SearchConte
     };
 
     let now = std::time::Instant::now();
-    while let Some(searcher_message) = receiver.recv().await {
+    while let Some(file_result) = receiver.recv().await {
         if stop_signal.load(Ordering::SeqCst) {
             return;
         }
 
-        match searcher_message {
-            SearcherMessage::Match(file_result) => {
-                total_matched += 1;
-                total_processed += 1;
+        total_matched += 1;
 
-                if best_results.results.len() <= best_results.max_capacity {
-                    best_results.results.push(file_result);
-                    best_results.sort();
+        let total_processed = total_processed.load(Ordering::Relaxed);
 
-                    let now = Instant::now();
-                    if now > best_results.past + UPDATE_INTERVAL {
-                        let display_lines = to_display_lines(&best_results.results, icon);
+        if best_results.results.len() <= best_results.max_capacity {
+            best_results.results.push(file_result);
+            best_results.sort();
+
+            let now = Instant::now();
+            if now > best_results.past + UPDATE_INTERVAL {
+                let display_lines = to_display_lines(&best_results.results, icon);
+                progressor.update_all(&display_lines, total_matched, total_processed);
+                best_results.last_lines = display_lines.lines;
+                best_results.past = now;
+            }
+        } else {
+            let last = best_results
+                .results
+                .last_mut()
+                .expect("Max capacity is non-zero; qed");
+
+            let new = file_result;
+            if new.rank > last.rank {
+                *last = new;
+                best_results.sort();
+            }
+
+            if total_matched % 16 == 0 || total_processed % 16 == 0 {
+                let now = Instant::now();
+                if now > best_results.past + UPDATE_INTERVAL {
+                    let display_lines = to_display_lines(&best_results.results, icon);
+
+                    let visible_highlights = display_lines
+                        .indices
+                        .iter()
+                        .map(|line_highlights| {
+                            line_highlights
+                                .iter()
+                                .copied()
+                                .filter(|&x| x <= line_width)
+                                .collect::<Vec<_>>()
+                        })
+                        .collect::<Vec<_>>();
+
+                    if best_results.last_lines != display_lines.lines.as_slice()
+                        || best_results.last_visible_highlights != visible_highlights
+                    {
                         progressor.update_all(&display_lines, total_matched, total_processed);
                         best_results.last_lines = display_lines.lines;
-                        best_results.past = now;
-                    }
-                } else {
-                    let last = best_results
-                        .results
-                        .last_mut()
-                        .expect("Max capacity is non-zero; qed");
-
-                    let new = file_result;
-                    if new.rank > last.rank {
-                        *last = new;
-                        best_results.sort();
+                        best_results.last_visible_highlights = visible_highlights;
+                    } else {
+                        progressor.quick_update(total_matched, total_processed)
                     }
 
-                    if total_matched % 16 == 0 || total_processed % 16 == 0 {
-                        let now = Instant::now();
-                        if now > best_results.past + UPDATE_INTERVAL {
-                            let display_lines = to_display_lines(&best_results.results, icon);
-
-                            let visible_highlights = display_lines
-                                .indices
-                                .iter()
-                                .map(|line_highlights| {
-                                    line_highlights
-                                        .iter()
-                                        .copied()
-                                        .filter(|&x| x <= line_width)
-                                        .collect::<Vec<_>>()
-                                })
-                                .collect::<Vec<_>>();
-
-                            if best_results.last_lines != display_lines.lines.as_slice()
-                                || best_results.last_visible_highlights != visible_highlights
-                            {
-                                progressor.update_all(
-                                    &display_lines,
-                                    total_matched,
-                                    total_processed,
-                                );
-                                best_results.last_lines = display_lines.lines;
-                                best_results.last_visible_highlights = visible_highlights;
-                            } else {
-                                progressor.quick_update(total_matched, total_processed)
-                            }
-
-                            best_results.past = now;
-                        }
-                    }
+                    best_results.past = now;
                 }
-            }
-            SearcherMessage::ProcessedOne => {
-                total_processed += 1;
             }
         }
     }
@@ -340,6 +333,7 @@ pub async fn search(query: String, matcher: Matcher, search_context: SearchConte
 
     let display_lines = to_display_lines(&best_results.results, icon);
 
+    let total_processed = total_processed.load(Ordering::SeqCst);
     progressor.on_finished(display_lines, total_matched, total_processed);
 
     tracing::debug!(

--- a/crates/maple_core/src/searcher/grep/stoppable_searcher.rs
+++ b/crates/maple_core/src/searcher/grep/stoppable_searcher.rs
@@ -159,6 +159,9 @@ impl StoppableSearchImpl {
 struct BestFileResults {
     /// Time of last notification.
     past: Instant,
+    // TODO: Use BinaryHeap than sorted vector.
+    //
+    // Blocked by https://github.com/rust-lang/rust/pull/124012
     results: Vec<FileResult>,
     last_lines: Vec<String>,
     last_visible_highlights: Vec<Vec<usize>>,

--- a/crates/maple_core/src/searcher/mod.rs
+++ b/crates/maple_core/src/searcher/mod.rs
@@ -11,13 +11,6 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use types::MatchedItem;
-
-#[derive(Debug)]
-enum SearcherMessage<T = MatchedItem> {
-    Match(T),
-    ProcessedOne,
-}
 
 #[derive(Debug, Clone)]
 pub struct SearchContext {

--- a/crates/maple_core/src/searcher/tagfiles.rs
+++ b/crates/maple_core/src/searcher/tagfiles.rs
@@ -348,6 +348,10 @@ pub async fn search(query: String, cwd: PathBuf, matcher: Matcher, search_contex
         best_items.on_new_match(matched_item, total_matched, total_processed);
     }
 
+    if stop_signal.load(Ordering::SeqCst) {
+        return;
+    }
+
     let elapsed = now.elapsed().as_millis();
 
     let BestItems {


### PR DESCRIPTION
This PR optimize the searcher performance even further, the hyperfine result indicates it's significantly improved by 60%. The series of optimization efforts have achieved 2x performance than v0.52.

```
hyperfine --warmup 3 './maple-v0.52 grep --ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client'  './maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client' './target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client'
Benchmark 1: ./maple-v0.52 grep --ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
  Time (mean ± σ):     657.0 ms ±  19.9 ms    [User: 1242.2 ms, System: 461.2 ms]
  Range (min … max):   610.5 ms … 677.2 ms    10 runs
 
Benchmark 2: ./maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
  Time (mean ± σ):     519.0 ms ±   9.2 ms    [User: 1014.1 ms, System: 354.4 ms]
  Range (min … max):   500.4 ms … 535.1 ms    10 runs
 
Benchmark 3: ./target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
  Time (mean ± σ):     322.0 ms ±   3.6 ms    [User: 514.1 ms, System: 215.0 ms]
  Range (min … max):   317.4 ms … 326.4 ms    10 runs
 
Summary
  ./target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client ran
    1.61 ± 0.03 times faster than ./maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
    2.04 ± 0.07 times faster than ./maple-v0.52 grep --ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
```