### PR TITLE
Add tree-sitter support for Swift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3254,6 +3254,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-swift"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65aeb41726119416567d0333ec17580ac4abfb96db1f67c4bd638c65f9992fe"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-tags"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3306,6 +3316,7 @@ dependencies = [
  "tree-sitter-md",
  "tree-sitter-python",
  "tree-sitter-rust",
+ "tree-sitter-swift",
  "tree-sitter-tags",
  "tree-sitter-toml",
  "tree-sitter-vim",

--- a/crates/tree_sitter/Cargo.toml
+++ b/crates/tree_sitter/Cargo.toml
@@ -23,6 +23,7 @@ tree-sitter-json = "0.23"
 tree-sitter-md = "0.3.2"
 tree-sitter-python = "0.23"
 tree-sitter-rust = "0.23"
+tree-sitter-swift = "0.6"
 # tree-sitter-traversal = "0.1"
 
 # Forked languages.

--- a/crates/tree_sitter/src/language.rs
+++ b/crates/tree_sitter/src/language.rs
@@ -151,6 +151,7 @@ pub enum Language {
     Markdown,
     Python,
     Rust,
+    Swift,
     Toml,
     Viml,
 }
@@ -169,6 +170,7 @@ impl FromStr for Language {
             "markdown" => Self::Markdown,
             "python" => Self::Python,
             "rust" => Self::Rust,
+            "swift" => Self::Swift,
             "toml" => Self::Toml,
             "viml" => Self::Viml,
             _ => return Err(format!("Unknown language: {s}")),
@@ -197,6 +199,7 @@ impl Language {
             "md" => Self::Markdown,
             "py" | "pyi" | "pyc" | "pyd" | "pyw" => Self::Python,
             "rs" => Self::Rust,
+            "swift" => Self::Swift,
             "toml" => Self::Toml,
             "vim" => Self::Viml,
             _ => return None,
@@ -218,6 +221,7 @@ impl Language {
             "markdown" => Self::Markdown,
             "python" => Self::Python,
             "rust" => Self::Rust,
+            "swift" => Self::Swift,
             "toml" => Self::Toml,
             "vim" => Self::Viml,
             _ => return None,
@@ -252,6 +256,7 @@ impl Language {
             Self::Markdown => tree_sitter_md::HIGHLIGHT_QUERY_BLOCK,
             Self::Python => tree_sitter_python::HIGHLIGHTS_QUERY,
             Self::Rust => tree_sitter_rust::HIGHLIGHTS_QUERY,
+            Self::Swift => tree_sitter_swift::HIGHLIGHTS_QUERY,
             Self::Toml => tree_sitter_toml::HIGHLIGHTS_QUERY,
             Self::Viml => tree_sitter_vim::HIGHLIGHT_QUERY,
         }
@@ -330,6 +335,13 @@ impl Language {
                 "",
                 "",
             ),
+            Language::Swift => HighlightConfiguration::new(
+                tree_sitter_swift::LANGUAGE.into(),
+                "swift",
+                tree_sitter_swift::HIGHLIGHTS_QUERY,
+                "",
+                "",
+            ),
             Language::Toml => HighlightConfiguration::new(
                 tree_sitter_toml::LANGUAGE.into(),
                 "toml",
@@ -382,6 +394,6 @@ mod tests {
 
     #[test]
     fn test_tree_sitter_config() {
-        assert_eq!(CONFIG.language.len(), 7);
+        assert_eq!(CONFIG.language.len(), 8);
     }
 }

--- a/crates/tree_sitter/tree_sitter_config.toml
+++ b/crates/tree_sitter/tree_sitter_config.toml
@@ -113,6 +113,30 @@ highlight-name-and-groups = [
   ["variable.parameter", "Identifier"],
 ]
 
+[language.swift]
+highlight-name-and-groups = [
+  ["attribute", "Special"],
+  ["comment", "Comment"],
+  ["constant", "Constant"],
+  ["constant.builtin", "Constant"],
+  ["constructor", "Function"],
+  ["function", "Function"],
+  ["function.builtin", "Special"],
+  ["function.method", "Function"],
+  ["keyword", "Keyword"],
+  ["number", "Number"],
+  ["operator", "Operator"],
+  ["property", "SpecialKey"],
+  ["punctuation.bracket", "Delimiter"],
+  ["punctuation.delimiter", "Delimiter"],
+  ["string", "String"],
+  ["type", "Type"],
+  ["type.builtin", "Type"],
+  ["variable", "Identifier"],
+  ["variable.builtin", "Identifier"],
+  ["variable.parameter", "Identifier"],
+]
+
 [language.viml]
 highlight-name-and-groups = [
   ["_option", "StorageClass"],


### PR DESCRIPTION
Add Swift language support to vim-clap's tree-sitter integration:
- Add tree-sitter-swift 0.6.0 dependency (compatible with tree-sitter 0.23)
- Add Swift to Language enum with file extension (.swift) and filetype detection
- Add Swift highlight configuration with proper capture groups
- Update test to reflect new language count (8 languages)

Swift files will now be properly syntax highlighted using tree-sitter in vim-clap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

Close #1124