### PR TITLE
Update variable name for source to avoid function name conflict

### DIFF
--- a/autoload/clap.vim
+++ b/autoload/clap.vim
@@ -125,15 +125,15 @@ function! s:inject_default_impl_is_ok(provider_info) abort
 endfunction
 
 function! s:detect_source_type() abort
-  let Source = g:clap.provider._().source
-  let source_ty = type(Source)
+  let ClapProviderSource = g:clap.provider._().source
+  let source_ty = type(ClapProviderSource)
 
   if source_ty == v:t_string
     return g:__t_string
   elseif source_ty == v:t_list
     return g:__t_list
   elseif source_ty == v:t_func
-    let string_or_list = Source()
+    let string_or_list = ClapProviderSource()
     if type(string_or_list) == v:t_string
       return g:__t_func_string
     elseif type(string_or_list) == v:t_list

--- a/autoload/clap/api/clap.vim
+++ b/autoload/clap/api/clap.vim
@@ -366,17 +366,17 @@ function! s:init_provider() abort
   endfunction
 
   function! provider._apply_source() abort
-    let Source = self._().source
+    let ClapProviderSource = self._().source
 
     if self.source_type == g:__t_string
-      return s:_system(Source)
+      return s:_system(ClapProviderSource)
     elseif self.source_type == g:__t_list
       " Use copy here, otherwise it could be one-off List.
-      return copy(Source)
+      return copy(ClapProviderSource)
     elseif self.source_type == g:__t_func_string
-      return s:_system(Source())
+      return s:_system(ClapProviderSource())
     elseif self.source_type == g:__t_func_list
-      return copy(Source())
+      return copy(ClapProviderSource())
     else
       return ['source() must return a List or a String if it is a Funcref']
     endif


### PR DESCRIPTION
Hi @liuchengxu,

I am adding PR to update variable name from `Source` to `ClapProviderSource` to avoid function name conflict. In my case, I have a `Source` function to source vim config. I can change my config to fix this issue but I think that `Source` is quite common function name, others can be affected by this error as well. Please help me to review and accept this PR if you find it does make senses, thanks.

```
Error detected while processing function clap#[45]..clap#open_provider[23]..<SNR>45_detect_source_type:
line    1:
E705: Variable name conflicts with existing function: Source
```

