### PR TITLE
Optimize grep performance specifically for short queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,6 +1788,8 @@ dependencies = [
  "fuzzy-matcher",
  "grep-matcher",
  "grep-regex",
+ "norm",
+ "nucleo-matcher",
  "pattern",
  "types",
 ]
@@ -1855,6 +1857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "norm"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5725a3379c44dc0adf3437af87cf21c10df473ed858d654b12603dea102508"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1873,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -3302,6 +3323,12 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,6 +1662,7 @@ dependencies = [
  "chrono",
  "clap",
  "cli",
+ "tikv-jemallocator",
  "tokio",
  "upgrade",
 ]
@@ -2824,6 +2825,26 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/maple/Cargo.toml
+++ b/crates/maple/Cargo.toml
@@ -17,6 +17,9 @@ tokio = { workspace = true, features = ["rt"] }
 cli = { workspace = true }
 upgrade = { workspace = true }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = "0.5"
+
 [build-dependencies]
 built = { package = "built", version = "0.6", features = ["git2"] }
 chrono = { workspace = true }

--- a/crates/maple/src/main.rs
+++ b/crates/maple/src/main.rs
@@ -1,6 +1,10 @@
 use clap::Parser;
 use cli::{Args, RunCmd};
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 const BUILD_TIME: &str = include!(concat!(env!("OUT_DIR"), "/compiled_at.txt"));
 
 mod built_info {

--- a/crates/maple_core/src/searcher/grep/mod.rs
+++ b/crates/maple_core/src/searcher/grep/mod.rs
@@ -9,6 +9,8 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::unbounded_channel;
 
+use super::SearchInfo;
+
 #[derive(Debug)]
 pub struct SearchResult {
     pub matches: Vec<FileResult>,
@@ -21,14 +23,16 @@ pub async fn cli_search(paths: Vec<PathBuf>, matcher: Matcher) -> SearchResult {
 
     let stop_signal = Arc::new(AtomicBool::new(false));
 
-    let total_processed = Arc::new(AtomicUsize::new(0));
+    let search_info = SearchInfo {
+        total_processed: Arc::new(AtomicUsize::new(0)),
+    };
 
     {
-        let total_processed = total_processed.clone();
+        let search_info = search_info.clone();
         std::thread::Builder::new()
             .name("searcher-worker".into())
             .spawn(move || {
-                StoppableSearchImpl::new(paths, matcher, sender, stop_signal).run(total_processed)
+                StoppableSearchImpl::new(paths, matcher, sender, stop_signal).run(search_info)
             })
             .expect("Failed to spawn searcher worker thread");
     }
@@ -41,7 +45,9 @@ pub async fn cli_search(paths: Vec<PathBuf>, matcher: Matcher) -> SearchResult {
     while let Some(file_result) = receiver.recv().await {
         matches.push(file_result);
         total_matched += 1;
-        let total_processed = total_processed.load(std::sync::atomic::Ordering::Relaxed);
+        let total_processed = search_info
+            .total_processed
+            .load(std::sync::atomic::Ordering::Relaxed);
 
         if total_matched % 16 == 0 || total_processed % 16 == 0 {
             let now = Instant::now();
@@ -52,7 +58,9 @@ pub async fn cli_search(paths: Vec<PathBuf>, matcher: Matcher) -> SearchResult {
         }
     }
 
-    let total_processed = total_processed.load(std::sync::atomic::Ordering::SeqCst) as u64;
+    let total_processed = search_info
+        .total_processed
+        .load(std::sync::atomic::Ordering::SeqCst) as u64;
 
     SearchResult {
         matches,

--- a/crates/maple_core/src/searcher/mod.rs
+++ b/crates/maple_core/src/searcher/mod.rs
@@ -9,8 +9,14 @@ use ignore::{WalkBuilder, WalkParallel};
 use paths::AbsPathBuf;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::Arc;
+
+// Shareable searching info.
+#[derive(Clone, Debug)]
+pub struct SearchInfo {
+    pub total_processed: Arc<AtomicUsize>,
+}
 
 #[derive(Debug, Clone)]
 pub struct SearchContext {

--- a/crates/maple_core/src/searcher/mod.rs
+++ b/crates/maple_core/src/searcher/mod.rs
@@ -15,7 +15,7 @@ use std::sync::Arc;
 use types::Rank;
 
 // Shareable searching info.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct SearchInfo {
     pub lowest_rank: Arc<RwLock<Rank>>,
     pub total_matched: Arc<AtomicUsize>,
@@ -24,11 +24,7 @@ pub struct SearchInfo {
 
 impl SearchInfo {
     pub fn new() -> Self {
-        Self {
-            lowest_rank: Arc::new(RwLock::new(Rank::default())),
-            total_matched: Arc::new(AtomicUsize::new(0)),
-            total_processed: Arc::new(AtomicUsize::new(0)),
-        }
+        Self::default()
     }
 }
 

--- a/crates/maple_core/src/searcher/mod.rs
+++ b/crates/maple_core/src/searcher/mod.rs
@@ -6,16 +6,30 @@ pub mod tagfiles;
 use crate::stdio_server::Vim;
 use icon::Icon;
 use ignore::{WalkBuilder, WalkParallel};
+use parking_lot::RwLock;
 use paths::AbsPathBuf;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::Arc;
+use types::Rank;
 
 // Shareable searching info.
 #[derive(Clone, Debug)]
 pub struct SearchInfo {
+    pub lowest_rank: Arc<RwLock<Rank>>,
+    pub total_matched: Arc<AtomicUsize>,
     pub total_processed: Arc<AtomicUsize>,
+}
+
+impl SearchInfo {
+    pub fn new() -> Self {
+        Self {
+            lowest_rank: Arc::new(RwLock::new(Rank::default())),
+            total_matched: Arc::new(AtomicUsize::new(0)),
+            total_processed: Arc::new(AtomicUsize::new(0)),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/matcher/Cargo.toml
+++ b/crates/matcher/Cargo.toml
@@ -13,3 +13,5 @@ code_tools = { workspace = true }
 extracted_fzy = { path = "./extracted_fzy" }
 pattern = { workspace = true }
 types = { workspace = true }
+norm = { version = "0.1.1", features = ["fzf-v1", "fzf-v2", "__into-score"] }
+nucleo-matcher = "0.3.1"

--- a/crates/matcher/src/algo/fzf.rs
+++ b/crates/matcher/src/algo/fzf.rs
@@ -1,0 +1,19 @@
+use crate::{MatchResult, Score};
+use norm::fzf::{FzfParser, FzfV2};
+use norm::Metric;
+
+pub fn fuzzy_indices_v2(text: &str, query: &str) -> Option<MatchResult> {
+    let mut fzf = FzfV2::new();
+    let mut parser = FzfParser::new();
+    let query = parser.parse(query);
+
+    let mut ranges: Vec<std::ops::Range<usize>> = Vec::new();
+    fzf.distance_and_ranges(query, text, &mut ranges)
+        .map(|distance| {
+            // norm use i64 as Score, but we use i32.
+            MatchResult::new(
+                distance.into_score() as Score,
+                ranges.into_iter().flatten().collect(),
+            )
+        })
+}

--- a/crates/matcher/src/algo/mod.rs
+++ b/crates/matcher/src/algo/mod.rs
@@ -1,4 +1,6 @@
+pub mod fzf;
 pub mod fzy;
+pub mod nucleo;
 pub mod skim;
 pub mod substring;
 
@@ -8,9 +10,11 @@ use types::{CaseMatching, FuzzyText};
 // TODO: Integrate https://github.com/nomad/norm for fzf algo.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum FuzzyAlgorithm {
-    Skim,
     #[default]
     Fzy,
+    Skim,
+    FzfV2,
+    Nucleo,
 }
 
 impl std::str::FromStr for FuzzyAlgorithm {
@@ -25,6 +29,8 @@ impl<T: AsRef<str>> From<T> for FuzzyAlgorithm {
         match algo.as_ref().to_lowercase().as_str() {
             "skim" => Self::Skim,
             "fzy" => Self::Fzy,
+            "fzf-v2" => Self::FzfV2,
+            "nucleo" => Self::Nucleo,
             _ => Self::Fzy,
         }
     }
@@ -45,6 +51,8 @@ impl FuzzyAlgorithm {
         let fuzzy_result = match self {
             Self::Fzy => fzy::fuzzy_indices(text, query, case_matching),
             Self::Skim => skim::fuzzy_indices(text, query, case_matching),
+            Self::FzfV2 => fzf::fuzzy_indices_v2(text, query),
+            Self::Nucleo => nucleo::fuzzy_indices(text, query, case_matching),
         };
         fuzzy_result.map(|MatchResult { score, indices }| {
             let mut indices = indices;

--- a/crates/matcher/src/algo/nucleo.rs
+++ b/crates/matcher/src/algo/nucleo.rs
@@ -1,0 +1,32 @@
+use nucleo_matcher::{
+    pattern::{AtomKind, CaseMatching, Normalization, Pattern},
+    Config, Matcher, Utf32Str,
+};
+use types::{MatchResult, Score};
+
+/// Make the arguments order same to Skim's `fuzzy_indices()`.
+pub fn fuzzy_indices(
+    line: &str,
+    query: &str,
+    case_sensitive: types::CaseMatching,
+) -> Option<MatchResult> {
+    let mut matcher = Matcher::new(Config::DEFAULT.match_paths());
+    let mut indices = Vec::new();
+
+    let case_matching = match case_sensitive {
+        types::CaseMatching::Ignore => CaseMatching::Ignore,
+        types::CaseMatching::Respect => CaseMatching::Respect,
+        types::CaseMatching::Smart => CaseMatching::Smart,
+    };
+
+    let mut char_buf = Vec::new();
+    let haystack = Utf32Str::new(line, &mut char_buf);
+    Pattern::new(query, case_matching, Normalization::Smart, AtomKind::Fuzzy)
+        .indices(haystack, &mut matcher, &mut indices)
+        .map(|score| {
+            MatchResult::new(
+                score as Score,
+                indices.into_iter().map(|idx| idx as usize).collect(),
+            )
+        })
+}

--- a/crates/matcher/src/algo/nucleo.rs
+++ b/crates/matcher/src/algo/nucleo.rs
@@ -1,7 +1,5 @@
-use nucleo_matcher::{
-    pattern::{AtomKind, CaseMatching, Normalization, Pattern},
-    Config, Matcher, Utf32Str,
-};
+use nucleo_matcher::pattern::{AtomKind, CaseMatching, Normalization, Pattern};
+use nucleo_matcher::{Config, Matcher, Utf32Str};
 use types::{MatchResult, Score};
 
 /// Make the arguments order same to Skim's `fuzzy_indices()`.

--- a/crates/types/src/matcher.rs
+++ b/crates/types/src/matcher.rs
@@ -41,26 +41,6 @@ impl From<[Score; 4]> for Rank {
     }
 }
 
-impl Rank {
-    /// Packs four i32 values into a single u64.
-    pub fn as_u64(&self) -> u64 {
-        let a = self.0[0] as u64 & 0xFFFF_FFFF;
-        let b = self.0[1] as u64 & 0xFFFF_FFFF;
-        let c = self.0[2] as u64 & 0xFFFF_FFFF;
-        let d = self.0[3] as u64 & 0xFFFF_FFFF;
-        (a << 48) | (b << 32) | (c << 16) | d
-    }
-
-    /// Unpacks a u64 into four i32 values.
-    pub fn from_u64(value: u64) -> Self {
-        let a = (value >> 48) as i32;
-        let b = ((value >> 32) & 0xFFFF_FFFF) as i32;
-        let c = ((value >> 16) & 0xFFFF_FFFF) as i32;
-        let d = (value & 0xFFFF_FFFF) as i32;
-        Self([a, b, c, d])
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct RankCalculator {
     criteria: Vec<RankCriterion>,

--- a/crates/types/src/matcher.rs
+++ b/crates/types/src/matcher.rs
@@ -32,14 +32,7 @@ pub fn parse_criteria(text: &str) -> Option<RankCriterion> {
 }
 
 /// The greater, the better.
-#[derive(Clone, Debug, Copy, Eq, PartialEq, PartialOrd, Ord, Default)]
-pub struct Rank([Score; 4]);
-
-impl From<[Score; 4]> for Rank {
-    fn from(inner: [Score; 4]) -> Self {
-        Self(inner)
-    }
-}
+pub type Rank = [Score; 4];
 
 #[derive(Debug, Clone)]
 pub struct RankCalculator {
@@ -93,7 +86,7 @@ impl RankCalculator {
             rank[index] = value;
         }
 
-        rank.into()
+        rank
     }
 }
 

--- a/crates/types/src/matcher.rs
+++ b/crates/types/src/matcher.rs
@@ -32,7 +32,34 @@ pub fn parse_criteria(text: &str) -> Option<RankCriterion> {
 }
 
 /// The greater, the better.
-pub type Rank = [Score; 4];
+#[derive(Clone, Debug, Copy, Eq, PartialEq, PartialOrd, Ord, Default)]
+pub struct Rank([Score; 4]);
+
+impl From<[Score; 4]> for Rank {
+    fn from(inner: [Score; 4]) -> Self {
+        Self(inner)
+    }
+}
+
+impl Rank {
+    /// Packs four i32 values into a single u64.
+    pub fn as_u64(&self) -> u64 {
+        let a = self.0[0] as u64 & 0xFFFF_FFFF;
+        let b = self.0[1] as u64 & 0xFFFF_FFFF;
+        let c = self.0[2] as u64 & 0xFFFF_FFFF;
+        let d = self.0[3] as u64 & 0xFFFF_FFFF;
+        (a << 48) | (b << 32) | (c << 16) | d
+    }
+
+    /// Unpacks a u64 into four i32 values.
+    pub fn from_u64(value: u64) -> Self {
+        let a = (value >> 48) as i32;
+        let b = ((value >> 32) & 0xFFFF_FFFF) as i32;
+        let c = ((value >> 16) & 0xFFFF_FFFF) as i32;
+        let d = (value & 0xFFFF_FFFF) as i32;
+        Self([a, b, c, d])
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct RankCalculator {
@@ -86,7 +113,7 @@ impl RankCalculator {
             rank[index] = value;
         }
 
-        rank
+        rank.into()
     }
 }
 


### PR DESCRIPTION
When the query is merely one or two chars, the tokio mpsc channel could be heavily used which can be one bottleneck as we observed before. This PR optimizes for this scenario, ~20% boost gained, the impact of this tactic on the performance of other cases is negligible.

```
hyperfine --warmup 3 -L query c './maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ {query}' './target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ {query}'
Benchmark 1: ./maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ c
  Time (mean ± σ):     616.3 ms ±  12.6 ms    [User: 1011.6 ms, System: 530.5 ms]
  Range (min … max):   590.6 ms … 629.2 ms    10 runs
 
Benchmark 2: ./target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ c
  Time (mean ± σ):     509.0 ms ±  16.5 ms    [User: 850.1 ms, System: 376.8 ms]
  Range (min … max):   465.7 ms … 525.2 ms    10 runs
 
Summary
  ./target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ c ran
    1.21 ± 0.05 times faster than ./maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ c
```

```
hyperfine --warmup 3 -L query client './maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ {query}' './target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ {query}'
Benchmark 1: ./maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
  Time (mean ± σ):     329.5 ms ±   8.2 ms    [User: 514.3 ms, System: 233.7 ms]
  Range (min … max):   315.1 ms … 342.6 ms    10 runs
 
Benchmark 2: ./target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
  Time (mean ± σ):     331.6 ms ±  10.5 ms    [User: 529.8 ms, System: 217.8 ms]
  Range (min … max):   311.0 ms … 350.0 ms    10 runs
 
Summary
  ./maple-master grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client ran
    1.01 ± 0.04 times faster than ./target/release/maple grep --lib-ripgrep --cmd-dir /home/xlc/Data2/github.com/paritytech/polkadot-sdk/ client
 ```